### PR TITLE
Reject stale panel dist assets

### DIFF
--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -136,7 +136,7 @@ mod tests {
             status_for_error_code, status_for_v3_error_payload, status_for_v3_state_load_error,
         },
         handlers::v3_status,
-        static_serve::{content_type_for, resolve_panel_asset_path},
+        static_serve::{content_type_for, ensure_panel_dist, resolve_panel_asset_path},
     };
     use crate::cli::{
         BindingAddArgs, CaptureArgs, Command, ProjectArgs, ProjectionMethod, SkillCommand,
@@ -160,6 +160,7 @@ mod tests {
         net::{IpAddr, Ipv4Addr, SocketAddr},
         path::Path,
         sync::Arc,
+        time::Duration,
     };
     use uuid::Uuid;
 
@@ -294,6 +295,38 @@ mod tests {
             content_type_for(Path::new("artifact.bin")),
             "application/octet-stream"
         );
+    }
+
+    #[test]
+    fn ensure_panel_dist_rejects_stale_assets_until_rebuilt() {
+        let root = std::env::temp_dir().join(format!("loom-panel-dist-test-{}", Uuid::new_v4()));
+        let panel_dir = root.join("panel");
+        let dist_dir = panel_dir.join("dist");
+        let src_dir = panel_dir.join("src");
+
+        fs::create_dir_all(&dist_dir).expect("create panel dist dir");
+        fs::create_dir_all(&src_dir).expect("create panel src dir");
+        fs::write(dist_dir.join("index.html"), "<html>old build</html>").expect("write dist");
+
+        // Sleep because some filesystems coarsen mtime granularity.
+        std::thread::sleep(Duration::from_secs(1));
+        fs::write(
+            src_dir.join("panel-entry.tsx"),
+            "export const build = 'newer';",
+        )
+        .expect("write newer source");
+
+        let err = ensure_panel_dist(&dist_dir).expect_err("stale dist should be rejected");
+        assert!(
+            err.to_string().contains("panel frontend assets are stale"),
+            "unexpected error: {err}"
+        );
+
+        std::thread::sleep(Duration::from_secs(1));
+        fs::write(dist_dir.join("index.html"), "<html>fresh build</html>").expect("rewrite dist");
+
+        ensure_panel_dist(&dist_dir).expect("fresh dist should pass");
+        cleanup_root(root);
     }
 
     #[test]

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -330,6 +330,36 @@ mod tests {
     }
 
     #[test]
+    fn ensure_panel_dist_ignores_untracked_dist_files_when_checking_staleness() {
+        let root = std::env::temp_dir().join(format!("loom-panel-dist-test-{}", Uuid::new_v4()));
+        let panel_dir = root.join("panel");
+        let dist_dir = panel_dir.join("dist");
+        let src_dir = panel_dir.join("src");
+
+        fs::create_dir_all(&dist_dir).expect("create panel dist dir");
+        fs::create_dir_all(&src_dir).expect("create panel src dir");
+        fs::write(dist_dir.join("index.html"), "<html>old build</html>").expect("write dist");
+
+        std::thread::sleep(Duration::from_secs(1));
+        fs::write(
+            src_dir.join("panel-entry.tsx"),
+            "export const build = 'newer';",
+        )
+        .expect("write newer source");
+
+        std::thread::sleep(Duration::from_secs(1));
+        fs::write(dist_dir.join("scratch.txt"), "new but unrelated").expect("write scratch file");
+
+        let err = ensure_panel_dist(&dist_dir).expect_err("stale dist should still be rejected");
+        assert!(
+            err.to_string().contains("panel frontend assets are stale"),
+            "unexpected error: {err}"
+        );
+
+        cleanup_root(root);
+    }
+
+    #[test]
     fn error_envelope_uses_expected_shape() {
         assert_eq!(
             error_envelope("skill.capture", "req-1", "INTERNAL_ERROR", "boom"),

--- a/src/panel/static_serve.rs
+++ b/src/panel/static_serve.rs
@@ -49,12 +49,7 @@ pub(super) fn ensure_panel_dist(dist_dir: &Path) -> Result<()> {
             dist_dir.display()
         )
     })?;
-    let Some((built_asset, built_at)) = newest_file_in_tree(dist_dir)? else {
-        return Err(anyhow!(
-            "panel frontend not built; expected assets under {}",
-            dist_dir.display()
-        ));
-    };
+    let (built_asset, built_at) = newest_panel_dist_artifact(dist_dir)?;
 
     if let Some((source_path, source_mtime)) = newest_panel_build_input(panel_dir)?
         && source_mtime > built_at
@@ -132,10 +127,24 @@ fn newest_panel_build_input(panel_dir: &Path) -> Result<Option<(PathBuf, SystemT
     Ok(newest)
 }
 
-fn newest_file_in_tree(root: &Path) -> Result<Option<(PathBuf, SystemTime)>> {
+fn newest_panel_dist_artifact(dist_dir: &Path) -> Result<(PathBuf, SystemTime)> {
     let mut newest = None;
-    update_newest_from_tree(root, &mut newest)?;
-    Ok(newest)
+
+    update_newest_file(dist_dir.join("index.html"), &mut newest)?;
+    update_newest_file(dist_dir.join("landing.html"), &mut newest)?;
+    update_newest_file(dist_dir.join("favicon.svg"), &mut newest)?;
+
+    let assets_dir = dist_dir.join("assets");
+    if assets_dir.is_dir() {
+        update_newest_from_tree(&assets_dir, &mut newest)?;
+    }
+
+    newest.ok_or_else(|| {
+        anyhow!(
+            "panel frontend not built; expected assets under {}",
+            dist_dir.display()
+        )
+    })
 }
 
 fn update_newest_from_tree(root: &Path, newest: &mut Option<(PathBuf, SystemTime)>) -> Result<()> {

--- a/src/panel/static_serve.rs
+++ b/src/panel/static_serve.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::time::SystemTime;
 
 use anyhow::{Result, anyhow};
 use axum::{
@@ -8,6 +9,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use walkdir::WalkDir;
 
 use super::PanelState;
 
@@ -34,14 +36,37 @@ pub(super) async fn frontend_static_asset(
 
 pub(super) fn ensure_panel_dist(dist_dir: &Path) -> Result<()> {
     let index_path = dist_dir.join("index.html");
-    if index_path.is_file() {
-        Ok(())
-    } else {
-        Err(anyhow!(
+    if !index_path.is_file() {
+        return Err(anyhow!(
             "panel frontend not built; expected {}",
             index_path.display()
-        ))
+        ));
     }
+
+    let panel_dir = dist_dir.parent().ok_or_else(|| {
+        anyhow!(
+            "panel frontend not built; invalid dist directory {}",
+            dist_dir.display()
+        )
+    })?;
+    let Some((built_asset, built_at)) = newest_file_in_tree(dist_dir)? else {
+        return Err(anyhow!(
+            "panel frontend not built; expected assets under {}",
+            dist_dir.display()
+        ));
+    };
+
+    if let Some((source_path, source_mtime)) = newest_panel_build_input(panel_dir)?
+        && source_mtime > built_at
+    {
+        return Err(anyhow!(
+            "panel frontend assets are stale: {} is newer than {}. Run `make panel-build` or `cd panel && bun run build`.",
+            source_path.display(),
+            built_asset.display()
+        ));
+    }
+
+    Ok(())
 }
 
 pub(crate) fn resolve_panel_asset_path(dist_dir: &Path, requested: &str) -> Option<PathBuf> {
@@ -80,6 +105,60 @@ fn serve_panel_asset(path: PathBuf) -> Response {
         )
             .into_response(),
     }
+}
+
+fn newest_panel_build_input(panel_dir: &Path) -> Result<Option<(PathBuf, SystemTime)>> {
+    let mut newest = None;
+
+    for relative in [
+        "index.html",
+        "landing.html",
+        "package.json",
+        "package-lock.json",
+        "bun.lock",
+        "tsconfig.json",
+        "vite.config.ts",
+    ] {
+        update_newest_file(panel_dir.join(relative), &mut newest)?;
+    }
+
+    for relative in ["src", "public"] {
+        let path = panel_dir.join(relative);
+        if path.is_dir() {
+            update_newest_from_tree(&path, &mut newest)?;
+        }
+    }
+
+    Ok(newest)
+}
+
+fn newest_file_in_tree(root: &Path) -> Result<Option<(PathBuf, SystemTime)>> {
+    let mut newest = None;
+    update_newest_from_tree(root, &mut newest)?;
+    Ok(newest)
+}
+
+fn update_newest_from_tree(root: &Path, newest: &mut Option<(PathBuf, SystemTime)>) -> Result<()> {
+    for entry in WalkDir::new(root) {
+        let entry = entry?;
+        if entry.file_type().is_file() {
+            update_newest_file(entry.path().to_path_buf(), newest)?;
+        }
+    }
+    Ok(())
+}
+
+fn update_newest_file(path: PathBuf, newest: &mut Option<(PathBuf, SystemTime)>) -> Result<()> {
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let modified = fs::metadata(&path)?.modified()?;
+    match newest {
+        Some((_, newest_time)) if modified <= *newest_time => {}
+        _ => *newest = Some((path, modified)),
+    }
+    Ok(())
 }
 
 pub(crate) fn content_type_for(path: &Path) -> &'static str {


### PR DESCRIPTION
## Summary
- reject stale `panel/dist` assets when frontend build inputs are newer than the built output
- scan panel source/config inputs recursively instead of trusting `dist/index.html` existence alone
- add a regression test covering stale assets until `dist` is rebuilt

## Root cause
`ensure_panel_dist` only checked whether `panel/dist/index.html` existed. If source or build inputs changed after a previous frontend build, `loom panel` would still serve that older `dist/` tree.

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test