### PR TITLE
Add optional pre-commit hook for cargo fmt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Loom pre-commit hook.
+#
+# Installed via `make install-hooks` (sets core.hooksPath=.githooks).
+# Keeps CI's Rust format gate local so fmt drift fails at commit time,
+# not after a push.
+#
+# Disable with `git config --unset core.hooksPath`.
+
+set -e
+
+# Skip the cargo probe when no Rust files are staged — keeps docs/config
+# commits fast.
+if ! git diff --cached --name-only --diff-filter=ACM | grep -qE '\.rs$'; then
+    exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "[pre-commit] cargo not found on PATH — skipping fmt check" >&2
+    exit 0
+fi
+
+if ! cargo fmt --all -- --check; then
+    echo "" >&2
+    echo "[pre-commit] cargo fmt check FAILED." >&2
+    echo "[pre-commit] Fix with 'cargo fmt --all' (or 'make fmt'), then re-stage." >&2
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: fmt fmt-check test lint panel-build e2e check ci
+.PHONY: fmt fmt-check test lint panel-build e2e check ci install-hooks
 
 fmt:
 	cargo fmt --all
 
 fmt-check:
 	cargo fmt --all --check
+
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "pre-commit hook installed (core.hooksPath=.githooks). Disable with 'git config --unset core.hooksPath'."
 
 test:
 	cargo test -q

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ make e2e
 make ci
 ```
 
+## Pre-Commit Hook (Recommended)
+
+Bind `cargo fmt` to every `git commit` so CI never flags format drift:
+
+```bash
+make install-hooks
+```
+
+The hook runs `cargo fmt --all -- --check` only when `.rs` files are staged,
+and fails the commit if rustfmt would make changes. Disable with
+`git config --unset core.hooksPath`.
+
 ## JSON Envelope
 
 Most commands support `--json` for machine-readable output.


### PR DESCRIPTION
## Summary
- `.githooks/pre-commit` runs `cargo fmt --all -- --check` only when `.rs` files are staged.
- `make install-hooks` sets `core.hooksPath=.githooks`; opt-in per clone.
- README gets one section explaining how to enable / disable.

## Why
PR #2 CI went red on format drift that only surfaced after push. There was no local guard binding `make fmt-check` to commits.

## Test plan
- [x] Hook exits 0 when no `.rs` staged (doc/config commits fast-path)
- [x] Hook exits 0 when `cargo` missing (CI-only machines not blocked)
- [x] `make install-hooks` writes `core.hooksPath=.githooks` from repo root
- [ ] Windows shell path (hook is POSIX sh — untested)