### PR TITLE
Panel honesty pass + Ops history tab

### DIFF
--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import type { PanelPageKey } from "../../lib/types";
 import { api } from "../../lib/api/client";
 import { LoomMark } from "../icons/LoomMark";
-import { GitIcon, PlayIcon, SearchIcon } from "../icons/nav_icons";
+import { GitIcon, PlayIcon } from "../icons/nav_icons";
 
 const CRUMBS: Record<PanelPageKey, string> = {
   overview: "Overview",
@@ -97,17 +97,12 @@ export function Topbar(props: TopbarProps) {
         <span className="cur">{CRUMBS[props.page]}</span>
       </div>
       <div className="spacer" />
-      <div className="searchbar" style={{ width: 240 }}>
-        <SearchIcon />
-        <input placeholder="Jump to skill or target…" />
-        <kbd>⌘K</kbd>
-      </div>
       <div className="top-actions">
         <button className="top-btn" title={props.error ?? undefined}>
           <span className="status-dot" style={status.dotStyle} /> {status.label}
         </button>
-        <button className="top-btn">
-          <GitIcon /> {props.remoteState ? props.remoteState.toLowerCase() : "main"}
+        <button className="top-btn" title={props.live ? "remote sync state" : "registry offline"}>
+          <GitIcon /> {props.live ? (props.remoteState ? props.remoteState.toLowerCase() : "local only") : "offline"}
         </button>
         <button
           className="top-btn primary"

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -10,6 +10,29 @@ import type { V3Projection } from "../../generated/V3Projection";
 import type { V3Rule } from "../../generated/V3Rule";
 import type { V3Target } from "../../generated/V3Target";
 
+export interface V3OperationRecord {
+  op_id: string;
+  intent: string;
+  status: string;
+  ack: boolean;
+  payload: unknown;
+  effects: unknown;
+  last_error?: { code: string; message: string };
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OpsPayload {
+  ok: boolean;
+  data?: {
+    state_model?: string;
+    count: number;
+    operations: V3OperationRecord[];
+    checkpoint?: { last_scanned_op_id?: string; last_acked_op_id?: string; updated_at?: string };
+  };
+  error?: { code?: string; message?: string };
+}
+
 export interface BindingShowPayload {
   ok: boolean;
   data?: {
@@ -140,6 +163,7 @@ export const api = {
   info: (signal?: AbortSignal) => getJson<InfoPayload>("/api/info", signal),
   skills: (signal?: AbortSignal) => getJson<SkillsPayload>("/api/skills", signal),
   v3Status: (signal?: AbortSignal) => getJson<V3Payload>("/api/v3/status", signal),
+  ops: (signal?: AbortSignal) => getJson<OpsPayload>("/api/v3/ops", signal),
   bindingShow: (id: string, signal?: AbortSignal) =>
     getJson<BindingShowPayload>(`/api/v3/bindings/${encodeURIComponent(id)}`, signal),
   targetShow: (id: string, signal?: AbortSignal) =>

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -5,6 +5,34 @@ import type {
   RemotePayload,
   V3Payload,
 } from "../../types";
+import type { V3Binding } from "../../generated/V3Binding";
+import type { V3Projection } from "../../generated/V3Projection";
+import type { V3Rule } from "../../generated/V3Rule";
+import type { V3Target } from "../../generated/V3Target";
+
+export interface BindingShowPayload {
+  ok: boolean;
+  data?: {
+    state_model?: string;
+    binding: V3Binding;
+    default_target?: V3Target | null;
+    rules?: V3Rule[];
+    projections?: V3Projection[];
+  };
+  error?: { code?: string; message?: string };
+}
+
+export interface TargetShowPayload {
+  ok: boolean;
+  data?: {
+    state_model?: string;
+    target: V3Target;
+    bindings?: V3Binding[];
+    rules?: V3Rule[];
+    projections?: V3Projection[];
+  };
+  error?: { code?: string; message?: string };
+}
 
 export interface SkillsPayload {
   skills?: string[];
@@ -112,6 +140,10 @@ export const api = {
   info: (signal?: AbortSignal) => getJson<InfoPayload>("/api/info", signal),
   skills: (signal?: AbortSignal) => getJson<SkillsPayload>("/api/skills", signal),
   v3Status: (signal?: AbortSignal) => getJson<V3Payload>("/api/v3/status", signal),
+  bindingShow: (id: string, signal?: AbortSignal) =>
+    getJson<BindingShowPayload>(`/api/v3/bindings/${encodeURIComponent(id)}`, signal),
+  targetShow: (id: string, signal?: AbortSignal) =>
+    getJson<TargetShowPayload>(`/api/v3/targets/${encodeURIComponent(id)}`, signal),
   remoteStatus: (signal?: AbortSignal) => getJson<RemoteStatusResponse>("/api/remote/status", signal),
   pending: (signal?: AbortSignal) => getJson<PendingPayload>("/api/pending", signal),
 

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -11,6 +11,8 @@ import { TargetsPage } from "./panel/TargetsPage";
 import { BindingsPage } from "./panel/BindingsPage";
 import { OpsPage } from "./panel/OpsPage";
 import { PlaceholderPage } from "./panel/PlaceholderPage";
+import { SettingsPage } from "./panel/SettingsPage";
+import { SyncPage } from "./panel/SyncPage";
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -22,6 +24,7 @@ const DEFAULT_TWEAKS: TweakState = {
 };
 
 const PAGE_STORAGE_KEY = "loom.page";
+const TWEAKS_STORAGE_KEY = "loom.tweaks";
 const VALID_PAGES: PanelPageKey[] = [
   "overview",
   "skills",
@@ -38,9 +41,20 @@ function loadInitialPage(): PanelPageKey {
   return VALID_PAGES.includes(stored as PanelPageKey) ? (stored as PanelPageKey) : "overview";
 }
 
+function loadInitialTweaks(): TweakState {
+  const raw = localStorage.getItem(TWEAKS_STORAGE_KEY);
+  if (!raw) return DEFAULT_TWEAKS;
+  try {
+    const parsed = JSON.parse(raw) as Partial<TweakState>;
+    return { ...DEFAULT_TWEAKS, ...parsed };
+  } catch {
+    return DEFAULT_TWEAKS;
+  }
+}
+
 export function PanelApp() {
   const [page, setPage] = useState<PanelPageKey>(loadInitialPage);
-  const [tweaks, setTweaks] = useState<TweakState>(DEFAULT_TWEAKS);
+  const [tweaks, setTweaks] = useState<TweakState>(loadInitialTweaks);
   const [tweakVisible, setTweakVisible] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
   const [selectedTarget, setSelectedTarget] = useState<string | null>(null);
@@ -50,6 +64,10 @@ export function PanelApp() {
   useEffect(() => {
     localStorage.setItem(PAGE_STORAGE_KEY, page);
   }, [page]);
+
+  useEffect(() => {
+    localStorage.setItem(TWEAKS_STORAGE_KEY, JSON.stringify(tweaks));
+  }, [tweaks]);
 
   useEffect(() => {
     document.documentElement.style.setProperty("--accent", tweaks.accent);
@@ -150,6 +168,7 @@ export function PanelApp() {
         <SkillsPage
           skills={skills}
           targets={targets}
+          bindings={bindings}
           selectedSkill={selectedSkill}
           onSelectSkill={(id) => setSelectedSkill(id)}
           onMutation={onMutation}
@@ -174,6 +193,20 @@ export function PanelApp() {
       break;
     case "ops":
       view = <OpsPage ops={ops} />;
+      break;
+    case "sync":
+      view = (
+        <SyncPage
+          remote={live.remote}
+          pendingCount={live.pendingCount}
+          registryRoot={live.registryRoot}
+          readOnly={readOnly}
+          onMutation={onMutation}
+        />
+      );
+      break;
+    case "settings":
+      view = <SettingsPage live={live.live} registryRoot={live.registryRoot} />;
       break;
     default:
       view = <PlaceholderPage page={page} />;

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -9,6 +9,7 @@ import { OverviewPage } from "./panel/OverviewPage";
 import { SkillsPage } from "./panel/SkillsPage";
 import { TargetsPage } from "./panel/TargetsPage";
 import { BindingsPage } from "./panel/BindingsPage";
+import { HistoryPage } from "./panel/HistoryPage";
 import { OpsPage } from "./panel/OpsPage";
 import { PlaceholderPage } from "./panel/PlaceholderPage";
 import { SettingsPage } from "./panel/SettingsPage";
@@ -193,6 +194,9 @@ export function PanelApp() {
       break;
     case "ops":
       view = <OpsPage ops={ops} />;
+      break;
+    case "history":
+      view = <HistoryPage live={live.live} />;
       break;
     case "sync":
       view = (

--- a/panel/src/pages/panel/BindingsPage.tsx
+++ b/panel/src/pages/panel/BindingsPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Binding, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon } from "../../components/icons/nav_icons";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
+import { api, ApiError, type BindingShowPayload } from "../../lib/api/client";
 
 interface BindingsPageProps {
   bindings: Binding[];
@@ -13,6 +14,9 @@ interface BindingsPageProps {
 
 export function BindingsPage({ bindings, targets, onMutation, readOnly }: BindingsPageProps) {
   const [addOpen, setAddOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const sel = bindings.find((b) => b.id === selectedId) ?? null;
+
   return (
     <>
       <div className="page-header">
@@ -34,71 +38,181 @@ export function BindingsPage({ bindings, targets, onMutation, readOnly }: Bindin
           </button>
         </div>
       </div>
-      <div className="page-body">
+      <div className="page-body" style={{ padding: 0 }}>
         {addOpen && (
-          <BindingAddForm
-            targets={targets}
-            onCancel={() => setAddOpen(false)}
-            onSuccess={() => {
-              setAddOpen(false);
-              onMutation();
-            }}
-          />
+          <div style={{ padding: "0 28px 12px" }}>
+            <BindingAddForm
+              targets={targets}
+              onCancel={() => setAddOpen(false)}
+              onSuccess={() => {
+                setAddOpen(false);
+                onMutation();
+              }}
+            />
+          </div>
         )}
-        <table
-          className="tbl"
-          style={{
-            background: "var(--bg-1)",
-            borderRadius: 10,
-            overflow: "hidden",
-            border: "1px solid var(--line)",
-          }}
-        >
-          <thead>
-            <tr>
-              <th>Binding</th>
-              <th>Skill</th>
-              <th>Target</th>
-              <th>Matcher</th>
-              <th>Method</th>
-              <th>Policy</th>
-            </tr>
-          </thead>
-          <tbody>
-            {bindings.map((b) => {
-              const t = targets.find((x) => x.id === b.target);
-              return (
-                <tr key={b.id}>
-                  <td className="mono dim">{b.id}</td>
-                  <td className="name">{b.skill}</td>
-                  <td>
-                    {t && (
-                      <span className="row-flex">
-                        <AgentAvatar agent={t.agent} />
-                        <span style={{ color: "var(--ink-1)" }}>
-                          {t.agent}/{t.profile}
-                        </span>
-                      </span>
-                    )}
-                  </td>
-                  <td className="mono">{b.matcher}</td>
-                  <td>
-                    <span className={`chip method ${b.method}`}>{b.method}</span>
-                  </td>
-                  <td>
-                    <span
-                      className="chip"
-                      style={{ color: b.policy === "auto" ? "var(--ok)" : "var(--warn)" }}
-                    >
-                      {b.policy}
-                    </span>
-                  </td>
+        <div className="two-col" style={{ height: "100%", gap: 0 }}>
+          <div style={{ overflow: "auto", borderRight: "1px solid var(--line)" }}>
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Binding</th>
+                  <th>Skill</th>
+                  <th>Target</th>
+                  <th>Matcher</th>
+                  <th>Method</th>
+                  <th>Policy</th>
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
+              </thead>
+              <tbody>
+                {bindings.map((b) => {
+                  const t = targets.find((x) => x.id === b.target);
+                  return (
+                    <tr
+                      key={b.id}
+                      className={selectedId === b.id ? "selected" : ""}
+                      onClick={() => setSelectedId(b.id === selectedId ? null : b.id)}
+                    >
+                      <td className="mono dim">{b.id}</td>
+                      <td className="name">{b.skill}</td>
+                      <td>
+                        {t && (
+                          <span className="row-flex">
+                            <AgentAvatar agent={t.agent} />
+                            <span style={{ color: "var(--ink-1)" }}>
+                              {t.agent}/{t.profile}
+                            </span>
+                          </span>
+                        )}
+                      </td>
+                      <td className="mono">{b.matcher}</td>
+                      <td>
+                        <span className={`chip method ${b.method}`}>{b.method}</span>
+                      </td>
+                      <td>
+                        <span
+                          className="chip"
+                          style={{ color: b.policy === "auto" ? "var(--ok)" : "var(--warn)" }}
+                        >
+                          {b.policy}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div style={{ padding: 20, overflow: "auto" }}>
+            {sel ? (
+              <BindingDetail binding={sel} targets={targets} />
+            ) : (
+              <div className="empty">Select a binding to inspect its rules, projections, and default target.</div>
+            )}
+          </div>
+        </div>
       </div>
     </>
+  );
+}
+
+type DetailState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; payload: NonNullable<BindingShowPayload["data"]> }
+  | { kind: "error"; message: string };
+
+function BindingDetail({ binding, targets }: { binding: Binding; targets: Target[] }) {
+  const [state, setState] = useState<DetailState>({ kind: "idle" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ kind: "loading" });
+    api
+      .bindingShow(binding.id, controller.signal)
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        if (!res.ok || !res.data) {
+          setState({ kind: "error", message: res.error?.message ?? "binding fetch returned ok=false" });
+          return;
+        }
+        setState({ kind: "ready", payload: res.data });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => controller.abort();
+  }, [binding.id]);
+
+  const t = targets.find((x) => x.id === binding.target);
+  const rules = state.kind === "ready" ? state.payload.rules ?? [] : [];
+  const projections = state.kind === "ready" ? state.payload.projections ?? [] : [];
+
+  return (
+    <div className="detail">
+      <h4>{binding.id}</h4>
+      <div className="dpath">
+        {binding.skill} → {binding.target}
+      </div>
+      <div className="kv">
+        <div className="k">Skill</div>
+        <div className="v">{binding.skill}</div>
+        <div className="k">Target</div>
+        <div className="v">
+          {t ? `${t.agent}/${t.profile}` : binding.target}
+        </div>
+        <div className="k">Matcher</div>
+        <div className="v mono">{binding.matcher}</div>
+        <div className="k">Method</div>
+        <div className="v">{binding.method}</div>
+        <div className="k">Policy</div>
+        <div className="v">{binding.policy}</div>
+      </div>
+
+      <div style={{ marginTop: 18 }}>
+        <div className="section-title">Rules on chain</div>
+        {state.kind === "loading" && <div className="empty mono">loading…</div>}
+        {state.kind === "error" && <div className="empty" style={{ color: "var(--err)" }}>{state.message}</div>}
+        {state.kind === "ready" && rules.length === 0 && <div className="empty">No rules bound.</div>}
+        {state.kind === "ready" && rules.length > 0 && (
+          <ul style={{ fontSize: 12, paddingLeft: 0, listStyle: "none" }}>
+            {rules.map((r, i) => (
+              <li key={i} style={{ padding: "6px 0", borderBottom: "1px solid var(--line-soft)" }}>
+                <span className="mono" style={{ color: "var(--ink-1)" }}>
+                  {r.skill_id}
+                </span>
+                <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
+                  method={r.method}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div style={{ marginTop: 18 }}>
+        <div className="section-title">Projections</div>
+        {state.kind === "loading" && <div className="empty mono">loading…</div>}
+        {state.kind === "ready" && projections.length === 0 && (
+          <div className="empty">No projections realized yet for this binding.</div>
+        )}
+        {state.kind === "ready" && projections.length > 0 && (
+          <ul style={{ fontSize: 12, paddingLeft: 0, listStyle: "none" }}>
+            {projections.map((p, i) => (
+              <li key={i} style={{ padding: "6px 0", borderBottom: "1px solid var(--line-soft)" }}>
+                <span className="mono" style={{ color: "var(--ink-1)" }}>
+                  {p.skill_id} → {p.target_id}
+                </span>
+                <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
+                  {p.method} · rev {p.last_applied_rev?.slice(0, 8) ?? "—"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
   );
 }

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState } from "react";
+import { api, ApiError, type OpsPayload, type V3OperationRecord } from "../../lib/api/client";
+
+type FilterKey = "all" | "pending" | "ok" | "err";
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; payload: NonNullable<OpsPayload["data"]> }
+  | { kind: "error"; message: string };
+
+interface HistoryPageProps {
+  live: boolean;
+}
+
+export function HistoryPage({ live }: HistoryPageProps) {
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [filter, setFilter] = useState<FilterKey>("all");
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ kind: "loading" });
+    api
+      .ops(controller.signal)
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        if (!res.ok || !res.data) {
+          setState({ kind: "error", message: res.error?.message ?? "ops fetch returned ok=false" });
+          return;
+        }
+        setState({ kind: "ready", payload: res.data });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => controller.abort();
+  }, [live]);
+
+  const operations = state.kind === "ready" ? state.payload.operations : [];
+  const ordered = useMemo(
+    () =>
+      [...operations].sort((a, b) =>
+        (b.created_at ?? "").localeCompare(a.created_at ?? ""),
+      ),
+    [operations],
+  );
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return ordered.filter((op) => {
+      if (filter !== "all" && bucket(op) !== filter) return false;
+      if (!needle) return true;
+      return (
+        op.op_id.toLowerCase().includes(needle) ||
+        op.intent.toLowerCase().includes(needle) ||
+        (op.last_error?.message ?? "").toLowerCase().includes(needle)
+      );
+    });
+  }, [ordered, filter, query]);
+
+  const counts = useMemo(() => {
+    const c = { all: ordered.length, pending: 0, ok: 0, err: 0 };
+    for (const op of ordered) {
+      const b = bucket(op);
+      if (b === "pending") c.pending += 1;
+      else if (b === "ok") c.ok += 1;
+      else if (b === "err") c.err += 1;
+    }
+    return c;
+  }, [ordered]);
+
+  const checkpoint = state.kind === "ready" ? state.payload.checkpoint : undefined;
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Ops history</h1>
+          <div className="subtitle">
+            Every mutation Loom has applied to the registry, oldest writes first on disk. Pending ops also surface in the
+            Ops tab; failed ops point to a replay with <span className="mono">loom sync replay</span>.
+          </div>
+        </div>
+        <div className="header-actions">
+          <div className="searchbar" style={{ width: 260 }}>
+            <input
+              placeholder="Filter by id / intent / error…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="page-body">
+        {state.kind === "error" && (
+          <div
+            style={{
+              padding: "6px 28px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              borderBottom: "1px solid var(--line)",
+              color: "var(--err)",
+              background: "rgba(216,90,90,0.08)",
+            }}
+          >
+            {state.message}
+          </div>
+        )}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 18 }}>
+          <Kpi label="Tracked ops" value={counts.all} />
+          <Kpi label="Pending" value={counts.pending} tone={counts.pending > 0 ? "pending" : undefined} />
+          <Kpi label="Succeeded" value={counts.ok} />
+          <Kpi label="Failed" value={counts.err} tone={counts.err > 0 ? "err" : undefined} />
+        </div>
+
+        <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
+          {(["all", "pending", "ok", "err"] as FilterKey[]).map((k) => (
+            <button
+              key={k}
+              className="btn sm"
+              onClick={() => setFilter(k)}
+              style={{
+                background: filter === k ? "var(--bg-2)" : "transparent",
+                borderColor: filter === k ? "var(--line-hi)" : "transparent",
+                border: "1px solid",
+                color: filter === k ? "var(--ink-0)" : "var(--ink-2)",
+              }}
+            >
+              {k === "err" ? "failed" : k}{" "}
+              <span className="mono" style={{ color: "var(--ink-3)", marginLeft: 4 }}>
+                {counts[k]}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div
+          style={{
+            background: "var(--bg-1)",
+            borderRadius: 10,
+            overflow: "hidden",
+            border: "1px solid var(--line)",
+          }}
+        >
+          <table className="tbl">
+            <thead>
+              <tr>
+                <th>Op id</th>
+                <th>Intent</th>
+                <th>Status</th>
+                <th>ack</th>
+                <th>Created</th>
+                <th>Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.kind === "loading" && (
+                <tr>
+                  <td colSpan={6} className="mono" style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
+                    loading…
+                  </td>
+                </tr>
+              )}
+              {state.kind === "ready" && filtered.length === 0 && (
+                <tr>
+                  <td colSpan={6} style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
+                    {counts.all === 0
+                      ? "No operations recorded yet — every mutation via CLI or Panel will show up here."
+                      : "No operations match the current filter."}
+                  </td>
+                </tr>
+              )}
+              {filtered.map((op) => (
+                <OpHistoryRow key={op.op_id} op={op} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {checkpoint && (
+          <div style={{ marginTop: 12, fontSize: 11, color: "var(--ink-3)" }}>
+            Checkpoint: last scanned{" "}
+            <span className="mono" style={{ color: "var(--ink-1)" }}>
+              {checkpoint.last_scanned_op_id ?? "—"}
+            </span>
+            {checkpoint.last_acked_op_id && (
+              <>
+                {" · "}last acked{" "}
+                <span className="mono" style={{ color: "var(--ink-1)" }}>
+                  {checkpoint.last_acked_op_id}
+                </span>
+              </>
+            )}
+            {checkpoint.updated_at && (
+              <>
+                {" · updated "}
+                <span className="mono">{checkpoint.updated_at}</span>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function bucket(op: V3OperationRecord): "pending" | "ok" | "err" {
+  if (op.last_error) return "err";
+  const s = op.status.toLowerCase();
+  if (s === "pending" || s === "enqueued" || s === "in_flight" || s === "retrying") return "pending";
+  if (s === "ok" || s === "applied" || s === "completed" || s === "done") return "ok";
+  if (s === "err" || s === "error" || s === "failed") return "err";
+  return op.ack ? "ok" : "pending";
+}
+
+function OpHistoryRow({ op }: { op: V3OperationRecord }) {
+  const kind = bucket(op);
+  const color = kind === "err" ? "var(--err)" : kind === "pending" ? "var(--pending)" : "var(--ok)";
+  return (
+    <tr>
+      <td className="mono dim">{op.op_id}</td>
+      <td className="name">{op.intent}</td>
+      <td>
+        <span className="chip" style={{ color }}>
+          {op.last_error ? op.last_error.code : op.status}
+        </span>
+      </td>
+      <td className="mono dim">{op.ack ? "✓" : "—"}</td>
+      <td className="mono dim" style={{ fontSize: 10.5 }}>
+        {op.created_at}
+      </td>
+      <td className="mono dim" style={{ fontSize: 10.5 }}>
+        {op.updated_at}
+      </td>
+    </tr>
+  );
+}
+
+function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {
+  const color = tone === "pending" ? "var(--pending)" : tone === "err" ? "var(--err)" : "var(--ink-0)";
+  return (
+    <div className="kpi">
+      <div className="label">{label}</div>
+      <div className="value" style={{ color }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -220,7 +220,9 @@ function bucket(op: V3OperationRecord): "pending" | "ok" | "err" {
   if (op.last_error) return "err";
   const s = op.status.toLowerCase();
   if (s === "pending" || s === "enqueued" || s === "in_flight" || s === "retrying") return "pending";
-  if (s === "ok" || s === "applied" || s === "completed" || s === "done") return "ok";
+  // "succeeded" is what the backend actually writes (src/commands/projections.rs,
+  // src/state_model/persistence.rs); the rest are tolerated synonyms.
+  if (s === "ok" || s === "succeeded" || s === "applied" || s === "completed" || s === "done") return "ok";
   if (s === "err" || s === "error" || s === "failed") return "err";
   return op.ack ? "ok" : "pending";
 }

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -13,14 +13,23 @@ interface HistoryPageProps {
   live: boolean;
 }
 
+const REFRESH_INTERVAL_MS = 3000;
+
 export function HistoryPage({ live }: HistoryPageProps) {
   const [state, setState] = useState<LoadState>({ kind: "idle" });
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    if (!live) return;
+    const id = setInterval(() => setRefreshTick((t) => t + 1), REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [live]);
 
   useEffect(() => {
     const controller = new AbortController();
-    setState({ kind: "loading" });
+    setState((prev) => (prev.kind === "idle" ? { kind: "loading" } : prev));
     api
       .ops(controller.signal)
       .then((res) => {
@@ -37,7 +46,7 @@ export function HistoryPage({ live }: HistoryPageProps) {
         setState({ kind: "error", message });
       });
     return () => controller.abort();
-  }, [live]);
+  }, [live, refreshTick]);
 
   const operations = state.kind === "ready" ? state.payload.operations : [];
   const ordered = useMemo(

--- a/panel/src/pages/panel/OpsPage.tsx
+++ b/panel/src/pages/panel/OpsPage.tsx
@@ -3,7 +3,6 @@ import type { Op, OpStatus } from "../../lib/types";
 import { OpRow } from "../../components/panel/OpRow";
 import { RefreshIcon } from "../../components/icons/nav_icons";
 
-const SPARK = [3, 5, 2, 6, 4, 7, 9, 5, 8, 6, 4, 3, 5, 7, 11, 6, 4, 5, 8, 9, 6, 4, 3, 5];
 type FilterKey = "all" | OpStatus;
 
 export function OpsPage({ ops }: { ops: Op[] }) {
@@ -15,6 +14,9 @@ export function OpsPage({ ops }: { ops: Op[] }) {
     ok: ops.filter((o) => o.status === "ok").length,
     err: ops.filter((o) => o.status === "err").length,
   };
+  const finalized = counts.ok + counts.err;
+  const successRate = finalized > 0 ? (counts.ok / finalized) * 100 : null;
+  const oldestPending = ops.find((o) => o.status === "pending");
 
   return (
     <>
@@ -24,31 +26,33 @@ export function OpsPage({ ops }: { ops: Op[] }) {
           <div className="subtitle">Every state change is an op. Retry the pending, repair the failed, diagnose the rest.</div>
         </div>
         <div className="header-actions">
-          <button className="btn ghost">
+          <button className="btn ghost" disabled title="Coming in v1.0 — use `loom ops retry` via CLI">
             <RefreshIcon /> Retry failed
           </button>
-          <button className="btn ghost">Purge completed</button>
+          <button className="btn ghost" disabled title="Coming in v1.0 — use `loom ops purge` via CLI">
+            Purge completed
+          </button>
         </div>
       </div>
       <div className="page-body">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 18 }}>
           <div className="card">
             <div className="card-body">
-              <div style={section_label}>Last 24h</div>
-              <div style={{ fontFamily: "var(--font-display)", fontSize: 24 }}>47 ops</div>
-              <div className="spark" style={{ marginTop: 10 }}>
-                {SPARK.map((v, i) => (
-                  <div key={i} className={`bar ${v > 7 ? "hi" : ""}`} style={{ height: `${v * 2.4}px` }} />
-                ))}
+              <div style={section_label}>Tracked ops</div>
+              <div style={{ fontFamily: "var(--font-display)", fontSize: 24 }}>{counts.all}</div>
+              <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>
+                {counts.ok} ok · {counts.err} failed · {counts.pending} pending
               </div>
             </div>
           </div>
           <div className="card">
             <div className="card-body">
               <div style={section_label}>Success rate</div>
-              <div style={{ fontFamily: "var(--font-display)", fontSize: 24, color: "var(--ok)" }}>96.2%</div>
+              <div style={{ fontFamily: "var(--font-display)", fontSize: 24, color: successRate === null ? "var(--ink-3)" : "var(--ok)" }}>
+                {successRate === null ? "—" : `${successRate.toFixed(1)}%`}
+              </div>
               <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>
-                45 / 47 clean · 1 failed · 1 pending
+                {finalized === 0 ? "no finalized ops yet" : `${counts.ok} / ${finalized} clean`}
               </div>
             </div>
           </div>
@@ -59,7 +63,7 @@ export function OpsPage({ ops }: { ops: Op[] }) {
                 {counts.pending}
               </div>
               <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>
-                project refactor-patterns → claude/work
+                {oldestPending ? `${oldestPending.kind} ${oldestPending.skill} → ${oldestPending.target}` : "queue empty"}
               </div>
             </div>
           </div>

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -43,6 +43,13 @@ export function OverviewPage({
   const pendingOps = ops.filter((o) => o.status === "pending").length;
   const errOps = ops.filter((o) => o.status === "err").length;
   const totalProjections = skills.reduce((a, s) => a + s.targets.length, 0);
+  const totalRules = skills.reduce((a, s) => a + s.ruleCount, 0);
+  const uniqueAgents = new Set(targets.map((t) => t.agent)).size;
+  const uniqueProfiles = new Set(targets.map((t) => `${t.agent}/${t.profile}`)).size;
+  const methodCounts = projections.reduce<Record<string, number>>((acc, p) => {
+    acc[p.method] = (acc[p.method] ?? 0) + 1;
+    return acc;
+  }, {});
   const rootDisplay = registryRoot
     ? registryRoot.replace(/^\/Users\/[^/]+/, "~")
     : "~/.loom-registry";
@@ -107,9 +114,29 @@ export function OverviewPage({
       )}
       <div className="page-body">
         <div className="kpi-row">
-          <Kpi label="Skills" value={skills.length} meta={<><span className="trend">+2</span> · 52 captures · 38 releases</>} />
-          <Kpi label="Targets" value={targets.length} meta="6 agents · 4 profiles" />
-          <Kpi label="Projections" value={totalProjections} meta="symlink · copy · materialize" />
+          <Kpi
+            label="Skills"
+            value={skills.length}
+            meta={totalRules > 0 ? `${totalRules} rule${totalRules === 1 ? "" : "s"} on chain` : "no rules yet"}
+          />
+          <Kpi
+            label="Targets"
+            value={targets.length}
+            meta={
+              targets.length === 0
+                ? "no targets"
+                : `${uniqueAgents} agent${uniqueAgents === 1 ? "" : "s"} · ${uniqueProfiles} profile${uniqueProfiles === 1 ? "" : "s"}`
+            }
+          />
+          <Kpi
+            label="Projections"
+            value={totalProjections}
+            meta={
+              totalProjections === 0
+                ? "no projections"
+                : `${methodCounts.symlink ?? 0} symlink · ${methodCounts.copy ?? 0} copy · ${methodCounts.materialize ?? 0} materialize`
+            }
+          />
           <Kpi
             label="Ops"
             value={pendingOps + errOps}
@@ -223,13 +250,10 @@ export function OverviewPage({
                 <span className="c"># Current registry</span>
                 {"\n"}
                 <span className="k">--root</span> <span className="s">{rootDisplay}</span>
-                {"\n"}
-                <span className="c"># Git HEAD</span>
-                {"\n"}
-                <span className="n">2a3f8c1</span> <span className="s">"release: commit-message-writer v1.2.0"</span>
               </pre>
               <div style={{ color: "var(--ink-3)", fontSize: 11 }}>
-                Last pull from <span className="mono">origin/main</span> · 6h ago
+                Run <span className="mono" style={{ color: "var(--ink-1)" }}>loom status</span> for git HEAD · sync state
+                available via the Topbar.
               </div>
             </div>
           </div>

--- a/panel/src/pages/panel/SettingsPage.tsx
+++ b/panel/src/pages/panel/SettingsPage.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import type { InfoPayload } from "../../types";
+import { api, ApiError } from "../../lib/api/client";
+
+interface SettingsPageProps {
+  live: boolean;
+  registryRoot: string | null;
+}
+
+type InfoState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; info: InfoPayload }
+  | { kind: "error"; message: string };
+
+export function SettingsPage({ live, registryRoot }: SettingsPageProps) {
+  const [info, setInfo] = useState<InfoState>({ kind: "idle" });
+  const [cleared, setCleared] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setInfo({ kind: "loading" });
+    api
+      .info(controller.signal)
+      .then((payload) => {
+        if (controller.signal.aborted) return;
+        setInfo({ kind: "ready", info: payload });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
+        setInfo({ kind: "error", message });
+      });
+    return () => controller.abort();
+  }, [live]);
+
+  const resetTweaks = () => {
+    localStorage.removeItem("loom.tweaks");
+    setCleared(true);
+    window.setTimeout(() => window.location.reload(), 400);
+  };
+
+  const rows: Array<{ label: string; value: string | undefined; mono?: boolean }> = [
+    { label: "Registry root", value: registryRoot ?? undefined, mono: true },
+  ];
+  if (info.kind === "ready") {
+    const x = info.info;
+    rows.push(
+      { label: "State dir", value: x.state_dir, mono: true },
+      { label: "V3 targets file", value: x.v3_targets_file, mono: true },
+      { label: "Claude dir", value: x.claude_dir, mono: true },
+      { label: "Codex dir", value: x.codex_dir, mono: true },
+      { label: "Remote URL", value: x.remote_url, mono: true },
+    );
+  }
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Settings</h1>
+          <div className="subtitle">
+            Where Loom keeps its state. These paths come from <span className="mono">/api/info</span> and mirror the CLI
+            output of <span className="mono">loom info</span>.
+          </div>
+        </div>
+      </div>
+      <div className="page-body">
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div className="card-head">
+            <h3>Registry paths</h3>
+            {info.kind === "loading" && <span className="chip">loading…</span>}
+            {info.kind === "error" && <span className="chip" style={{ color: "var(--err)" }}>fetch failed</span>}
+          </div>
+          <div className="card-body">
+            {info.kind === "error" && (
+              <div style={{ color: "var(--err)", fontSize: 12, marginBottom: 10 }}>{info.message}</div>
+            )}
+            <table className="tbl" style={{ fontSize: 12 }}>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.label}>
+                    <td style={{ color: "var(--ink-2)", width: 160 }}>{r.label}</td>
+                    <td className={r.mono ? "mono" : undefined} style={{ color: r.value ? "var(--ink-0)" : "var(--ink-3)" }}>
+                      {r.value ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-head">
+            <h3>UI preferences</h3>
+            {cleared && <span className="chip ok">cleared · reloading…</span>}
+          </div>
+          <div className="card-body" style={{ fontSize: 12 }}>
+            <div style={{ marginBottom: 10, color: "var(--ink-2)" }}>
+              Viz mode, accent, density, font and compact toggle live in{" "}
+              <span className="mono">localStorage.loom.tweaks</span>. Click below to reset to defaults and reload.
+            </div>
+            <button className="btn" onClick={resetTweaks} disabled={cleared}>
+              Reset UI preferences
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { Skill, Target } from "../../lib/types";
+import type { Binding, Skill, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon, SearchIcon } from "../../components/icons/nav_icons";
 import { api } from "../../lib/api/client";
@@ -8,13 +8,14 @@ import { useMutation } from "../../lib/useMutation";
 interface SkillsPageProps {
   skills: Skill[];
   targets: Target[];
+  bindings: Binding[];
   selectedSkill: string | null;
   onSelectSkill: (id: string) => void;
   onMutation: () => void;
   readOnly: boolean;
 }
 
-export function SkillsPage({ skills, targets, selectedSkill, onSelectSkill, onMutation, readOnly }: SkillsPageProps) {
+export function SkillsPage({ skills, targets, bindings, selectedSkill, onSelectSkill, onMutation, readOnly }: SkillsPageProps) {
   const [q, setQ] = useState("");
   const filtered = skills.filter((s) => s.name.includes(q) || s.tag.includes(q));
   const sel = skills.find((s) => s.id === selectedSkill) ?? skills[0];
@@ -98,7 +99,11 @@ export function SkillsPage({ skills, targets, selectedSkill, onSelectSkill, onMu
             </table>
           </div>
           <div style={{ padding: 20, overflow: "auto" }}>
-            {sel ? <SkillDetail skill={sel} targets={targets} /> : <div className="empty">Select a skill.</div>}
+            {sel ? (
+              <SkillDetail skill={sel} targets={targets} bindings={bindings} />
+            ) : (
+              <div className="empty">Select a skill.</div>
+            )}
           </div>
         </div>
       </div>
@@ -107,6 +112,17 @@ export function SkillsPage({ skills, targets, selectedSkill, onSelectSkill, onMu
 }
 
 type DetailTab = "history" | "diff" | "targets";
+
+function summarizePolicy(skillBindings: Binding[]): string {
+  if (skillBindings.length === 0) return "— (no bindings)";
+  const counts = skillBindings.reduce<Record<string, number>>((acc, b) => {
+    acc[b.policy] = (acc[b.policy] ?? 0) + 1;
+    return acc;
+  }, {});
+  const kinds = Object.keys(counts);
+  if (kinds.length === 1) return `${kinds[0]} · ${skillBindings.length} binding${skillBindings.length === 1 ? "" : "s"}`;
+  return kinds.map((k) => `${counts[k]} ${k}`).join(" · ");
+}
 
 interface LifecycleEvent {
   kind: "release" | "capture" | "save" | "snapshot" | "project";
@@ -124,26 +140,17 @@ const KIND_COLOR: Record<LifecycleEvent["kind"], string> = {
   project: "var(--ok)",
 };
 
-// Lifecycle is illustrative filler — the registry does not yet surface
-// per-skill timelines via the panel API. The most recent entry anchors
-// to the skill's actual latest revision so users see a real hash rather
-// than a fabricated version tag.
-function lifecycleFor(skill: Skill): LifecycleEvent[] {
-  return [
-    { kind: "release", v: "v0.4", time: "4 days ago", who: "you", desc: "released after 3 captures" },
-    { kind: "capture", v: "#c7", time: "2 days ago", who: "you", desc: "precondition relaxed, added harness pairing" },
-    { kind: "save", v: "—", time: "2 days ago", who: "you", desc: "saved working tree" },
-    { kind: "snapshot", v: "sn-8f1", time: "2 days ago", who: "auto", desc: "pre-projection snapshot" },
-    { kind: "project", v: "—", time: "2 days ago", who: "auto", desc: "projected → claude/work, codex/home" },
-    { kind: "project", v: skill.latestRev, time: "6h ago", who: "auto", desc: "latest applied revision" },
-  ];
-}
+// Lifecycle events come from the panel API (per-skill observation stream);
+// until that endpoint ships (Wave 3) the component renders an empty state.
 
-function SkillDetail({ skill, targets }: { skill: Skill; targets: Target[] }) {
+function SkillDetail({ skill, targets, bindings }: { skill: Skill; targets: Target[]; bindings: Binding[] }) {
   const [tab, setTab] = useState<DetailTab>("history");
   const targetObjs = skill.targets
     .map((tid) => targets.find((t) => t.id === tid))
     .filter((t): t is Target => t !== undefined);
+
+  const skillBindings = bindings.filter((b) => b.skill === skill.name);
+  const policyLabel = summarizePolicy(skillBindings);
 
   return (
     <div className="detail">
@@ -157,7 +164,7 @@ function SkillDetail({ skill, targets }: { skill: Skill; targets: Target[] }) {
         <div className="k">Rules</div>
         <div className="v">{skill.ruleCount} on chain</div>
         <div className="k">Policy</div>
-        <div className="v">auto-project on binding match</div>
+        <div className="v">{policyLabel}</div>
       </div>
 
       <div className="tabs">
@@ -172,14 +179,24 @@ function SkillDetail({ skill, targets }: { skill: Skill; targets: Target[] }) {
         </button>
       </div>
 
-      {tab === "history" && <Lifecycle events={lifecycleFor(skill)} />}
-      {tab === "diff" && <DiffView latestRev={skill.latestRev} />}
+      {tab === "history" && <Lifecycle events={[]} skillName={skill.name} />}
+      {tab === "diff" && <DiffEmpty />}
       {tab === "targets" && <TargetsTab targets={targetObjs} />}
     </div>
   );
 }
 
-function Lifecycle({ events }: { events: LifecycleEvent[] }) {
+function Lifecycle({ events, skillName }: { events: LifecycleEvent[]; skillName: string }) {
+  if (events.length === 0) {
+    return (
+      <div style={{ padding: "18px 4px", fontSize: 12, color: "var(--ink-2)" }}>
+        <div style={{ marginBottom: 6 }}>No lifecycle events yet.</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+          Run <span style={{ color: "var(--ink-1)" }}>loom capture {skillName}</span> to start the chain.
+        </div>
+      </div>
+    );
+  }
   return (
     <div style={{ position: "relative", paddingLeft: 22 }}>
       <div style={{ position: "absolute", left: 7, top: 4, bottom: 4, width: 1, background: "var(--line)" }} />
@@ -213,43 +230,13 @@ function Lifecycle({ events }: { events: LifecycleEvent[] }) {
   );
 }
 
-function DiffView({ latestRev }: { latestRev: string }) {
+function DiffEmpty() {
   return (
-    <div>
-      <div className="section-title">{latestRev} vs v0.4.1</div>
-      <div style={{ border: "1px solid var(--line)", borderRadius: 6, overflow: "hidden" }}>
-        <div className="diff-row">
-          <div className="mark">4</div>
-          <div className="l" style={{ color: "var(--ink-2)" }}>
-            ## When to use
-          </div>
-        </div>
-        <div className="diff-row del">
-          <div className="mark">-</div>
-          <div className="l">- for simple function extractions only</div>
-        </div>
-        <div className="diff-row add">
-          <div className="mark">+</div>
-          <div className="l">+ for both function + module-level refactors</div>
-        </div>
-        <div className="diff-row add">
-          <div className="mark">+</div>
-          <div className="l">+ pairs well with rust-test-harness for verification</div>
-        </div>
-        <div className="diff-row">
-          <div className="mark">7</div>
-          <div className="l" style={{ color: "var(--ink-2)" }}>
-            ## Preconditions
-          </div>
-        </div>
-        <div className="diff-row del">
-          <div className="mark">-</div>
-          <div className="l">- all tests green on HEAD</div>
-        </div>
-        <div className="diff-row add">
-          <div className="mark">+</div>
-          <div className="l">+ all tests green on HEAD OR baseline noted in capture</div>
-        </div>
+    <div style={{ padding: "18px 4px", fontSize: 12, color: "var(--ink-2)" }}>
+      <div style={{ marginBottom: 6 }}>No diff available.</div>
+      <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+        Per-revision diff view coming in v1.0. Use{" "}
+        <span style={{ color: "var(--ink-1)" }}>git -C skills/&lt;name&gt; diff</span> for now.
       </div>
     </div>
   );

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -1,0 +1,154 @@
+import type { RemotePayload } from "../../types";
+import { PlayIcon, RefreshIcon, SyncIcon } from "../../components/icons/nav_icons";
+import { api } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
+
+interface SyncPageProps {
+  remote: RemotePayload | null;
+  pendingCount: number;
+  registryRoot: string | null;
+  readOnly: boolean;
+  onMutation: () => void;
+}
+
+export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutation }: SyncPageProps) {
+  const push = useMutation();
+  const pull = useMutation();
+  const replay = useMutation();
+  const configured = remote?.configured === true;
+  const state = remote?.sync_state ?? (configured ? "unknown" : "not configured");
+  const rootDisplay = registryRoot ? registryRoot.replace(/^\/Users\/[^/]+/, "~") : "—";
+
+  const banner =
+    push.error ?? pull.error ?? replay.error ??
+    push.success ?? pull.success ?? replay.success ?? null;
+  const bannerType = push.error || pull.error || replay.error ? "err" : banner ? "ok" : null;
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Git sync</h1>
+          <div className="subtitle">
+            Your registry is a git repo. Push/pull/replay keep its state synchronized across machines.
+          </div>
+        </div>
+      </div>
+      {banner && (
+        <div
+          style={{
+            padding: "6px 28px",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            borderBottom: "1px solid var(--line)",
+            color: bannerType === "err" ? "var(--err)" : "var(--ok)",
+            background: bannerType === "err" ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
+          }}
+        >
+          {banner}
+        </div>
+      )}
+      <div className="page-body">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 18 }}>
+          <Kpi label="Sync state" value={state} />
+          <Kpi label="Ahead" value={remote?.ahead ?? 0} />
+          <Kpi label="Behind" value={remote?.behind ?? 0} />
+          <Kpi
+            label="Pending ops"
+            value={pendingCount}
+            tone={pendingCount > 0 ? "pending" : undefined}
+          />
+        </div>
+
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div className="card-head">
+            <h3>Remote</h3>
+            <span className={`chip ${configured ? "ok" : "warn"}`}>
+              {configured ? "configured" : "not configured"}
+            </span>
+          </div>
+          <div className="card-body" style={{ fontSize: 12 }}>
+            <pre className="code" style={{ marginBottom: 8 }}>
+              <span className="c"># Registry root</span>
+              {"\n"}
+              <span className="k">--root</span> <span className="s">{rootDisplay}</span>
+              {remote?.url && (
+                <>
+                  {"\n"}
+                  <span className="c"># Remote URL</span>
+                  {"\n"}
+                  <span className="s">{remote.url}</span>
+                </>
+              )}
+              {remote?.remote && (
+                <>
+                  {"\n"}
+                  <span className="c"># Remote name</span>
+                  {"\n"}
+                  <span className="s">{remote.remote}</span>
+                </>
+              )}
+            </pre>
+            {remote?.tracking_ref === false && (
+              <div style={{ color: "var(--warn)", fontSize: 11 }}>
+                ⚠ Local-only — no upstream tracking branch configured.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-head">
+            <h3>Actions</h3>
+          </div>
+          <div className="card-body" style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <button
+              className="btn"
+              disabled={readOnly || pull.busy}
+              onClick={() => pull.run("sync pull", api.syncPull, onMutation)}
+              title={readOnly ? "registry offline" : "fetch + fast-forward from remote"}
+            >
+              <SyncIcon /> {pull.busy ? "pulling…" : "Pull"}
+            </button>
+            <button
+              className="btn"
+              disabled={readOnly || push.busy}
+              onClick={() => push.run("sync push", api.syncPush, onMutation)}
+              title={readOnly ? "registry offline" : "push local registry to remote"}
+            >
+              <SyncIcon /> {push.busy ? "pushing…" : "Push"}
+            </button>
+            <button
+              className="btn primary"
+              disabled={readOnly || replay.busy}
+              onClick={() => replay.run("sync replay", api.syncReplay, onMutation)}
+              title={readOnly ? "registry offline" : `replay ${pendingCount} pending op${pendingCount === 1 ? "" : "s"}`}
+            >
+              <PlayIcon /> {replay.busy ? "replaying…" : `Replay pending (${pendingCount})`}
+            </button>
+            <button
+              className="btn ghost"
+              disabled={readOnly}
+              onClick={onMutation}
+              title="re-fetch remote status + pending ops"
+            >
+              <RefreshIcon /> Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {
+  const color = tone === "pending" ? "var(--pending)" : tone === "err" ? "var(--err)" : "var(--ink-0)";
+  return (
+    <div className="kpi">
+      <div className="label">{label}</div>
+      <div className="value" style={{ color }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/panel/src/pages/panel/TargetsPage.tsx
+++ b/panel/src/pages/panel/TargetsPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Skill, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon } from "../../components/icons/nav_icons";
 import { TargetAddForm } from "../../components/panel/forms/TargetAddForm";
+import { api, ApiError, type TargetShowPayload } from "../../lib/api/client";
 
 interface TargetsPageProps {
   targets: Target[];
@@ -15,6 +16,8 @@ interface TargetsPageProps {
 
 export function TargetsPage({ targets, skills, selectedTarget, onSelectTarget, onMutation, readOnly }: TargetsPageProps) {
   const [addOpen, setAddOpen] = useState(false);
+  const sel = targets.find((t) => t.id === selectedTarget) ?? null;
+
   return (
     <>
       <div className="page-header">
@@ -48,13 +51,13 @@ export function TargetsPage({ targets, skills, selectedTarget, onSelectTarget, o
         )}
         <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12 }}>
           {targets.map((t) => {
-            const sel = selectedTarget === t.id;
+            const isSel = selectedTarget === t.id;
             const inbound = skills.filter((s) => s.targets.includes(t.id)).length;
             return (
               <div
                 key={t.id}
                 className="card"
-                style={{ cursor: "pointer", borderColor: sel ? "var(--accent)" : "var(--line)" }}
+                style={{ cursor: "pointer", borderColor: isSel ? "var(--accent)" : "var(--line)" }}
                 onClick={() => onSelectTarget(t.id)}
               >
                 <div style={{ padding: "14px 16px", display: "flex", alignItems: "center", gap: 12 }}>
@@ -96,7 +99,106 @@ export function TargetsPage({ targets, skills, selectedTarget, onSelectTarget, o
             );
           })}
         </div>
+        {sel && (
+          <div className="card" style={{ marginTop: 16 }}>
+            <div className="card-head">
+              <h3>
+                {sel.agent}/{sel.profile}
+                <span className="mono" style={{ color: "var(--ink-3)", marginLeft: 8, fontSize: 12 }}>
+                  {sel.id}
+                </span>
+              </h3>
+              <span className={`chip ${sel.ownership}`}>
+                <span className="dot" />
+                {sel.ownership}
+              </span>
+            </div>
+            <div className="card-body">
+              <TargetDetail target={sel} />
+            </div>
+          </div>
+        )}
       </div>
     </>
+  );
+}
+
+type DetailState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; payload: NonNullable<TargetShowPayload["data"]> }
+  | { kind: "error"; message: string };
+
+function TargetDetail({ target }: { target: Target }) {
+  const [state, setState] = useState<DetailState>({ kind: "idle" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ kind: "loading" });
+    api
+      .targetShow(target.id, controller.signal)
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        if (!res.ok || !res.data) {
+          setState({ kind: "error", message: res.error?.message ?? "target fetch returned ok=false" });
+          return;
+        }
+        setState({ kind: "ready", payload: res.data });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => controller.abort();
+  }, [target.id]);
+
+  const bindings = state.kind === "ready" ? state.payload.bindings ?? [] : [];
+  const projections = state.kind === "ready" ? state.payload.projections ?? [] : [];
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 18, fontSize: 12 }}>
+      <div>
+        <div className="section-title">Bindings → this target</div>
+        {state.kind === "loading" && <div className="empty mono">loading…</div>}
+        {state.kind === "error" && <div className="empty" style={{ color: "var(--err)" }}>{state.message}</div>}
+        {state.kind === "ready" && bindings.length === 0 && <div className="empty">No bindings point here yet.</div>}
+        {state.kind === "ready" && bindings.length > 0 && (
+          <ul style={{ paddingLeft: 0, listStyle: "none" }}>
+            {bindings.map((b) => (
+              <li key={b.binding_id} style={{ padding: "6px 0", borderBottom: "1px solid var(--line-soft)" }}>
+                <span className="mono" style={{ color: "var(--ink-1)" }}>
+                  {b.binding_id}
+                </span>
+                <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
+                  {b.workspace_matcher.kind}:{b.workspace_matcher.value}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div>
+        <div className="section-title">Projections realized</div>
+        {state.kind === "loading" && <div className="empty mono">loading…</div>}
+        {state.kind === "ready" && projections.length === 0 && (
+          <div className="empty">No projections realized yet.</div>
+        )}
+        {state.kind === "ready" && projections.length > 0 && (
+          <ul style={{ paddingLeft: 0, listStyle: "none" }}>
+            {projections.map((p, i) => (
+              <li key={i} style={{ padding: "6px 0", borderBottom: "1px solid var(--line-soft)" }}>
+                <span className="mono" style={{ color: "var(--ink-1)" }}>
+                  {p.skill_id}
+                </span>
+                <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
+                  {p.method} · rev {p.last_applied_rev?.slice(0, 8) ?? "—"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -76,6 +76,23 @@ pub(super) async fn v3_status(State(state): State<PanelState>) -> Json<serde_jso
     }
 }
 
+/// Return the full operations journal (`.loom/v3/operations.jsonl`). The panel
+/// History page reads this to show every state-changing op, not just the
+/// in-flight ones surfaced by `/api/pending`. Entries are returned in append
+/// order; callers paginate client-side (total volume is bounded by the
+/// checkpoint watermark and `loom sync replay`).
+pub(super) async fn v3_ops(State(state): State<PanelState>) -> Json<serde_json::Value> {
+    match load_v3_snapshot(&state.ctx) {
+        Ok(snapshot) => v3_ok(json!({
+            "state_model": "v3",
+            "count": snapshot.operations.len(),
+            "operations": snapshot.operations,
+            "checkpoint": snapshot.checkpoint,
+        })),
+        Err(err) => err,
+    }
+}
+
 pub(super) async fn v3_bindings(State(state): State<PanelState>) -> Json<serde_json::Value> {
     match load_v3_snapshot(&state.ctx) {
         Ok(snapshot) => v3_ok(json!({

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -84,6 +84,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/info", get(info))
         .route("/api/skills", get(skills))
         .route("/api/v3/status", get(v3_status))
+        .route("/api/v3/ops", get(v3_ops))
         .route("/api/v3/bindings", get(v3_bindings))
         .route("/api/v3/bindings/{binding_id}", get(v3_binding_show))
         .route("/api/v3/targets", get(v3_targets))


### PR DESCRIPTION
## Summary

Two commits lighting up panel surfaces that had been shipping as empty states.

### b9ede07 — Panel honesty pass
- Dropped placeholder/mock data from Overview, Bindings, Targets, Skills, Ops.
- Wired four previously unreachable routes (Sync, Settings, plus Bindings/Targets detail drilldowns) through `PanelApp.tsx`.
- Added `SyncPage` + `SettingsPage` (real views, not stubs).
- No schema changes.

### 62e4c15 — Ops history tab
- Added `GET /api/v3/ops` backend handler that returns the journal verbatim.
- Added `HistoryPage.tsx` so the sidebar "History" entry now renders real op records instead of a 404.

## Test plan

- [x] `cargo test` — all unit + integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `npx tsc --noEmit` clean on `panel/`
- [ ] Manual UI walk-through (not done — flagged per W-16; reviewer should click each sidebar entry before merging)

## Related

Sets up the groundwork for #11 (Wave 3b tracker). Does not close #8 / #9 / #10 — those are separate PRs.