### PR TITLE
Fail fast when projection target cannot host symlinks

### DIFF
--- a/src/commands/fs_probe.rs
+++ b/src/commands/fs_probe.rs
@@ -114,11 +114,7 @@ mod tests {
         let leftover: Vec<_> = fs::read_dir(&dir)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with(".loom-probe-")
-            })
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".loom-probe-"))
             .collect();
         assert!(leftover.is_empty(), "probe files must be cleaned up");
         let _ = fs::remove_dir_all(&dir);
@@ -135,5 +131,4 @@ mod tests {
         assert!(deep.exists(), "probe must create missing parent");
         let _ = fs::remove_dir_all(&base);
     }
-
 }

--- a/src/commands/fs_probe.rs
+++ b/src/commands/fs_probe.rs
@@ -1,0 +1,139 @@
+//! Runtime probe of what a projection target's filesystem can physically do.
+//!
+//! This is distinct from [`crate::state_model::V3TargetCapabilities`], which is
+//! a *policy* capability declared at `target add` time (based on ownership).
+//! A managed target always declares `capabilities.symlink = true`, but that
+//! says nothing about whether the actual filesystem accepts the syscall:
+//!
+//! - Windows without Developer Mode or admin rejects `symlink_dir`.
+//! - FAT32 / exFAT / some SMB mounts have no symlink concept.
+//! - macOS TCC-restricted directories block the operation.
+//!
+//! Policy says "you may try"; the probe says "it actually works here".
+//! Projection uses the probe result to decide whether to honour the requested
+//! method or fall back.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use uuid::Uuid;
+
+/// Whether the target filesystem physically supports symlinks, as measured
+/// at projection time.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SymlinkProbe {
+    pub supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl SymlinkProbe {
+    pub fn supported() -> Self {
+        Self {
+            supported: true,
+            reason: None,
+        }
+    }
+
+    pub fn unsupported(reason: impl Into<String>) -> Self {
+        Self {
+            supported: false,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Try to create a throw-away symlink inside `parent` and report whether the
+/// filesystem accepts the syscall. Creates `parent` if missing.
+///
+/// The probe points at a non-existent target: POSIX and Windows both allow
+/// dangling symlinks, and we only care whether the syscall succeeds.
+pub fn probe_symlink(parent: &Path) -> SymlinkProbe {
+    if let Err(err) = fs::create_dir_all(parent) {
+        return SymlinkProbe::unsupported(format!(
+            "cannot create target parent {}: {}",
+            parent.display(),
+            err
+        ));
+    }
+
+    let probe_path: PathBuf = parent.join(format!(".loom-probe-{}", Uuid::new_v4().simple()));
+    let probe_target = parent.join(".loom-probe-target-does-not-exist");
+
+    let result = create_symlink_probe(&probe_target, &probe_path);
+    let _ = fs::remove_file(&probe_path);
+
+    match result {
+        Ok(()) => SymlinkProbe::supported(),
+        Err(err) => SymlinkProbe::unsupported(format!("symlink not supported: {}", err)),
+    }
+}
+
+#[cfg(unix)]
+fn create_symlink_probe(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn create_symlink_probe(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(src, dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = env::temp_dir().join(format!(
+            "loom-fs-probe-{}-{}",
+            label,
+            Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    #[test]
+    fn unix_supports_symlink_on_tmp() {
+        if !cfg!(unix) {
+            return;
+        }
+        let dir = scratch_dir("supports");
+        let probe = probe_symlink(&dir);
+        assert!(probe.supported, "unix tmp should support symlink");
+        assert!(probe.reason.is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn probe_cleans_up_after_itself() {
+        let dir = scratch_dir("cleanup");
+        let _ = probe_symlink(&dir);
+        let leftover: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(".loom-probe-")
+            })
+            .collect();
+        assert!(leftover.is_empty(), "probe files must be cleaned up");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn probe_creates_missing_parent() {
+        let base = scratch_dir("mkparent");
+        let deep = base.join("does/not/exist/yet");
+        let probe = probe_symlink(&deep);
+        if cfg!(unix) {
+            assert!(probe.supported);
+        }
+        assert!(deep.exists(), "probe must create missing parent");
+        let _ = fs::remove_dir_all(&base);
+    }
+
+}

--- a/src/commands/fs_probe.rs
+++ b/src/commands/fs_probe.rs
@@ -62,7 +62,11 @@ pub fn probe_symlink(parent: &Path) -> SymlinkProbe {
     let probe_target = parent.join(".loom-probe-target-does-not-exist");
 
     let result = create_symlink_probe(&probe_target, &probe_path);
-    let _ = fs::remove_file(&probe_path);
+    // Best-effort cleanup. Windows creates the probe via `symlink_dir`,
+    // which produces a *directory* symlink: `remove_file` errors on those
+    // entries and would leak `.loom-probe-*` on every successful probe.
+    // `remove_symlink_probe` dispatches to the right API per platform.
+    let _ = remove_symlink_probe(&probe_path);
 
     match result {
         Ok(()) => SymlinkProbe::supported(),
@@ -78,6 +82,16 @@ fn create_symlink_probe(src: &Path, dst: &Path) -> std::io::Result<()> {
 #[cfg(windows)]
 fn create_symlink_probe(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::os::windows::fs::symlink_dir(src, dst)
+}
+
+#[cfg(unix)]
+fn remove_symlink_probe(path: &Path) -> std::io::Result<()> {
+    fs::remove_file(path)
+}
+
+#[cfg(windows)]
+fn remove_symlink_probe(path: &Path) -> std::io::Result<()> {
+    fs::remove_dir(path)
 }
 
 #[cfg(test)]

--- a/src/commands/fs_probe.rs
+++ b/src/commands/fs_probe.rs
@@ -58,8 +58,15 @@ pub fn probe_symlink(parent: &Path) -> SymlinkProbe {
         ));
     }
 
-    let probe_path: PathBuf = parent.join(format!(".loom-probe-{}", Uuid::new_v4().simple()));
-    let probe_target = parent.join(".loom-probe-target-does-not-exist");
+    // Both paths share the same UUID suffix so a single probe run leaves
+    // nothing colliding, and the target side is ALSO unique-per-run: a
+    // fixed target name could collide with a user-owned entry of an
+    // incompatible type (a real `.loom-probe-target-does-not-exist` dir or
+    // file), which on Windows makes `symlink_dir` fail and turns a
+    // symlink-capable filesystem into a false "symlink not supported".
+    let suffix = Uuid::new_v4().simple();
+    let probe_path: PathBuf = parent.join(format!(".loom-probe-{}", suffix));
+    let probe_target = parent.join(format!(".loom-probe-target-{}", suffix));
 
     let result = create_symlink_probe(&probe_target, &probe_path);
     // Best-effort cleanup. Windows creates the probe via `symlink_dir`,

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -16,8 +16,8 @@ use super::CommandFailure;
 
 // Re-export items from sibling modules so existing `use super::helpers::*` paths keep working.
 pub(crate) use super::file_ops::{
-    backup_path_if_exists, copy_dir_recursive, copy_dir_recursive_without_symlinks,
-    read_git_field, rollback_added_skill,
+    backup_path_if_exists, copy_dir_recursive, copy_dir_recursive_without_symlinks, read_git_field,
+    rollback_added_skill,
 };
 pub use super::projections::{collect_skill_inventory, remote_status_payload};
 pub(crate) use super::projections::{
@@ -163,9 +163,7 @@ pub(crate) fn target_ownership_as_str(ownership: crate::cli::TargetOwnership) ->
     }
 }
 
-pub(crate) fn target_capabilities(
-    ownership: crate::cli::TargetOwnership,
-) -> V3TargetCapabilities {
+pub(crate) fn target_capabilities(ownership: crate::cli::TargetOwnership) -> V3TargetCapabilities {
     match ownership {
         crate::cli::TargetOwnership::Managed => V3TargetCapabilities {
             symlink: true,
@@ -352,11 +350,7 @@ fn unique_id(base: &str, existing: Vec<&str>) -> String {
     format!("{}_{}", base, Uuid::new_v4().simple())
 }
 
-pub(crate) fn projection_instance_id(
-    skill: &str,
-    binding_id: &str,
-    target_id: &str,
-) -> String {
+pub(crate) fn projection_instance_id(skill: &str, binding_id: &str, target_id: &str) -> String {
     format!(
         "inst_{}_{}_{}",
         slugify(skill),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -112,10 +112,7 @@ impl App {
         &self,
     ) -> std::result::Result<crate::state_model::V3Snapshot, CommandFailure> {
         let paths = V3StatePaths::from_root(&self.ctx.root);
-        match paths
-            .maybe_load_snapshot()
-            .map_err(helpers::map_v3_state)?
-        {
+        match paths.maybe_load_snapshot().map_err(helpers::map_v3_state)? {
             Some(snapshot) => Ok(snapshot),
             None => Err(CommandFailure::new(
                 ErrorCode::ArgInvalid,
@@ -124,9 +121,7 @@ impl App {
         }
     }
 
-    pub(crate) fn ensure_v3_layout(
-        &self,
-    ) -> std::result::Result<V3StatePaths, CommandFailure> {
+    pub(crate) fn ensure_v3_layout(&self) -> std::result::Result<V3StatePaths, CommandFailure> {
         let paths = V3StatePaths::from_root(&self.ctx.root);
         paths.ensure_layout().map_err(helpers::map_v3_state)?;
         Ok(paths)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod file_ops;
+mod fs_probe;
 mod helpers;
 mod projections;
 mod skill_cmds;

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -18,10 +18,8 @@ use crate::state_model::{
 use crate::types::{ErrorCode, SyncState};
 
 use super::CommandFailure;
-use super::helpers::{
-    map_git, map_io, map_push_rejected, map_queue, map_remote_unreachable,
-};
 use super::file_ops::{copy_dir_recursive, create_symlink_dir};
+use super::helpers::{map_git, map_io, map_push_rejected, map_queue, map_remote_unreachable};
 
 // ---------------------------------------------------------------------------
 // V3 state mutators

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -488,3 +488,66 @@ pub(crate) fn sync_replay_internal(
     sync_push_internal(ctx)?;
     Ok("replayed")
 }
+
+#[cfg(test)]
+mod project_skill_tests {
+    use super::*;
+    use std::env;
+    use std::fs as stdfs;
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = env::temp_dir().join(format!(
+            "loom-projections-{}-{}",
+            label,
+            Uuid::new_v4().simple()
+        ));
+        stdfs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    fn make_skill_src(base: &Path) -> PathBuf {
+        let skill = base.join("sample-skill");
+        stdfs::create_dir_all(&skill).expect("skill dir");
+        stdfs::write(skill.join("SKILL.md"), "# sample\n").expect("SKILL.md");
+        skill
+    }
+
+    #[test]
+    fn copy_method_materializes_files() {
+        let base = scratch_dir("copy");
+        let src = make_skill_src(&base);
+        let dst = base.join("dst-copy");
+        project_skill_to_target(&src, &dst, ProjectionMethod::Copy).expect("copy ok");
+        assert!(dst.join("SKILL.md").is_file(), "SKILL.md must be copied");
+        let _ = stdfs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn materialize_method_materializes_files() {
+        let base = scratch_dir("materialize");
+        let src = make_skill_src(&base);
+        let dst = base.join("dst-mat");
+        project_skill_to_target(&src, &dst, ProjectionMethod::Materialize).expect("materialize ok");
+        assert!(dst.join("SKILL.md").is_file());
+        let _ = stdfs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn symlink_method_creates_link_on_unix_tmp() {
+        if !cfg!(unix) {
+            return;
+        }
+        let base = scratch_dir("symlink");
+        let src = make_skill_src(&base);
+        let dst = base.join("dst-symlink");
+        project_skill_to_target(&src, &dst, ProjectionMethod::Symlink).expect("symlink ok");
+        assert!(
+            stdfs::symlink_metadata(&dst)
+                .expect("dst exists")
+                .file_type()
+                .is_symlink(),
+            "dst must be a symlink"
+        );
+        let _ = stdfs::remove_dir_all(&base);
+    }
+}

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -23,6 +23,7 @@ use super::helpers::{
     update_projection_after_capture, upsert_projection, upsert_rule, validate_projection_method,
     validate_skill_name,
 };
+use super::fs_probe::probe_symlink;
 use super::{App, CommandFailure};
 
 impl App {
@@ -179,6 +180,29 @@ impl App {
         let target_base = PathBuf::from(&target.path);
         fs::create_dir_all(&target_base).map_err(map_io)?;
         let materialized_path = target_base.join(&args.skill);
+
+        // Fail-fast physical probe for symlink requests — run BEFORE any
+        // destructive operation (backup, remove) so a filesystem that cannot
+        // host symlinks (Windows without Developer Mode, FAT32, etc.) does
+        // not corrupt an existing projection. Policy allowed it via
+        // V3TargetCapabilities; here we verify the filesystem actually can.
+        if matches!(args.method, crate::cli::ProjectionMethod::Symlink) {
+            let probe = probe_symlink(&target_base);
+            if !probe.supported {
+                return Err(CommandFailure::new(
+                    ErrorCode::ArgInvalid,
+                    format!(
+                        "target '{}' filesystem does not support symlink projection: {}. \
+                         retry with --method copy",
+                        target.target_id,
+                        probe
+                            .reason
+                            .unwrap_or_else(|| "unknown reason".to_string())
+                    ),
+                ));
+            }
+        }
+
         let replaced_projection_backup =
             backup_path_if_exists(&self.ctx, &materialized_path, "project.replace_projection")
                 .map_err(map_io)?;

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -6,8 +6,7 @@ use serde_json::json;
 use uuid::Uuid;
 
 use crate::cli::{
-    AddArgs, CaptureArgs, DiffArgs, ProjectArgs, ReleaseArgs, RollbackArgs, SaveArgs,
-    SkillOnlyArgs,
+    AddArgs, CaptureArgs, DiffArgs, ProjectArgs, ReleaseArgs, RollbackArgs, SaveArgs, SkillOnlyArgs,
 };
 use crate::envelope::Meta;
 use crate::gitops;
@@ -15,15 +14,15 @@ use crate::state::remove_path_if_exists;
 use crate::state_model::{V3BindingRule, V3ProjectionInstance};
 use crate::types::ErrorCode;
 
+use super::fs_probe::probe_symlink;
 use super::helpers::{
     backup_path_if_exists, copy_dir_recursive, copy_dir_recursive_without_symlinks,
     ensure_skill_exists, map_arg, map_git, map_io, map_lock, map_project_io, map_v3_state,
-    maybe_autosync_or_queue, projection_instance_id, projection_method_as_str,
-    project_skill_to_target, record_v3_operation, resolve_capture_projection, rollback_added_skill,
-    update_projection_after_capture, upsert_projection, upsert_rule, validate_projection_method,
-    validate_skill_name,
+    maybe_autosync_or_queue, project_skill_to_target, projection_instance_id,
+    projection_method_as_str, record_v3_operation, resolve_capture_projection,
+    rollback_added_skill, update_projection_after_capture, upsert_projection, upsert_rule,
+    validate_projection_method, validate_skill_name,
 };
-use super::fs_probe::probe_symlink;
 use super::{App, CommandFailure};
 
 impl App {
@@ -195,9 +194,7 @@ impl App {
                         "target '{}' filesystem does not support symlink projection: {}. \
                          retry with --method copy",
                         target.target_id,
-                        probe
-                            .reason
-                            .unwrap_or_else(|| "unknown reason".to_string())
+                        probe.reason.unwrap_or_else(|| "unknown reason".to_string())
                     ),
                 ));
             }

--- a/src/commands/sync_cmds.rs
+++ b/src/commands/sync_cmds.rs
@@ -6,8 +6,8 @@ use crate::gitops;
 use crate::types::ErrorCode;
 
 use super::helpers::{
-    map_git, map_io, map_lock, map_replay_conflict, remote_status_payload,
-    sync_push_internal, sync_replay_internal,
+    map_git, map_io, map_lock, map_replay_conflict, remote_status_payload, sync_push_internal,
+    sync_replay_internal,
 };
 use super::{App, CommandFailure};
 

--- a/src/gitops/history.rs
+++ b/src/gitops/history.rs
@@ -14,9 +14,10 @@ use super::{
 };
 
 use super::history_impl::{
-    apply_history_retention, build_tree_from_entries, compact_local_history_branch,
-    compose_history_state, create_commit_tree, detect_history_conflicts, history_tree_entries,
-    load_history_branch_state, synthesize_history_snapshot_blob, update_ref, ComposedHistoryState,
+    ComposedHistoryState, apply_history_retention, build_tree_from_entries,
+    compact_local_history_branch, compose_history_state, create_commit_tree,
+    detect_history_conflicts, history_tree_entries, load_history_branch_state,
+    synthesize_history_snapshot_blob, update_ref,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/gitops/history_impl.rs
+++ b/src/gitops/history_impl.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 
 use anyhow::{Result, anyhow};
 
-use crate::state::{AppContext, summarize_history_body, synthesize_snapshot_raw_from_segment_bodies};
+use crate::state::{
+    AppContext, summarize_history_body, synthesize_snapshot_raw_from_segment_bodies,
+};
 
 use super::{
     EMPTY_TREE_SHA, HISTORY_ARCHIVES_DIR, HISTORY_BRANCH_REF, HISTORY_COMPACT_AFTER_SEGMENTS,

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -15,12 +15,10 @@ use crate::commands::{collect_skill_inventory, remote_status_payload};
 use crate::state::resolve_agent_skill_dirs;
 use crate::state_model::V3StatePaths;
 
-use super::{
-    BindingAddRequest, CaptureRequest, PanelState, ProjectRequest, TargetAddRequest,
-};
 use super::auth::{
     ensure_mutation_authorized, load_v3_snapshot, run_panel_command, v3_error, v3_ok,
 };
+use super::{BindingAddRequest, CaptureRequest, PanelState, ProjectRequest, TargetAddRequest};
 
 pub(super) async fn health() -> Json<serde_json::Value> {
     Json(json!({"ok": true, "service": "loom-panel"}))

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -13,9 +13,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::cli::{
-    AgentKind, ProjectionMethod, TargetOwnership, WorkspaceMatcherKind,
-};
+use crate::cli::{AgentKind, ProjectionMethod, TargetOwnership, WorkspaceMatcherKind};
 use crate::state::AppContext;
 
 use handlers::*;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,8 +1,7 @@
 mod ops;
 
 pub use ops::{
-    summarize_history_body, synthesize_snapshot_raw_from_segment_bodies,
-    remove_path_if_exists,
+    remove_path_if_exists, summarize_history_body, synthesize_snapshot_raw_from_segment_bodies,
 };
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::gitops;
 use crate::types::PendingOp;
 
-use super::{append_lines, maybe_fault_inject, write_atomic, write_history_segment_if_missing};
 use super::{AppContext, OPS_COMPACTION_THRESHOLD};
+use super::{append_lines, maybe_fault_inject, write_atomic, write_history_segment_if_missing};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]

--- a/src/state_model/persistence.rs
+++ b/src/state_model/persistence.rs
@@ -5,12 +5,12 @@ use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use super::{
-    V3BindingsFile, V3ObservationEvent, V3OperationRecord, V3OpsCheckpoint, V3ProjectionsFile,
-    V3RulesFile, V3SchemaFile, V3Snapshot, V3StatePaths, V3TargetsFile, V3_SCHEMA_VERSION,
+    V3_SCHEMA_VERSION, V3BindingsFile, V3ObservationEvent, V3OperationRecord, V3OpsCheckpoint,
+    V3ProjectionsFile, V3RulesFile, V3SchemaFile, V3Snapshot, V3StatePaths, V3TargetsFile,
     empty_bindings_file, empty_projections_file, empty_rules_file, empty_targets_file,
 };
 


### PR DESCRIPTION
## Summary

- Add a runtime physical probe before symlink projections; if the filesystem cannot host symlinks (Windows no-dev-mode, FAT32, TCC-restricted dirs), return `ARG_INVALID` with a reason and the suggestion to retry with `--method copy`.
- The probe runs **before** backup/remove, so an unsupported target no longer loses its existing projection to a stray backup.
- No auto-downgrade: the caller chooses whether to retry with another method. Policy-level `V3TargetCapabilities` is unchanged; this checks the physical layer separately.

## Why

`validate_projection_method` only verifies policy intent from ownership. The actual syscall can still be rejected by the kernel/filesystem, and `cmd_project` already performs destructive operations (backup + remove) before attempting the symlink. Today a user on Windows without Developer Mode, or with a target on FAT32, ends up with the old projection gone and a backup they have to reconcile by hand.

## What changed

- `src/commands/fs_probe.rs` (new): `SymlinkProbe` + `probe_symlink(parent)` using a dangling `.loom-probe-<uuid>` link, cleans up after itself, creates the parent if missing.
- `src/commands/skill_cmds.rs`: `cmd_project` calls `probe_symlink` up front when the requested method is `Symlink`; probe failure returns `ARG_INVALID` with the probe reason.
- `src/commands/projections.rs`: `project_skill_to_target` signature is unchanged (`Result<()>`). Added unit tests covering copy / materialize / symlink success paths.
- `src/commands/mod.rs`: register `mod fs_probe`.

## Test plan

- [x] `cargo test` — 77 tests pass (new: `fs_probe::tests::*` + `project_skill_tests::*`)
- [x] `cargo check --tests`
- [ ] Manual: Windows non-admin / FAT32 / SELinux directory behavior (no CI matrix yet)