### PR TITLE
Fix /api/remote/status failure contract

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -31,6 +31,27 @@ export class ApiError extends Error {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRemoteStatusResponse(path: string, body: unknown): RemoteStatusResponse {
+  if (!isRecord(body)) {
+    throw new ApiError(path, 200, `GET ${path} returned malformed remote status payload`);
+  }
+  if (isRecord(body.error)) {
+    const message =
+      typeof body.error.message === "string"
+        ? body.error.message
+        : `GET ${path} returned error-shaped payload`;
+    throw new ApiError(path, 200, message);
+  }
+  if (!isRecord(body.remote)) {
+    throw new ApiError(path, 200, `GET ${path} returned malformed remote status payload`);
+  }
+  return body as RemoteStatusResponse;
+}
+
 async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(path, { signal });
   let body: unknown;
@@ -165,7 +186,8 @@ export const api = {
   info: (signal?: AbortSignal) => getJson<InfoPayload>("/api/info", signal),
   skills: (signal?: AbortSignal) => getJson<SkillsPayload>("/api/skills", signal),
   v3Status: (signal?: AbortSignal) => getJson<V3Payload>("/api/v3/status", signal),
-  remoteStatus: (signal?: AbortSignal) => getJson<RemoteStatusResponse>("/api/remote/status", signal),
+  remoteStatus: async (signal?: AbortSignal) =>
+    parseRemoteStatusResponse("/api/remote/status", await getJson<unknown>("/api/remote/status", signal)),
   pending: (signal?: AbortSignal) => getJson<PendingPayload>("/api/pending", signal),
 
   targetAdd: (body: TargetAddBody) => postJson("/api/v3/targets", body),

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -17,7 +17,7 @@ use crate::state_model::V3StatePaths;
 
 use super::auth::{
     ensure_mutation_authorized, error_envelope, load_v3_snapshot, run_panel_command,
-    status_for_v3_error_payload, v3_error, v3_ok,
+    status_for_error_code, status_for_v3_error_payload, v3_error, v3_ok,
 };
 use super::{BindingAddRequest, CaptureRequest, PanelState, ProjectRequest, TargetAddRequest};
 
@@ -378,10 +378,24 @@ pub(super) async fn sync_replay(
     )
 }
 
-pub(super) async fn remote_status(State(state): State<PanelState>) -> Json<serde_json::Value> {
+pub(super) async fn remote_status(
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
     match remote_status_payload(&state.ctx) {
-        Ok((remote, meta)) => Json(json!({"remote": remote, "warnings": meta.warnings})),
-        Err(err) => Json(json!({"error": err.message, "code": err.code.as_str()})),
+        Ok((remote, meta)) => (
+            StatusCode::OK,
+            Json(json!({"remote": remote, "warnings": meta.warnings})),
+        ),
+        Err(err) => (
+            status_for_error_code(Some(err.code.as_str())),
+            Json(json!({
+                "ok": false,
+                "error": {
+                    "code": err.code.as_str(),
+                    "message": err.message,
+                }
+            })),
+        ),
     }
 }
 

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -135,7 +135,7 @@ mod tests {
             ensure_mutation_authorized, error_envelope, request_origin_matches, run_panel_command,
             status_for_error_code, status_for_v3_error_payload, status_for_v3_state_load_error,
         },
-        handlers::v3_status,
+        handlers::{remote_status, v3_status},
         static_serve::{content_type_for, ensure_panel_dist, resolve_panel_asset_path},
     };
     use crate::cli::{
@@ -658,6 +658,40 @@ mod tests {
             assert!(payload["error"]["message"].as_str().is_some());
             assert!(payload.get("meta").is_some());
         }
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn remote_status_returns_non_2xx_with_structured_error_body_on_failure() {
+        let (root, state) = make_test_state();
+        state
+            .ctx
+            .ensure_state_layout()
+            .expect("create pending ops layout");
+        fs::remove_file(&state.ctx.pending_ops_file).expect("remove pending ops file");
+        fs::create_dir_all(&state.ctx.pending_ops_file).expect("replace pending ops file with dir");
+
+        let (status, Json(payload)) = remote_status(State(state)).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(payload["ok"], json!(false));
+        assert_eq!(payload["error"]["code"], json!("IO_ERROR"));
+        assert!(payload["error"]["message"].as_str().is_some());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn remote_status_returns_success_payload_when_remote_is_not_configured() {
+        let (root, state) = make_test_state();
+
+        let (status, Json(payload)) = remote_status(State(state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["remote"]["configured"], json!(false));
+        assert!(payload["remote"].is_object());
+        assert!(payload["warnings"].is_array());
 
         let _ = fs::remove_dir_all(root);
     }


### PR DESCRIPTION
Closes #24

## Summary
- return mapped non-2xx responses with nested error bodies from `/api/remote/status`
- reject error-shaped or malformed 200 bodies in the panel remote status client
- add regression tests for the failure path and the configured-false success path

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test
- npm --prefix panel run typecheck