### PR TITLE
test(panel): extend mutation auth test to cover ops.retry/purge/history.repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +729,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "include_dir",
  "libc",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "skillloom"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [[bin]]
 name = "loom"
@@ -12,6 +13,7 @@ anyhow = "1.0.98"
 axum = { version = "0.8.4", features = ["json"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive"] }
+include_dir = "0.7.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ loom --root ~/.loom-registry target add \
 loom --root ~/.loom-registry panel        # → http://localhost:43117
 ```
 
+`loom panel` now serves a frontend bundled into the Rust binary at build time, so it works even when `--root` points at a separate registry directory. If panel assets are unavailable in your build, reinstall from a checkout with `bun` available so Loom can package the frontend during compile.
+
 Prefer a guided walkthrough? Run `./scripts/demo.sh` for a scripted end-to-end tour (init → target add → status → panel hint) against a throwaway registry. `./scripts/e2e-agent-flow.sh` runs the four real integration scenarios used in CI.
 
 ## Panel

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,95 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let panel_dir = manifest_dir.join("panel");
+    let source_dist = panel_dir.join("dist");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
+    let embedded_dist = out_dir.join("panel-dist");
+
+    println!("cargo:rerun-if-changed=panel/package.json");
+    println!("cargo:rerun-if-changed=panel/bun.lock");
+    println!("cargo:rerun-if-changed=panel/index.html");
+    println!("cargo:rerun-if-changed=panel/landing.html");
+    println!("cargo:rerun-if-changed=panel/public");
+    println!("cargo:rerun-if-changed=panel/src");
+    println!("cargo:rerun-if-changed=panel/vite.config.ts");
+    println!("cargo:rerun-if-changed=panel/tsconfig.json");
+
+    if embedded_dist.exists() {
+        fs::remove_dir_all(&embedded_dist).expect("remove previous embedded panel dir");
+    }
+    fs::create_dir_all(&embedded_dist).expect("create embedded panel dir");
+
+    if !source_dist.join("index.html").is_file() {
+        maybe_build_panel(&panel_dir);
+    }
+
+    if source_dist.join("index.html").is_file() {
+        copy_dir_recursive(&source_dist, &embedded_dist);
+        println!("cargo:rustc-env=LOOM_PANEL_EMBED_STATUS=ready");
+    } else {
+        println!(
+            "cargo:warning=panel frontend assets missing; 'loom panel' will be unavailable unless 'bun run build' succeeds during build"
+        );
+        println!("cargo:rustc-env=LOOM_PANEL_EMBED_STATUS=missing");
+    }
+}
+
+fn maybe_build_panel(panel_dir: &Path) {
+    let bun = if cfg!(windows) { "bun.exe" } else { "bun" };
+
+    let install_status = Command::new(bun)
+        .arg("install")
+        .arg("--frozen-lockfile")
+        .current_dir(panel_dir)
+        .status();
+
+    let Ok(install_status) = install_status else {
+        return;
+    };
+    if !install_status.success() {
+        return;
+    }
+
+    let _ = Command::new(bun)
+        .arg("run")
+        .arg("build")
+        .current_dir(panel_dir)
+        .status();
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) {
+    let entries = fs::read_dir(source).expect("read source dist dir");
+    for entry in entries {
+        let entry = entry.expect("read dist entry");
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type().expect("read dist file type");
+        if file_type.is_dir() {
+            fs::create_dir_all(&destination_path).expect("create embedded subdir");
+            copy_dir_recursive(&source_path, &destination_path);
+            continue;
+        }
+        if file_type.is_file() || file_type.is_symlink() {
+            fs::copy(&source_path, &destination_path).unwrap_or_else(|err| {
+                panic!(
+                    "copy panel asset '{}' -> '{}' failed: {}",
+                    display_path(&source_path),
+                    display_path(&destination_path),
+                    err
+                )
+            });
+        }
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.as_os_str()
+        .to_str()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| path.as_os_str().to_string_lossy().into_owned())
+}

--- a/docs/UI_BACKLOG.md
+++ b/docs/UI_BACKLOG.md
@@ -1,0 +1,299 @@
+# Loom UI Backlog
+
+Status date: 2026-04-24
+Scope: `panel/` landing + registry panel
+
+This backlog converts the current UI completion audit into implementation work.
+Priority is driven by product leverage, user trust, and closeness to existing code.
+
+## P0
+
+### 1. Make Ops a real control surface
+
+Problem:
+`Ops` looks actionable, but the main actions are not wired. This creates false affordance and leaves the operator stuck in the CLI for the very workflow the panel implies it owns.
+
+Current surface:
+- [panel/src/pages/panel/OpsPage.tsx](../panel/src/pages/panel/OpsPage.tsx)
+- [panel/src/components/panel/OpRow.tsx](../panel/src/components/panel/OpRow.tsx)
+
+Needed backend/API support:
+- Add panel endpoints for:
+  - `ops retry`
+  - `ops purge`
+  - `ops history diagnose`
+  - `ops history repair`
+- Expose enough op metadata to filter by status, skill, target, command kind.
+
+UI work:
+- Wire `Retry failed`.
+- Wire `Purge completed`.
+- Add `Diagnose history` and `Repair history` actions.
+- Add filters:
+  - status
+  - skill
+  - target
+  - command kind
+- Add per-op detail drawer or expandable row.
+
+Acceptance:
+- A failed op can be retried from the panel.
+- Completed ops can be purged from the panel.
+- Diagnose/repair workflows run without leaving the UI.
+- All action results show inline success/error feedback.
+
+### 2. Replace fake Overview stats with authoritative state
+
+Problem:
+The page mixes real data with hard-coded KPIs and static operational text. That weakens user trust because the screen looks live but parts of it are decorative.
+
+Current surface:
+- [panel/src/pages/panel/OverviewPage.tsx](../panel/src/pages/panel/OverviewPage.tsx)
+- [panel/src/lib/api/usePanelData.ts](../panel/src/lib/api/usePanelData.ts)
+
+Fake or illustrative areas to remove:
+- `+2 · 52 captures · 38 releases`
+- `6 agents · 4 profiles`
+- static git HEAD text
+- static "Last pull from origin/main · 6h ago"
+
+Needed backend/API support:
+- Surface:
+  - registered agent count
+  - profile count
+  - release/snapshot/capture counts if available
+  - git head / branch / status
+  - last successful sync pull / push timestamp
+  - write-guard state
+
+UI work:
+- Convert KPI cards to only render fields backed by API data.
+- If a metric is unavailable, show `—` with a tooltip or helper text.
+- Split "write guard" card into:
+  - registry root
+  - git state
+  - write safety
+  - remote sync state
+
+Acceptance:
+- No decorative metrics remain on Overview.
+- Every rendered status comes from a real backend field.
+- Missing fields degrade gracefully rather than fabricating numbers.
+
+### 3. Build the real Sync page
+
+Problem:
+Sync exists as actions in top-level buttons, but not as a dedicated operational page.
+
+Current surface:
+- [panel/src/pages/panel/PlaceholderPage.tsx](../panel/src/pages/panel/PlaceholderPage.tsx)
+- [panel/src/components/panel/Sidebar.tsx](../panel/src/components/panel/Sidebar.tsx)
+- [panel/src/components/panel/Topbar.tsx](../panel/src/components/panel/Topbar.tsx)
+
+Needed backend/API support:
+- Rich remote status payload:
+  - remote URL
+  - branch
+  - sync state
+  - ahead/behind if available
+  - last push / pull
+  - pending queue count
+  - divergence/conflict summary
+
+UI work:
+- Replace `sync` placeholder page with:
+  - remote summary
+  - push / pull / replay actions
+  - conflict and divergence state
+  - recent sync events
+  - warnings panel
+
+Acceptance:
+- Operators can understand remote sync state from a single page.
+- The page explains whether the registry is clean, pending push, local only, or diverged.
+
+## P1
+
+### 4. Build the real History page
+
+Problem:
+Audit/history is central to Loom’s value proposition, but the UI still routes this area to a placeholder.
+
+Current surface:
+- [panel/src/pages/panel/PlaceholderPage.tsx](../panel/src/pages/panel/PlaceholderPage.tsx)
+
+Needed backend/API support:
+- Read-only history timeline endpoint or payload including:
+  - op id
+  - intent
+  - status
+  - created/updated time
+  - affected skill / binding / target
+  - repair/archive events
+
+UI work:
+- Timeline view with filters.
+- Detail drawer for each history record.
+- Jump links from history entry to skill, binding, or target page.
+
+Acceptance:
+- History is browseable and filterable.
+- Operators can move from history event to affected object in one click.
+
+### 5. Turn Topbar search into command palette
+
+Problem:
+The search box visually promises global navigation, but currently has no behavior.
+
+Current surface:
+- [panel/src/components/panel/Topbar.tsx](../panel/src/components/panel/Topbar.tsx)
+
+UI work:
+- Add `⌘K` / `Ctrl+K` command palette.
+- Search across:
+  - skills
+  - targets
+  - bindings
+  - pages
+  - common actions
+- Action entries:
+  - sync pull
+  - sync push
+  - sync replay
+  - target add
+  - binding add
+
+Acceptance:
+- Typing a skill name jumps to its detail.
+- Typing a target jumps to the target page and selects it.
+- Common commands run from the palette.
+
+### 6. Replace illustrative Skill lifecycle with real history
+
+Problem:
+The detail panel is structurally right, but the lifecycle timeline is synthetic.
+
+Current surface:
+- [panel/src/pages/panel/SkillsPage.tsx](../panel/src/pages/panel/SkillsPage.tsx)
+
+Needed backend/API support:
+- Per-skill lifecycle/history payload including:
+  - capture
+  - save
+  - snapshot
+  - release
+  - rollback
+  - project
+
+UI work:
+- Replace `lifecycleFor(skill)` fake events with API-backed events.
+- Add projection health and drift summary for each skill.
+- Add quick links to related bindings and targets.
+
+Acceptance:
+- Skill detail shows only real lifecycle events.
+- Users can trace a skill from revision to projected targets.
+
+### 7. Add edit/remove flows for Targets and Bindings
+
+Problem:
+The panel currently supports creation but not full management. This forces a fallback to CLI for normal cleanup/edit cases.
+
+Current surface:
+- [panel/src/pages/panel/TargetsPage.tsx](../panel/src/pages/panel/TargetsPage.tsx)
+- [panel/src/pages/panel/BindingsPage.tsx](../panel/src/pages/panel/BindingsPage.tsx)
+
+Needed backend/API support:
+- Update and remove APIs where missing.
+
+UI work:
+- Add row/card actions:
+  - edit
+  - remove
+  - copy id/path
+- Add confirmation modals for destructive actions.
+- Show dependency warnings before deletion.
+
+Acceptance:
+- Targets and bindings can be fully managed from the panel.
+- Destructive actions require explicit confirmation and show blockers.
+
+## P2
+
+### 8. Improve state honesty across the panel
+
+Problem:
+The UI still relies on subtle placeholders in areas where the user expects exact operational truth.
+
+UI work:
+- Add explicit badges for:
+  - live
+  - mock
+  - read-only
+  - partial data
+- Add "source of truth" helper text in pages that mix derived and direct values.
+- Standardize success/error/pending banners across all pages.
+
+Acceptance:
+- A user can always tell whether the page is showing real registry data or fallback mock data.
+
+### 9. Tighten visual hierarchy in panel pages
+
+Problem:
+The visual language is coherent, but too many controls compete equally for attention.
+
+UI work:
+- Reduce decorative KPI metadata.
+- Keep one primary CTA per page.
+- Normalize card header density and spacing.
+- Simplify legend copy in the projection graph.
+- Reduce inline style sprawl by moving repeated presentation into CSS classes.
+
+Acceptance:
+- Primary actions are obvious.
+- Secondary actions are visually quieter.
+- Repeated layout styles are consolidated.
+
+### 10. Upgrade landing page for conversion, not just explanation
+
+Problem:
+The landing page explains Loom well, but it still leans too heavily on feature description instead of proof.
+
+Current surface:
+- [panel/src/pages/LandingPage.tsx](../panel/src/pages/LandingPage.tsx)
+- [panel/src/components/landing/Hero.tsx](../panel/src/components/landing/Hero.tsx)
+- [panel/src/components/landing/Features.tsx](../panel/src/components/landing/Features.tsx)
+
+UI/content work:
+- Add a real panel screenshot.
+- Add a short "30-second path" section:
+  - install
+  - init registry
+  - add target
+  - open panel
+- Add before/after examples:
+  - unmanaged multi-agent directories
+  - Loom-managed projection flow
+- Add social proof or "why this exists" with a more concrete pain story.
+
+Acceptance:
+- First-time visitors can understand the product from one scroll.
+- The page demonstrates proof, not only claims.
+
+## Suggested implementation order
+
+1. Ops page
+2. Overview truthfulness cleanup
+3. Sync page
+4. History page
+5. Command palette
+6. Real skill lifecycle
+7. Edit/remove flows
+8. Visual tightening
+9. Landing conversion pass
+
+## Notes
+
+- Do not add new decorative analytics unless the backend exposes them.
+- Prefer "missing" states over synthetic values.
+- When a page is not fully wired, say so explicitly in the UI instead of implying control that does not exist.

--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -25,7 +25,7 @@ interface TopbarProps {
   pendingCount: number;
   onReplay: () => void;
   commandItems: CommandItem[];
-  onCommand: (item: CommandItem) => void;
+  onCommand: (item: CommandItem) => void | Promise<void>;
   readOnly: boolean;
 }
 
@@ -79,6 +79,7 @@ export function Topbar(props: TopbarProps) {
   const [replayError, setReplayError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
+  const [commandError, setCommandError] = useState<string | null>(null);
 
   const results = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
@@ -116,6 +117,17 @@ export function Topbar(props: TopbarProps) {
     }
   };
 
+  const runCommand = async (item: CommandItem) => {
+    setCommandError(null);
+    try {
+      await props.onCommand(item);
+      setOpen(false);
+      setQuery("");
+    } catch (err) {
+      setCommandError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
   return (
     <div className="topbar">
       <div className="brand">
@@ -142,9 +154,7 @@ export function Topbar(props: TopbarProps) {
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter" && results[0]) {
-              props.onCommand(results[0]);
-              setOpen(false);
-              setQuery("");
+              void runCommand(results[0]);
             }
           }}
         />
@@ -168,11 +178,7 @@ export function Topbar(props: TopbarProps) {
               <button
                 key={item.id}
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={() => {
-                  props.onCommand(item);
-                  setOpen(false);
-                  setQuery("");
-                }}
+                onClick={() => void runCommand(item)}
                 style={{
                   display: "grid",
                   gap: 2,
@@ -190,6 +196,26 @@ export function Topbar(props: TopbarProps) {
                 </span>
               </button>
             ))}
+          </div>
+        )}
+        {commandError && (
+          <div
+            style={{
+              position: "absolute",
+              top: "calc(100% + 8px)",
+              left: 0,
+              right: 0,
+              padding: "8px 10px",
+              borderRadius: 10,
+              border: "1px solid rgba(216,90,90,0.25)",
+              background: "rgba(216,90,90,0.08)",
+              color: "var(--err)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              zIndex: 120,
+            }}
+          >
+            {commandError}
           </div>
         )}
       </div>

--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import type { PanelPageKey } from "../../lib/types";
+import { useEffect, useMemo, useState } from "react";
+import type { CommandItem, PanelPageKey } from "../../lib/types";
 import { api } from "../../lib/api/client";
 import { LoomMark } from "../icons/LoomMark";
 import { GitIcon, PlayIcon, SearchIcon } from "../icons/nav_icons";
@@ -24,6 +24,8 @@ interface TopbarProps {
   remoteState?: string;
   pendingCount: number;
   onReplay: () => void;
+  commandItems: CommandItem[];
+  onCommand: (item: CommandItem) => void;
   readOnly: boolean;
 }
 
@@ -75,6 +77,31 @@ export function Topbar(props: TopbarProps) {
   const status = statusDisplay(props);
   const [replaying, setReplaying] = useState(false);
   const [replayError, setReplayError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const results = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    const source = props.commandItems;
+    if (!trimmed) return source.slice(0, 8);
+    return source
+      .filter((item) => `${item.label} ${item.hint} ${item.kind}`.toLowerCase().includes(trimmed))
+      .slice(0, 8);
+  }, [props.commandItems, query]);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setOpen(true);
+      }
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const replay = async () => {
     setReplaying(true);
@@ -103,10 +130,68 @@ export function Topbar(props: TopbarProps) {
         <span className="cur">{CRUMBS[props.page]}</span>
       </div>
       <div className="spacer" />
-      <div className="searchbar" style={{ width: 240 }}>
+      <div className="searchbar" style={{ width: 280, position: "relative" }}>
         <SearchIcon />
-        <input placeholder="Jump to skill or target…" />
+        <input
+          placeholder="Jump to page, skill, target…"
+          value={query}
+          onFocus={() => setOpen(true)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && results[0]) {
+              props.onCommand(results[0]);
+              setOpen(false);
+              setQuery("");
+            }
+          }}
+        />
         <kbd>⌘K</kbd>
+        {open && results.length > 0 && (
+          <div
+            style={{
+              position: "absolute",
+              top: "calc(100% + 8px)",
+              left: 0,
+              right: 0,
+              background: "var(--bg-1)",
+              border: "1px solid var(--line)",
+              borderRadius: 12,
+              overflow: "hidden",
+              boxShadow: "0 18px 40px rgba(0,0,0,0.24)",
+              zIndex: 120,
+            }}
+          >
+            {results.map((item) => (
+              <button
+                key={item.id}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  props.onCommand(item);
+                  setOpen(false);
+                  setQuery("");
+                }}
+                style={{
+                  display: "grid",
+                  gap: 2,
+                  width: "100%",
+                  textAlign: "left",
+                  padding: "10px 12px",
+                  background: "transparent",
+                  border: "none",
+                  borderBottom: "1px solid var(--line-soft)",
+                }}
+              >
+                <span style={{ color: "var(--ink-0)", fontSize: 12.5 }}>{item.label}</span>
+                <span style={{ color: "var(--ink-3)", fontSize: 11 }}>
+                  {item.kind} · {item.hint}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
       <div className="top-actions">
         <button className="top-btn" title={props.error ?? undefined}>

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -4,6 +4,7 @@ import type {
   PendingPayload,
   RemotePayload,
   V3Payload,
+  WorkspaceStatusPayload,
 } from "../../types";
 
 export interface SkillsPayload {
@@ -142,6 +143,10 @@ export interface CaptureBody {
   message?: string;
 }
 
+export interface HistoryRepairBody {
+  strategy: "local" | "remote";
+}
+
 export interface SkillDiffFile {
   path: string;
   added: number;
@@ -163,10 +168,12 @@ export interface SkillDiffPayload {
 export const api = {
   health: (signal?: AbortSignal) => getJson<HealthPayload>("/api/health", signal),
   info: (signal?: AbortSignal) => getJson<InfoPayload>("/api/info", signal),
+  workspaceStatus: (signal?: AbortSignal) => getJson<WorkspaceStatusPayload>("/api/workspace/status", signal),
   skills: (signal?: AbortSignal) => getJson<SkillsPayload>("/api/skills", signal),
   v3Status: (signal?: AbortSignal) => getJson<V3Payload>("/api/v3/status", signal),
   remoteStatus: (signal?: AbortSignal) => getJson<RemoteStatusResponse>("/api/remote/status", signal),
   pending: (signal?: AbortSignal) => getJson<PendingPayload>("/api/pending", signal),
+  opsHistoryDiagnose: (signal?: AbortSignal) => getJson<CommandEnvelope>("/api/ops/history/diagnose", signal),
 
   targetAdd: (body: TargetAddBody) => postJson("/api/v3/targets", body),
   targetRemove: (targetId: string) => postJson(`/api/v3/targets/${encodeURIComponent(targetId)}/remove`, {}),
@@ -178,6 +185,9 @@ export const api = {
   syncPush: () => postJson("/api/sync/push", {}),
   syncPull: () => postJson("/api/sync/pull", {}),
   syncReplay: () => postJson("/api/sync/replay", {}),
+  opsRetry: () => postJson("/api/ops/retry", {}),
+  opsPurge: () => postJson("/api/ops/purge", {}),
+  opsHistoryRepair: (body: HistoryRepairBody) => postJson("/api/ops/history/repair", body),
 
   skillDiff: (name: string, revA?: string, revB?: string, signal?: AbortSignal) => {
     const params = new URLSearchParams();

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -4,6 +4,7 @@ import type {
   PendingPayload,
   RemotePayload,
   V3Payload,
+  HistoryListPayload,
   WorkspaceStatusPayload,
 } from "../../types";
 
@@ -173,6 +174,7 @@ export const api = {
   v3Status: (signal?: AbortSignal) => getJson<V3Payload>("/api/v3/status", signal),
   remoteStatus: (signal?: AbortSignal) => getJson<RemoteStatusResponse>("/api/remote/status", signal),
   pending: (signal?: AbortSignal) => getJson<PendingPayload>("/api/pending", signal),
+  opsHistoryList: (signal?: AbortSignal) => getJson<HistoryListPayload>("/api/ops/history/list", signal),
   opsHistoryDiagnose: (signal?: AbortSignal) => getJson<CommandEnvelope>("/api/ops/history/diagnose", signal),
 
   targetAdd: (body: TargetAddBody) => postJson("/api/v3/targets", body),

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { V3Projection } from "../../generated/V3Projection";
-import type { HealthPayload, RemotePayload, V3Payload } from "../../types";
+import type { HealthPayload, RemotePayload, V3Payload, WorkspaceStatusPayload } from "../../types";
 import type { Binding, Op, Skill, Target } from "../types";
 import {
   adaptBinding,
@@ -19,9 +19,17 @@ export interface PanelLiveData {
   loading: boolean;
   error: string | null;
   lastUpdated: string | null;
+  info: import("../../types").InfoPayload | null;
   registryRoot: string | null;
   remote: RemotePayload | null;
   health: HealthPayload | null;
+  workspaceStatus: WorkspaceStatusPayload["data"] | null;
+  git: WorkspaceStatusPayload["data"] extends infer T
+    ? T extends { git?: infer G }
+      ? G | null
+      : null
+    : null;
+  workspaceWarnings: string[];
   counts: V3Counts;
   skills: Skill[];
   targets: Target[];
@@ -45,9 +53,13 @@ const INITIAL_STATE: LiveState = {
   loading: true,
   error: null,
   lastUpdated: null,
+  info: null,
   registryRoot: null,
   remote: null,
   health: null,
+  workspaceStatus: null,
+  git: null,
+  workspaceWarnings: [],
   counts: EMPTY_COUNTS,
   skills: [],
   targets: [],
@@ -73,9 +85,10 @@ export function usePanelData(): PanelLiveData {
     const generation = ++generationRef.current;
 
     try {
-      const [health, info, skillsPayload, v3, remote, pending] = await Promise.all([
+      const [health, info, workspaceStatus, skillsPayload, v3, remote, pending] = await Promise.all([
         api.health(controller.signal),
         api.info(controller.signal),
+        api.workspaceStatus(controller.signal),
         api.skills(controller.signal),
         api.v3Status(controller.signal),
         api.remoteStatus(controller.signal),
@@ -104,9 +117,13 @@ export function usePanelData(): PanelLiveData {
         loading: false,
         error: null,
         lastUpdated: new Date().toISOString(),
+        info,
         registryRoot: info.root ?? null,
         remote: remote.remote ?? null,
         health,
+        workspaceStatus: workspaceStatus.data ?? null,
+        git: workspaceStatus.data?.git ?? null,
+        workspaceWarnings: workspaceStatus.meta?.warnings ?? [],
         counts: v3Data.counts ?? EMPTY_COUNTS,
         skills,
         targets,

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -107,3 +107,10 @@ export interface TweakState {
   hero: "graph" | "grid" | "focus";
   displayFont: "Fraunces" | "Inter" | "JetBrains Mono";
 }
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  hint: string;
+  kind: "page" | "skill" | "target" | "binding" | "action";
+}

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -33,6 +33,21 @@ describe("PanelApp status failure UI", () => {
           return Promise.resolve(jsonResponse({ ok: true }));
         case "/api/info":
           return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
+        case "/api/workspace/status":
+          return Promise.resolve(
+            jsonResponse({
+              ok: true,
+              data: {
+                pending_ops: 0,
+                registered_targets: { count: 0, target_ids: [] },
+                skill_sources: { count: 0, dirs: [] },
+                git: { branch: "main", head: "abc1234", status_short: "" },
+                remote: { sync_state: "CLEAN", ahead: 0, behind: 0, configured: true },
+                v3: { available: false },
+              },
+              meta: { warnings: [] },
+            }),
+          );
         case "/api/skills":
           return Promise.resolve(jsonResponse({ skills: ["typed-api-client"] }));
         case "/api/v3/status":

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { CommandItem, PanelPageKey, ProjectionLink, ProjectionMethod, TweakState, VizMode } from "../lib/types";
 import { usePanelData } from "../lib/api/usePanelData";
+import { api } from "../lib/api/client";
 import { BINDINGS, OPS, SKILLS, TARGETS } from "../lib/mock_data";
 import { Sidebar } from "../components/panel/Sidebar";
 import { Topbar } from "../components/panel/Topbar";
@@ -9,10 +10,10 @@ import { OverviewPage } from "./panel/OverviewPage";
 import { SkillsPage } from "./panel/SkillsPage";
 import { TargetsPage } from "./panel/TargetsPage";
 import { BindingsPage } from "./panel/BindingsPage";
+import { HistoryPage } from "./panel/HistoryPage";
 import { OpsPage } from "./panel/OpsPage";
 import { SettingsPage } from "./panel/SettingsPage";
 import { SyncPage } from "./panel/SyncPage";
-import { PlaceholderPage } from "./panel/PlaceholderPage";
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -124,6 +125,7 @@ export function PanelApp() {
   const readOnly = usingMock;
   const onMutation = live.refetch;
   const onNewBinding = () => setPage("bindings");
+  const onViewOps = () => setPage("ops");
 
   const commandItems: CommandItem[] = [
     ...VALID_PAGES.map((pageKey) => ({
@@ -158,7 +160,7 @@ export function PanelApp() {
     },
   ];
 
-  const runCommand = (item: CommandItem) => {
+  const runCommand = async (item: CommandItem) => {
     if (item.kind === "page") {
       setPage(item.label as PanelPageKey);
       return;
@@ -180,7 +182,8 @@ export function PanelApp() {
       return;
     }
     if (item.id === "action:replay") {
-      void live.refetch();
+      await api.syncReplay();
+      live.refetch();
     }
   };
 
@@ -206,6 +209,7 @@ export function PanelApp() {
           workspaceWarnings={live.workspaceWarnings}
           onMutation={onMutation}
           onNewBinding={onNewBinding}
+          onViewOps={onViewOps}
           readOnly={readOnly}
         />
       );
@@ -251,6 +255,9 @@ export function PanelApp() {
         />
       );
       break;
+    case "history":
+      view = <HistoryPage readOnly={readOnly} />;
+      break;
     case "settings":
       view = (
         <SettingsPage
@@ -261,7 +268,7 @@ export function PanelApp() {
       );
       break;
     default:
-      view = <PlaceholderPage page={page} />;
+      view = <SettingsPage info={live.info} workspaceStatus={live.workspaceStatus} workspaceWarnings={live.workspaceWarnings} />;
   }
 
   return (

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import type { PanelPageKey, ProjectionLink, ProjectionMethod, TweakState, VizMode } from "../lib/types";
+import type { CommandItem, PanelPageKey, ProjectionLink, ProjectionMethod, TweakState, VizMode } from "../lib/types";
 import { usePanelData } from "../lib/api/usePanelData";
 import { BINDINGS, OPS, SKILLS, TARGETS } from "../lib/mock_data";
 import { Sidebar } from "../components/panel/Sidebar";
@@ -10,6 +10,8 @@ import { SkillsPage } from "./panel/SkillsPage";
 import { TargetsPage } from "./panel/TargetsPage";
 import { BindingsPage } from "./panel/BindingsPage";
 import { OpsPage } from "./panel/OpsPage";
+import { SettingsPage } from "./panel/SettingsPage";
+import { SyncPage } from "./panel/SyncPage";
 import { PlaceholderPage } from "./panel/PlaceholderPage";
 
 const DEFAULT_TWEAKS: TweakState = {
@@ -123,6 +125,65 @@ export function PanelApp() {
   const onMutation = live.refetch;
   const onNewBinding = () => setPage("bindings");
 
+  const commandItems: CommandItem[] = [
+    ...VALID_PAGES.map((pageKey) => ({
+      id: `page:${pageKey}`,
+      label: pageKey,
+      hint: "page",
+      kind: "page" as const,
+    })),
+    ...skills.slice(0, 40).map((skill) => ({
+      id: `skill:${skill.id}`,
+      label: skill.name,
+      hint: `latest ${skill.latestRev}`,
+      kind: "skill" as const,
+    })),
+    ...targets.slice(0, 40).map((target) => ({
+      id: `target:${target.id}`,
+      label: `${target.agent}/${target.profile}`,
+      hint: target.path,
+      kind: "target" as const,
+    })),
+    ...bindings.slice(0, 40).map((binding) => ({
+      id: `binding:${binding.id}`,
+      label: binding.id,
+      hint: `${binding.skill} → ${binding.target}`,
+      kind: "binding" as const,
+    })),
+    {
+      id: "action:replay",
+      label: "Replay pending ops",
+      hint: "sync replay",
+      kind: "action" as const,
+    },
+  ];
+
+  const runCommand = (item: CommandItem) => {
+    if (item.kind === "page") {
+      setPage(item.label as PanelPageKey);
+      return;
+    }
+    if (item.kind === "skill") {
+      setPage("skills");
+      const skill = skills.find((candidate) => candidate.name === item.label);
+      if (skill) setSelectedSkill(skill.id);
+      return;
+    }
+    if (item.kind === "target") {
+      setPage("targets");
+      const target = targets.find((candidate) => `${candidate.agent}/${candidate.profile}` === item.label);
+      if (target) setSelectedTarget(target.id);
+      return;
+    }
+    if (item.kind === "binding") {
+      setPage("bindings");
+      return;
+    }
+    if (item.id === "action:replay") {
+      void live.refetch();
+    }
+  };
+
   let view: React.ReactNode;
   switch (page) {
     case "overview":
@@ -139,6 +200,10 @@ export function PanelApp() {
           onSelectSkill={toggleSkill}
           onSelectTarget={toggleTarget}
           registryRoot={live.registryRoot}
+          workspaceStatus={live.workspaceStatus}
+          git={live.git}
+          remote={live.remote}
+          workspaceWarnings={live.workspaceWarnings}
           onMutation={onMutation}
           onNewBinding={onNewBinding}
           readOnly={readOnly}
@@ -173,7 +238,27 @@ export function PanelApp() {
       view = <BindingsPage bindings={bindings} targets={targets} onMutation={onMutation} readOnly={readOnly} />;
       break;
     case "ops":
-      view = <OpsPage ops={ops} />;
+      view = <OpsPage ops={ops} onMutation={onMutation} readOnly={readOnly} />;
+      break;
+    case "sync":
+      view = (
+        <SyncPage
+          remote={live.remote}
+          workspaceStatus={live.workspaceStatus}
+          workspaceWarnings={live.workspaceWarnings}
+          onMutation={onMutation}
+          readOnly={readOnly}
+        />
+      );
+      break;
+    case "settings":
+      view = (
+        <SettingsPage
+          info={live.info}
+          workspaceStatus={live.workspaceStatus}
+          workspaceWarnings={live.workspaceWarnings}
+        />
+      );
       break;
     default:
       view = <PlaceholderPage page={page} />;
@@ -190,6 +275,8 @@ export function PanelApp() {
         remoteState={live.remote?.sync_state}
         pendingCount={live.pendingCount}
         onReplay={onMutation}
+        commandItems={commandItems}
+        onCommand={runCommand}
         readOnly={readOnly}
       />
       <Sidebar

--- a/panel/src/pages/panel/BindingsPage.tsx
+++ b/panel/src/pages/panel/BindingsPage.tsx
@@ -3,6 +3,8 @@ import type { Binding, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon } from "../../components/icons/nav_icons";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
+import { api } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
 
 interface BindingsPageProps {
   bindings: Binding[];
@@ -13,6 +15,8 @@ interface BindingsPageProps {
 
 export function BindingsPage({ bindings, targets, onMutation, readOnly }: BindingsPageProps) {
   const [addOpen, setAddOpen] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const remove = useMutation();
   return (
     <>
       <div className="page-header">
@@ -35,6 +39,23 @@ export function BindingsPage({ bindings, targets, onMutation, readOnly }: Bindin
         </div>
       </div>
       <div className="page-body">
+        {(remove.error || remove.success) && (
+          <div
+            style={{
+              marginBottom: 12,
+              padding: "8px 12px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              border: "1px solid",
+              borderColor: remove.error ? "rgba(216,90,90,0.28)" : "rgba(111,183,138,0.28)",
+              color: remove.error ? "var(--err)" : "var(--ok)",
+              background: remove.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
+              borderRadius: 10,
+            }}
+          >
+            {remove.error ?? `✓ ${remove.success}`}
+          </div>
+        )}
         {addOpen && (
           <BindingAddForm
             targets={targets}
@@ -62,6 +83,7 @@ export function BindingsPage({ bindings, targets, onMutation, readOnly }: Bindin
               <th>Matcher</th>
               <th>Method</th>
               <th>Policy</th>
+              <th />
             </tr>
           </thead>
           <tbody>
@@ -92,6 +114,38 @@ export function BindingsPage({ bindings, targets, onMutation, readOnly }: Bindin
                     >
                       {b.policy}
                     </span>
+                  </td>
+                  <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
+                    {confirmingId === b.id ? (
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                        <span style={{ fontSize: 11, color: "var(--ink-2)" }}>remove?</span>
+                        <button className="btn sm" onClick={() => setConfirmingId(null)} disabled={remove.busy}>
+                          Cancel
+                        </button>
+                        <button
+                          className="btn sm"
+                          style={{ color: "var(--err)", borderColor: "rgba(216,90,90,0.3)" }}
+                          disabled={remove.busy || readOnly}
+                          onClick={() =>
+                            remove.run(`remove ${b.id}`, () => api.bindingRemove(b.id), () => {
+                              setConfirmingId(null);
+                              onMutation();
+                            })
+                          }
+                        >
+                          {remove.busy ? "removing…" : "Remove"}
+                        </button>
+                      </span>
+                    ) : (
+                      <button
+                        className="btn sm"
+                        disabled={readOnly}
+                        onClick={() => setConfirmingId(b.id)}
+                        title={readOnly ? "registry offline" : undefined}
+                      >
+                        Remove
+                      </button>
+                    )}
                   </td>
                 </tr>
               );

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+import type { HistoryEntryPayload } from "../../types";
+import { api } from "../../lib/api/client";
+
+interface HistoryPageProps {
+  readOnly: boolean;
+}
+
+interface DiagnoseSummary {
+  ahead?: number;
+  behind?: number;
+  local_segments?: number;
+  local_archives?: number;
+  remote_segments?: number;
+  remote_archives?: number;
+  conflicts?: Array<{ path?: string; scope?: string }>;
+}
+
+function relativeTime(iso?: string | null) {
+  if (!iso) return "—";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return iso;
+  const ms = Date.now() - then;
+  if (ms < 0) return "now";
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+
+export function HistoryPage({ readOnly }: HistoryPageProps) {
+  const [entries, setEntries] = useState<HistoryEntryPayload[]>([]);
+  const [diagnose, setDiagnose] = useState<DiagnoseSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+    Promise.all([api.opsHistoryList(ctrl.signal), api.opsHistoryDiagnose(ctrl.signal)])
+      .then(([historyList, diagnoseEnvelope]) => {
+        setEntries(historyList.data?.entries ?? []);
+        setDiagnose((diagnoseEnvelope.data ?? {}) as DiagnoseSummary);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (err.name !== "AbortError") {
+          setError(err.message);
+          setLoading(false);
+        }
+      });
+    return () => ctrl.abort();
+  }, []);
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Ops history</h1>
+          <div className="subtitle">
+            Read-only view of the local <span className="mono">loom-history</span> branch: retained segments, archives, and current divergence state.
+          </div>
+        </div>
+      </div>
+      <div className="page-body">
+        {loading && <div className="empty" style={{ padding: "40px 20px" }}>Loading history…</div>}
+        {error && (
+          <div
+            style={{
+              padding: "10px 12px",
+              borderRadius: 10,
+              border: "1px solid rgba(216,90,90,0.25)",
+              background: "rgba(216,90,90,0.08)",
+              color: "var(--err)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+            }}
+          >
+            {error}
+          </div>
+        )}
+        {!loading && !error && (
+          <>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 16 }}>
+              <Metric label="entries" value={`${entries.length}`} meta="archives + active segments in local history branch" />
+              <Metric
+                label="ahead / behind"
+                value={`${diagnose?.ahead ?? 0} / ${diagnose?.behind ?? 0}`}
+                meta="relative to origin/loom-history"
+              />
+              <Metric
+                label="segments / archives"
+                value={`${diagnose?.local_segments ?? 0} / ${diagnose?.local_archives ?? 0}`}
+                meta="local retained history units"
+              />
+              <Metric
+                label="conflicts"
+                value={`${diagnose?.conflicts?.length ?? 0}`}
+                meta={readOnly ? "read-only UI mode" : "repair from Ops or Sync pages"}
+              />
+            </div>
+
+            <div className="card">
+              <div className="card-head">
+                <h3>History Entries</h3>
+                <span className={`badge ${(diagnose?.conflicts?.length ?? 0) === 0 ? "ok" : ""}`}>
+                  {(diagnose?.conflicts?.length ?? 0) === 0 ? "clean" : "attention"}
+                </span>
+              </div>
+              <table className="tbl">
+                <thead>
+                  <tr>
+                    <th>Scope</th>
+                    <th>Path</th>
+                    <th>Blob</th>
+                    <th>Lines</th>
+                    <th>First seen</th>
+                    <th>Last seen</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => (
+                    <tr key={`${entry.scope}:${entry.path}`}>
+                      <td><span className="chip">{entry.scope ?? "—"}</span></td>
+                      <td className="mono">{entry.path ?? "—"}</td>
+                      <td className="mono">{entry.blob ?? "—"}</td>
+                      <td>{entry.line_count ?? 0}</td>
+                      <td>{relativeTime(entry.first_at)}</td>
+                      <td>{relativeTime(entry.last_at)}</td>
+                    </tr>
+                  ))}
+                  {entries.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="empty" style={{ padding: "28px 16px" }}>
+                        No local loom-history entries yet.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function Metric({ label, value, meta }: { label: string; value: string; meta: string }) {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div style={labelStyle}>{label}</div>
+        <div style={{ fontFamily: "var(--font-display)", fontSize: 24 }}>{value}</div>
+        <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>{meta}</div>
+      </div>
+    </div>
+  );
+}
+
+const labelStyle = {
+  fontSize: 10.5,
+  color: "var(--ink-3)",
+  letterSpacing: "0.1em",
+  textTransform: "uppercase" as const,
+  fontWeight: 500,
+};

--- a/panel/src/pages/panel/OpsPage.tsx
+++ b/panel/src/pages/panel/OpsPage.tsx
@@ -1,14 +1,72 @@
-import { useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useMemo, useState } from "react";
 import type { Op, OpStatus } from "../../lib/types";
 import { OpRow } from "../../components/panel/OpRow";
 import { RefreshIcon } from "../../components/icons/nav_icons";
+import { api } from "../../lib/api/client";
 
 const SPARK = [3, 5, 2, 6, 4, 7, 9, 5, 8, 6, 4, 3, 5, 7, 11, 6, 4, 5, 8, 9, 6, 4, 3, 5];
 type FilterKey = "all" | OpStatus;
+type RepairStrategy = "local" | "remote";
 
-export function OpsPage({ ops }: { ops: Op[] }) {
+interface OpsPageProps {
+  ops: Op[];
+  onMutation: () => void;
+  readOnly: boolean;
+}
+
+interface HistoryConflict {
+  scope?: string;
+  path?: string;
+  local_blob?: string;
+  remote_blob?: string;
+  local_rename_path?: string;
+  remote_rename_path?: string;
+}
+
+interface HistoryDiagnoseResult {
+  local_branch?: boolean;
+  remote_tracking?: boolean;
+  ahead?: number;
+  behind?: number;
+  local_segments?: number;
+  local_archives?: number;
+  remote_segments?: number;
+  remote_archives?: number;
+  local_snapshot?: boolean;
+  remote_snapshot?: boolean;
+  compact_after_segments?: number;
+  retain_recent_segments?: number;
+  retain_archives?: number;
+  conflicts?: HistoryConflict[];
+}
+
+interface ActionState {
+  busy: string | null;
+  error: string | null;
+  success: string | null;
+}
+
+const INITIAL_ACTION_STATE: ActionState = {
+  busy: null,
+  error: null,
+  success: null,
+};
+
+function uniqueSorted(values: string[]) {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
   const [filter, setFilter] = useState<FilterKey>("all");
-  const filtered = filter === "all" ? ops : ops.filter((o) => o.status === filter);
+  const [skillFilter, setSkillFilter] = useState("all");
+  const [targetFilter, setTargetFilter] = useState("all");
+  const [kindFilter, setKindFilter] = useState("all");
+  const [selectedId, setSelectedId] = useState<string | null>(ops[0]?.id ?? null);
+  const [diagnose, setDiagnose] = useState<HistoryDiagnoseResult | null>(null);
+  const [repairStrategy, setRepairStrategy] = useState<RepairStrategy>("local");
+  const [action, setAction] = useState<ActionState>(INITIAL_ACTION_STATE);
+
   const counts = {
     all: ops.length,
     pending: ops.filter((o) => o.status === "pending").length,
@@ -16,67 +74,137 @@ export function OpsPage({ ops }: { ops: Op[] }) {
     err: ops.filter((o) => o.status === "err").length,
   };
 
+  const skillOptions = useMemo(() => uniqueSorted(ops.map((o) => o.skill)), [ops]);
+  const targetOptions = useMemo(
+    () => uniqueSorted(ops.filter((o) => o.target !== "—").map((o) => o.target)),
+    [ops],
+  );
+  const kindOptions = useMemo(() => uniqueSorted(ops.map((o) => o.kind)), [ops]);
+
+  const filtered = useMemo(() => {
+    return ops.filter((o) => {
+      if (filter !== "all" && o.status !== filter) return false;
+      if (skillFilter !== "all" && o.skill !== skillFilter) return false;
+      if (targetFilter !== "all" && o.target !== targetFilter) return false;
+      if (kindFilter !== "all" && o.kind !== kindFilter) return false;
+      return true;
+    });
+  }, [filter, kindFilter, ops, skillFilter, targetFilter]);
+
+  const selected = filtered.find((o) => o.id === selectedId) ?? filtered[0] ?? null;
+
+  async function runAction(label: string, fn: () => Promise<unknown>, refresh = true) {
+    setAction({ busy: label, error: null, success: null });
+    try {
+      await fn();
+      setAction({ busy: null, error: null, success: label });
+      if (refresh) onMutation();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setAction({ busy: null, error: `${label}: ${message}`, success: null });
+    }
+  }
+
+  const diagnoseHistory = async () => {
+    setAction({ busy: "diagnose history", error: null, success: null });
+    try {
+      const res = await api.opsHistoryDiagnose();
+      setDiagnose((res.data ?? {}) as HistoryDiagnoseResult);
+      setAction({ busy: null, error: null, success: "diagnose history" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setAction({ busy: null, error: `diagnose history: ${message}`, success: null });
+    }
+  };
+
   return (
     <>
       <div className="page-header">
         <div className="title-block">
           <h1>Ops</h1>
-          <div className="subtitle">Every state change is an op. Retry the pending, repair the failed, diagnose the rest.</div>
+          <div className="subtitle">Every state change is an op. Retry pending work, purge queue residue, and repair history divergence from one surface.</div>
         </div>
-        <div className="header-actions">
-          <button className="btn ghost">
+        <div className="header-actions" style={{ flexWrap: "wrap" }}>
+          <button
+            className="btn ghost"
+            disabled={readOnly || action.busy !== null}
+            onClick={() => runAction("retry failed", api.opsRetry)}
+            title={readOnly ? "registry offline" : undefined}
+          >
             <RefreshIcon /> Retry failed
           </button>
-          <button className="btn ghost">Purge completed</button>
+          <button
+            className="btn ghost"
+            disabled={readOnly || action.busy !== null}
+            onClick={() => runAction("purge completed", api.opsPurge)}
+            title={readOnly ? "registry offline" : undefined}
+          >
+            Purge completed
+          </button>
+          <button className="btn ghost" disabled={action.busy !== null} onClick={diagnoseHistory}>
+            Diagnose history
+          </button>
+          <select
+            value={repairStrategy}
+            onChange={(e) => setRepairStrategy(e.target.value as RepairStrategy)}
+            style={miniSelectStyle}
+          >
+            <option value="local">repair: keep local</option>
+            <option value="remote">repair: keep remote</option>
+          </select>
+          <button
+            className="btn primary"
+            disabled={readOnly || action.busy !== null}
+            onClick={() => runAction("repair history", () => api.opsHistoryRepair({ strategy: repairStrategy }))}
+            title={readOnly ? "registry offline" : undefined}
+          >
+            Repair history
+          </button>
         </div>
       </div>
+      {(action.error || action.success || action.busy) && (
+        <div
+          style={{
+            padding: "6px 28px",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            borderBottom: "1px solid var(--line)",
+            color: action.error ? "var(--err)" : action.busy ? "var(--ink-2)" : "var(--ok)",
+            background: action.error
+              ? "rgba(216,90,90,0.08)"
+              : action.busy
+              ? "var(--bg-2)"
+              : "rgba(111,183,138,0.08)",
+          }}
+        >
+          {action.busy ? `${action.busy}…` : action.error ?? `✓ ${action.success}`}
+        </div>
+      )}
       <div className="page-body">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 18 }}>
-          <div className="card">
-            <div className="card-body">
-              <div style={section_label}>Last 24h</div>
-              <div style={{ fontFamily: "var(--font-display)", fontSize: 24 }}>47 ops</div>
-              <div className="spark" style={{ marginTop: 10 }}>
-                {SPARK.map((v, i) => (
-                  <div key={i} className={`bar ${v > 7 ? "hi" : ""}`} style={{ height: `${v * 2.4}px` }} />
-                ))}
-              </div>
+          <MetricCard label="Last 24h" value={`${ops.length} ops`} sub="Panel-visible queue + projection events">
+            <div className="spark" style={{ marginTop: 10 }}>
+              {SPARK.map((v, i) => (
+                <div key={i} className={`bar ${v > 7 ? "hi" : ""}`} style={{ height: `${v * 2.4}px` }} />
+              ))}
             </div>
-          </div>
-          <div className="card">
-            <div className="card-body">
-              <div style={section_label}>Success rate</div>
-              <div style={{ fontFamily: "var(--font-display)", fontSize: 24, color: "var(--ok)" }}>96.2%</div>
-              <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>
-                45 / 47 clean · 1 failed · 1 pending
-              </div>
-            </div>
-          </div>
-          <div className="card">
-            <div className="card-body">
-              <div style={section_label}>Pending</div>
-              <div style={{ fontFamily: "var(--font-display)", fontSize: 24, color: "var(--pending)" }}>
-                {counts.pending}
-              </div>
-              <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>
-                project refactor-patterns → claude/work
-              </div>
-            </div>
-          </div>
+          </MetricCard>
+          <MetricCard
+            label="Success rate"
+            value={`${ops.length === 0 ? 100 : Math.round((counts.ok / Math.max(ops.length, 1)) * 1000) / 10}%`}
+            accent="var(--ok)"
+            sub={`${counts.ok} clean · ${counts.err} failed · ${counts.pending} pending`}
+          />
+          <MetricCard label="Pending" value={`${counts.pending}`} accent="var(--pending)" sub="retry or replay unresolved work from here" />
         </div>
 
-        <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
+        <div style={{ display: "flex", gap: 4, marginBottom: 12, flexWrap: "wrap" }}>
           {(["all", "pending", "ok", "err"] as FilterKey[]).map((k) => (
             <button
               key={k}
               className="btn sm"
               onClick={() => setFilter(k)}
-              style={{
-                background: filter === k ? "var(--bg-2)" : "transparent",
-                borderColor: filter === k ? "var(--line-hi)" : "transparent",
-                border: "1px solid",
-                color: filter === k ? "var(--ink-0)" : "var(--ink-2)",
-              }}
+              style={filterButtonStyle(filter === k)}
             >
               {k === "err" ? "failed" : k}{" "}
               <span className="mono" style={{ color: "var(--ink-3)", marginLeft: 4 }}>
@@ -86,21 +214,222 @@ export function OpsPage({ ops }: { ops: Op[] }) {
           ))}
         </div>
 
-        <div>
-          {filtered.map((o) => (
-            <OpRow key={o.id} op={o} />
-          ))}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8, marginBottom: 14 }}>
+          <FilterSelect label="skill" value={skillFilter} onChange={setSkillFilter} options={skillOptions} />
+          <FilterSelect label="target" value={targetFilter} onChange={setTargetFilter} options={targetOptions} />
+          <FilterSelect label="kind" value={kindFilter} onChange={setKindFilter} options={kindOptions} />
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1.4fr) minmax(320px, 0.9fr)", gap: 16 }}>
+          <div className="card">
+            <div className="card-head">
+              <h3>Visible Ops</h3>
+              <span className="badge">{filtered.length}</span>
+            </div>
+            <div style={{ padding: 8 }}>
+              {filtered.length === 0 ? (
+                <div className="empty" style={{ padding: "28px 16px" }}>No ops match the current filters.</div>
+              ) : (
+                filtered.map((o) => (
+                  <button
+                    key={o.id}
+                    onClick={() => setSelectedId(o.id)}
+                    style={{
+                      display: "block",
+                      width: "100%",
+                      textAlign: "left",
+                      padding: 0,
+                      background: selected?.id === o.id ? "rgba(217,119,54,0.06)" : "transparent",
+                      border: selected?.id === o.id ? "1px solid rgba(217,119,54,0.24)" : "1px solid transparent",
+                      borderRadius: 10,
+                      marginBottom: 6,
+                    }}
+                  >
+                    <OpRow op={o} />
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gap: 16, alignSelf: "start" }}>
+            <div className="card">
+              <div className="card-head">
+                <h3>Op Detail</h3>
+                {selected && <span className={`chip method ${selected.method !== "—" ? selected.method : "symlink"}`}>{selected.status}</span>}
+              </div>
+              <div className="card-body" style={{ fontSize: 12 }}>
+                {selected ? (
+                  <div className="kv" style={{ gridTemplateColumns: "110px 1fr" }}>
+                    <div className="k">id</div>
+                    <div className="v mono">{selected.id}</div>
+                    <div className="k">kind</div>
+                    <div className="v">{selected.kind}</div>
+                    <div className="k">skill</div>
+                    <div className="v">{selected.skill}</div>
+                    <div className="k">target</div>
+                    <div className="v mono">{selected.target}</div>
+                    <div className="k">method</div>
+                    <div className="v">{selected.method}</div>
+                    <div className="k">time</div>
+                    <div className="v">{selected.time}</div>
+                    <div className="k">reason</div>
+                    <div className="v">{selected.reason ?? "—"}</div>
+                  </div>
+                ) : (
+                  <div className="empty" style={{ padding: "24px 12px" }}>Select an op to inspect its detail.</div>
+                )}
+              </div>
+            </div>
+
+            <div className="card">
+              <div className="card-head">
+                <h3>History Diagnose</h3>
+                {diagnose?.conflicts && diagnose.conflicts.length > 0 ? (
+                  <span className="badge" style={{ color: "var(--err)" }}>{diagnose.conflicts.length} conflicts</span>
+                ) : (
+                  <span className="badge ok">clean</span>
+                )}
+              </div>
+              <div className="card-body" style={{ fontSize: 12 }}>
+                {diagnose ? (
+                  <>
+                    <div className="kv" style={{ gridTemplateColumns: "140px 1fr" }}>
+                      <div className="k">ahead / behind</div>
+                      <div className="v mono">{diagnose.ahead ?? 0} / {diagnose.behind ?? 0}</div>
+                      <div className="k">local segments</div>
+                      <div className="v">{diagnose.local_segments ?? 0}</div>
+                      <div className="k">local archives</div>
+                      <div className="v">{diagnose.local_archives ?? 0}</div>
+                      <div className="k">remote segments</div>
+                      <div className="v">{diagnose.remote_segments ?? 0}</div>
+                      <div className="k">remote archives</div>
+                      <div className="v">{diagnose.remote_archives ?? 0}</div>
+                      <div className="k">snapshots</div>
+                      <div className="v">
+                        local {diagnose.local_snapshot ? "yes" : "no"} · remote {diagnose.remote_snapshot ? "yes" : "no"}
+                      </div>
+                    </div>
+                    {diagnose.conflicts && diagnose.conflicts.length > 0 && (
+                      <div style={{ marginTop: 14, display: "grid", gap: 10 }}>
+                        {diagnose.conflicts.slice(0, 5).map((conflict, index) => (
+                          <div key={`${conflict.path ?? "conflict"}-${index}`} style={conflictStyle}>
+                            <div className="mono" style={{ color: "var(--ink-0)", marginBottom: 4 }}>
+                              {conflict.scope}:{conflict.path}
+                            </div>
+                            <div style={{ color: "var(--ink-2)" }}>
+                              local {conflict.local_blob} · remote {conflict.remote_blob}
+                            </div>
+                            <div style={{ color: "var(--ink-3)", marginTop: 4 }}>
+                              rename suggestions:
+                              {" "}
+                              <span className="mono">{conflict.local_rename_path}</span>
+                              {" / "}
+                              <span className="mono">{conflict.remote_rename_path}</span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="empty" style={{ padding: "24px 12px" }}>Run diagnose to inspect loom-history divergence and path conflicts.</div>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </>
   );
 }
 
-const section_label = {
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+}) {
+  return (
+    <label style={{ display: "grid", gap: 6 }}>
+      <span style={sectionLabel}>{label}</span>
+      <select value={value} onChange={(e) => onChange(e.target.value)} style={filterSelectStyle}>
+        <option value="all">all</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  sub,
+  accent,
+  children,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  accent?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div style={sectionLabel}>{label}</div>
+        <div style={{ fontFamily: "var(--font-display)", fontSize: 24, color: accent ?? "var(--ink-0)" }}>{value}</div>
+        <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>{sub}</div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function filterButtonStyle(active: boolean): CSSProperties {
+  return {
+    background: active ? "var(--bg-2)" : "transparent",
+    borderColor: active ? "var(--line-hi)" : "transparent",
+    border: "1px solid",
+    color: active ? "var(--ink-0)" : "var(--ink-2)",
+  };
+}
+
+const sectionLabel = {
   fontSize: 10.5,
   color: "var(--ink-3)",
   letterSpacing: "0.1em",
   textTransform: "uppercase" as const,
   fontWeight: 500,
-  marginBottom: 8,
+};
+
+const filterSelectStyle: CSSProperties = {
+  padding: "7px 10px",
+  borderRadius: 8,
+  border: "1px solid var(--line)",
+  background: "var(--bg-1)",
+  color: "var(--ink-0)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+};
+
+const miniSelectStyle: CSSProperties = {
+  ...filterSelectStyle,
+  width: 160,
+};
+
+const conflictStyle: CSSProperties = {
+  border: "1px solid var(--line)",
+  background: "var(--bg-1)",
+  borderRadius: 10,
+  padding: "10px 12px",
 };

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -1,3 +1,4 @@
+import type { RemotePayload, WorkspaceStatusPayload } from "../../types";
 import type { Op, ProjectionLink, Skill, Target, VizMode } from "../../lib/types";
 import { OpRow } from "../../components/panel/OpRow";
 import { ProjectionGraph } from "../../components/panel/ProjectionGraph";
@@ -17,6 +18,10 @@ interface OverviewPageProps {
   onSelectSkill: (id: string) => void;
   onSelectTarget: (id: string) => void;
   registryRoot: string | null;
+  workspaceStatus: WorkspaceStatusPayload["data"] | null;
+  git: WorkspaceStatusPayload["data"] extends infer T ? (T extends { git?: infer G } ? G | null : null) : null;
+  remote: RemotePayload | null;
+  workspaceWarnings: string[];
   onMutation: () => void;
   onNewBinding: () => void;
   readOnly: boolean;
@@ -34,6 +39,10 @@ export function OverviewPage({
   onSelectSkill,
   onSelectTarget,
   registryRoot,
+  workspaceStatus,
+  git,
+  remote,
+  workspaceWarnings,
   onMutation,
   onNewBinding,
   readOnly,
@@ -46,6 +55,12 @@ export function OverviewPage({
   const rootDisplay = registryRoot
     ? registryRoot.replace(/^\/Users\/[^/]+/, "~")
     : "~/.loom-registry";
+  const branch = git?.branch ?? "—";
+  const headShort = git?.head ? git.head.slice(0, 7) : "—";
+  const worktreeDirty = Boolean(git?.status_short && git.status_short.trim().length > 0);
+  const registeredTargetCount = workspaceStatus?.registered_targets?.count ?? targets.length;
+  const sourceDirCount = workspaceStatus?.skill_sources?.count ?? 0;
+  const remoteState = remote?.sync_state ?? "unknown";
   const sync = useMutation();
 
   return (
@@ -107,9 +122,25 @@ export function OverviewPage({
       )}
       <div className="page-body">
         <div className="kpi-row">
-          <Kpi label="Skills" value={skills.length} meta={<><span className="trend">+2</span> · 52 captures · 38 releases</>} />
-          <Kpi label="Targets" value={targets.length} meta="6 agents · 4 profiles" />
-          <Kpi label="Projections" value={totalProjections} meta="symlink · copy · materialize" />
+          <Kpi
+            label="Skills"
+            value={skills.length}
+            meta={`${sourceDirCount} source ${sourceDirCount === 1 ? "dir" : "dirs"} · ${registeredTargetCount} registered target${registeredTargetCount === 1 ? "" : "s"}`}
+          />
+          <Kpi
+            label="Targets"
+            value={targets.length}
+            meta={
+              registeredTargetCount === targets.length
+                ? "all registered targets loaded"
+                : `${registeredTargetCount} registered · ${targets.length} rendered`
+            }
+          />
+          <Kpi
+            label="Projections"
+            value={totalProjections}
+            meta={`${workspaceStatus?.v3?.available ? "v3 state loaded" : "v3 not initialized"} · ${remoteState.toLowerCase().replace(/_/g, " ")}`}
+          />
           <Kpi
             label="Ops"
             value={pendingOps + errOps}
@@ -211,25 +242,44 @@ export function OverviewPage({
           </div>
           <div className="card">
             <div className="card-head">
-              <h3>Write Guard</h3>
-              <span className="badge ok">active</span>
+              <h3>Registry State</h3>
+              <span className={`badge ${worktreeDirty ? "" : "ok"}`}>{worktreeDirty ? "dirty" : "clean"}</span>
             </div>
             <div className="card-body" style={{ fontSize: 12, color: "var(--ink-1)" }}>
               <div className="row-flex" style={{ marginBottom: 10 }}>
-                <ShieldIcon style={{ color: "var(--ok)" }} />
-                <span>Registry root is independent of Loom tool repo. Mutable ops enabled.</span>
+                <ShieldIcon style={{ color: worktreeDirty ? "var(--warn)" : "var(--ok)" }} />
+                <span>
+                  {workspaceWarnings.length > 0
+                    ? workspaceWarnings[0]
+                    : readOnly
+                    ? "Panel is in read-only fallback mode."
+                    : "Mutable ops enabled for the current registry root."}
+                </span>
               </div>
               <pre className="code" style={{ marginBottom: 10 }}>
                 <span className="c"># Current registry</span>
                 {"\n"}
                 <span className="k">--root</span> <span className="s">{rootDisplay}</span>
                 {"\n"}
-                <span className="c"># Git HEAD</span>
+                <span className="c"># Git branch / HEAD</span>
                 {"\n"}
-                <span className="n">2a3f8c1</span> <span className="s">"release: commit-message-writer v1.2.0"</span>
+                <span className="n">{branch}</span> <span className="s">{headShort}</span>
+                {"\n"}
+                <span className="c"># Remote</span>
+                {"\n"}
+                <span className="n">{remote?.remote ?? "—"}</span> <span className="s">{remote?.url ?? "not configured"}</span>
               </pre>
-              <div style={{ color: "var(--ink-3)", fontSize: 11 }}>
-                Last pull from <span className="mono">origin/main</span> · 6h ago
+              <div style={{ color: "var(--ink-3)", fontSize: 11, display: "grid", gap: 4 }}>
+                <div>
+                  sync state <span className="mono">{remoteState.toLowerCase()}</span>
+                  {typeof remote?.ahead === "number" && typeof remote?.behind === "number" && (
+                    <> · ahead {remote.ahead} / behind {remote.behind}</>
+                  )}
+                </div>
+                <div>
+                  worktree {worktreeDirty ? "has local changes" : "clean"} · pending ops{" "}
+                  <span className="mono">{workspaceStatus?.pending_ops ?? 0}</span>
+                </div>
               </div>
             </div>
           </div>

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -24,6 +24,7 @@ interface OverviewPageProps {
   workspaceWarnings: string[];
   onMutation: () => void;
   onNewBinding: () => void;
+  onViewOps: () => void;
   readOnly: boolean;
 }
 
@@ -45,6 +46,7 @@ export function OverviewPage({
   workspaceWarnings,
   onMutation,
   onNewBinding,
+  onViewOps,
   readOnly,
 }: OverviewPageProps) {
   const selSkill = skills.find((s) => s.id === selectedSkill);
@@ -232,7 +234,7 @@ export function OverviewPage({
           <div className="card">
             <div className="card-head">
               <h3>Recent Ops</h3>
-              <button className="btn sm">View all →</button>
+              <button className="btn sm" onClick={onViewOps}>View all →</button>
             </div>
             <div style={{ padding: 8 }}>
               {ops.slice(0, 5).map((o) => (

--- a/panel/src/pages/panel/SettingsPage.tsx
+++ b/panel/src/pages/panel/SettingsPage.tsx
@@ -1,0 +1,132 @@
+import type { InfoPayload, WorkspaceStatusPayload } from "../../types";
+
+interface SettingsPageProps {
+  info: InfoPayload | null;
+  workspaceStatus: WorkspaceStatusPayload["data"] | null;
+  workspaceWarnings: string[];
+}
+
+function compactHome(path: string | undefined) {
+  if (!path) return "—";
+  return path.replace(/^\/Users\/[^/]+/, "~");
+}
+
+export function SettingsPage({ info, workspaceStatus, workspaceWarnings }: SettingsPageProps) {
+  const v3Available = workspaceStatus?.v3?.available ?? false;
+  const remote = workspaceStatus?.remote;
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Settings</h1>
+          <div className="subtitle">
+            Current registry wiring, agent defaults, and backend status exposed from the live workspace.
+          </div>
+        </div>
+      </div>
+      <div className="page-body">
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+          <div className="card">
+            <div className="card-head">
+              <h3>Workspace</h3>
+              <span className={`badge ${v3Available ? "ok" : ""}`}>{v3Available ? "v3 ready" : "v3 missing"}</span>
+            </div>
+            <div className="card-body">
+              <div className="kv" style={{ gridTemplateColumns: "140px 1fr" }}>
+                <div className="k">registry root</div>
+                <div className="v mono">{compactHome(info?.root)}</div>
+                <div className="k">state dir</div>
+                <div className="v mono">{compactHome(info?.state_dir)}</div>
+                <div className="k">backup dir</div>
+                <div className="v mono">{compactHome(workspaceStatus?.backup_dir)}</div>
+                <div className="k">v3 targets file</div>
+                <div className="v mono">{compactHome(info?.v3_targets_file)}</div>
+                <div className="k">registered targets</div>
+                <div className="v">{workspaceStatus?.registered_targets?.count ?? 0}</div>
+                <div className="k">source dirs</div>
+                <div className="v">{workspaceStatus?.skill_sources?.count ?? 0}</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-head">
+              <h3>Agent Defaults</h3>
+            </div>
+            <div className="card-body">
+              <div className="kv" style={{ gridTemplateColumns: "140px 1fr" }}>
+                <div className="k">Claude</div>
+                <div className="v mono">{compactHome(info?.claude_dir ?? workspaceStatus?.agent_dir_defaults?.claude_dir)}</div>
+                <div className="k">Codex</div>
+                <div className="v mono">{compactHome(info?.codex_dir ?? workspaceStatus?.agent_dir_defaults?.codex_dir)}</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-head">
+              <h3>Git</h3>
+            </div>
+            <div className="card-body">
+              <div className="kv" style={{ gridTemplateColumns: "140px 1fr" }}>
+                <div className="k">branch</div>
+                <div className="v">{workspaceStatus?.git?.branch ?? "—"}</div>
+                <div className="k">head</div>
+                <div className="v mono">{workspaceStatus?.git?.head ?? "—"}</div>
+                <div className="k">status</div>
+                <div className="v mono">{workspaceStatus?.git?.status_short?.trim() || "clean"}</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-head">
+              <h3>Remote</h3>
+            </div>
+            <div className="card-body">
+              <div className="kv" style={{ gridTemplateColumns: "140px 1fr" }}>
+                <div className="k">remote</div>
+                <div className="v">{remote?.remote ?? "—"}</div>
+                <div className="k">url</div>
+                <div className="v mono">{remote?.url ?? info?.remote_url ?? "not configured"}</div>
+                <div className="k">sync state</div>
+                <div className="v">{remote?.sync_state ?? "unknown"}</div>
+                <div className="k">ahead / behind</div>
+                <div className="v">{remote ? `${remote.ahead ?? 0} / ${remote.behind ?? 0}` : "0 / 0"}</div>
+                <div className="k">pending ops</div>
+                <div className="v">{workspaceStatus?.pending_ops ?? remote?.pending_ops ?? 0}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {workspaceWarnings.length > 0 && (
+          <div className="card" style={{ marginTop: 16 }}>
+            <div className="card-head">
+              <h3>Warnings</h3>
+            </div>
+            <div className="card-body" style={{ display: "grid", gap: 8 }}>
+              {workspaceWarnings.map((warning, index) => (
+                <div
+                  key={`${warning}-${index}`}
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: 10,
+                    border: "1px solid rgba(216,90,90,0.25)",
+                    background: "rgba(216,90,90,0.08)",
+                    color: "var(--err)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                  }}
+                >
+                  {warning}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -108,37 +108,6 @@ export function SkillsPage({ skills, targets, selectedSkill, onSelectSkill, onMu
 
 type DetailTab = "history" | "diff" | "targets";
 
-interface LifecycleEvent {
-  kind: "release" | "capture" | "save" | "snapshot" | "project";
-  v: string;
-  time: string;
-  who: string;
-  desc: string;
-}
-
-const KIND_COLOR: Record<LifecycleEvent["kind"], string> = {
-  release: "var(--accent)",
-  capture: "var(--pending)",
-  save: "var(--ink-2)",
-  snapshot: "var(--warn)",
-  project: "var(--ok)",
-};
-
-// Lifecycle is illustrative filler — the registry does not yet surface
-// per-skill timelines via the panel API. The most recent entry anchors
-// to the skill's actual latest revision so users see a real hash rather
-// than a fabricated version tag.
-function lifecycleFor(skill: Skill): LifecycleEvent[] {
-  return [
-    { kind: "release", v: "v0.4", time: "4 days ago", who: "you", desc: "released after 3 captures" },
-    { kind: "capture", v: "#c7", time: "2 days ago", who: "you", desc: "precondition relaxed, added harness pairing" },
-    { kind: "save", v: "—", time: "2 days ago", who: "you", desc: "saved working tree" },
-    { kind: "snapshot", v: "sn-8f1", time: "2 days ago", who: "auto", desc: "pre-projection snapshot" },
-    { kind: "project", v: "—", time: "2 days ago", who: "auto", desc: "projected → claude/work, codex/home" },
-    { kind: "project", v: skill.latestRev, time: "6h ago", who: "auto", desc: "latest applied revision" },
-  ];
-}
-
 function SkillDetail({ skill, targets }: { skill: Skill; targets: Target[] }) {
   const [tab, setTab] = useState<DetailTab>("history");
   const targetObjs = skill.targets
@@ -162,7 +131,7 @@ function SkillDetail({ skill, targets }: { skill: Skill; targets: Target[] }) {
 
       <div className="tabs">
         <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")}>
-          Lifecycle
+          Summary
         </button>
         <button className={tab === "diff" ? "active" : ""} onClick={() => setTab("diff")}>
           Diff
@@ -172,43 +141,36 @@ function SkillDetail({ skill, targets }: { skill: Skill; targets: Target[] }) {
         </button>
       </div>
 
-      {tab === "history" && <Lifecycle events={lifecycleFor(skill)} />}
+      {tab === "history" && <SkillSummary skill={skill} targetCount={targetObjs.length} />}
       {tab === "diff" && <SkillDiff skillName={skill.name} />}
       {tab === "targets" && <TargetsTab targets={targetObjs} />}
     </div>
   );
 }
 
-function Lifecycle({ events }: { events: LifecycleEvent[] }) {
+function SkillSummary({ skill, targetCount }: { skill: Skill; targetCount: number }) {
   return (
-    <div style={{ position: "relative", paddingLeft: 22 }}>
-      <div style={{ position: "absolute", left: 7, top: 4, bottom: 4, width: 1, background: "var(--line)" }} />
-      {events.map((e, i) => (
-        <div key={i} style={{ position: "relative", marginBottom: 14 }}>
-          <div
-            style={{
-              position: "absolute",
-              left: -22,
-              top: 4,
-              width: 15,
-              height: 15,
-              borderRadius: 8,
-              background: "var(--bg-0)",
-              border: `2px solid ${KIND_COLOR[e.kind]}`,
-            }}
-          />
-          <div style={{ fontSize: 12 }}>
-            <span style={{ color: "var(--ink-0)", fontWeight: 500 }}>{e.kind}</span>
-            <span className="mono" style={{ color: "var(--ink-2)", marginLeft: 6 }}>
-              {e.v}
-            </span>
-            <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
-              by {e.who} · {e.time}
-            </span>
-          </div>
-          <div style={{ fontSize: 11.5, color: "var(--ink-2)", marginTop: 2 }}>{e.desc}</div>
+    <div style={{ display: "grid", gap: 12 }}>
+      <div style={{ border: "1px solid var(--line)", borderRadius: 10, padding: "12px 14px", background: "var(--bg-1)" }}>
+        <div style={{ fontSize: 11, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--ink-3)", marginBottom: 6 }}>
+          Current state
         </div>
-      ))}
+        <div style={{ color: "var(--ink-1)", fontSize: 12.5 }}>
+          This view is backed by the current projection snapshot. It shows the latest applied revision, target coverage, and rule count without inventing lifecycle events the backend does not expose yet.
+        </div>
+      </div>
+      <div className="kv" style={{ gridTemplateColumns: "130px 1fr" }}>
+        <div className="k">latest revision</div>
+        <div className="v mono">{skill.latestRev}</div>
+        <div className="k">last changed</div>
+        <div className="v">{skill.changed}</div>
+        <div className="k">rule count</div>
+        <div className="v">{skill.ruleCount}</div>
+        <div className="k">projected targets</div>
+        <div className="v">{targetCount}</div>
+        <div className="k">classification</div>
+        <div className="v">{skill.tag}</div>
+      </div>
     </div>
   );
 }

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -1,0 +1,182 @@
+import type { RemotePayload, WorkspaceStatusPayload } from "../../types";
+import { RefreshIcon, SyncIcon } from "../../components/icons/nav_icons";
+import { api } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
+
+interface SyncPageProps {
+  remote: RemotePayload | null;
+  workspaceStatus: WorkspaceStatusPayload["data"] | null;
+  workspaceWarnings: string[];
+  onMutation: () => void;
+  readOnly: boolean;
+}
+
+export function SyncPage({
+  remote,
+  workspaceStatus,
+  workspaceWarnings,
+  onMutation,
+  readOnly,
+}: SyncPageProps) {
+  const sync = useMutation();
+  const syncState = (remote?.sync_state ?? "unknown").toLowerCase().replace(/_/g, " ");
+  const ahead = remote?.ahead ?? 0;
+  const behind = remote?.behind ?? 0;
+  const pendingOps = workspaceStatus?.pending_ops ?? remote?.pending_ops ?? 0;
+  const remoteConfigured = Boolean(remote?.configured);
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Git sync</h1>
+          <div className="subtitle">
+            Inspect registry remote state, then push, pull, or replay pending ops without leaving the panel.
+          </div>
+        </div>
+        <div className="header-actions">
+          <button
+            className="btn ghost"
+            disabled={readOnly || sync.busy}
+            onClick={() => sync.run("sync pull", api.syncPull, onMutation)}
+            title={readOnly ? "registry offline" : undefined}
+          >
+            <SyncIcon /> Sync pull
+          </button>
+          <button
+            className="btn ghost"
+            disabled={readOnly || sync.busy}
+            onClick={() => sync.run("sync push", api.syncPush, onMutation)}
+            title={readOnly ? "registry offline" : undefined}
+          >
+            <SyncIcon /> Sync push
+          </button>
+          <button
+            className="btn primary"
+            disabled={readOnly || sync.busy}
+            onClick={() => sync.run("sync replay", api.syncReplay, onMutation)}
+            title={readOnly ? "registry offline" : undefined}
+          >
+            <RefreshIcon /> Replay pending
+          </button>
+        </div>
+      </div>
+      {(sync.error || sync.success || sync.busy) && (
+        <div
+          style={{
+            padding: "6px 28px",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            borderBottom: "1px solid var(--line)",
+            color: sync.error ? "var(--err)" : sync.busy ? "var(--ink-2)" : "var(--ok)",
+            background: sync.error
+              ? "rgba(216,90,90,0.08)"
+              : sync.busy
+              ? "var(--bg-2)"
+              : "rgba(111,183,138,0.08)",
+          }}
+        >
+          {sync.busy ? "…" : sync.error ?? `✓ ${sync.success}`}
+        </div>
+      )}
+      <div className="page-body">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 16 }}>
+          <Metric label="Sync state" value={syncState} meta={remoteConfigured ? "remote configured" : "no remote configured"} />
+          <Metric label="Ahead / behind" value={`${ahead} / ${behind}`} meta="local branch relative to remote tracking ref" />
+          <Metric label="Pending ops" value={`${pendingOps}`} meta="queued work that may require replay after pull" />
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1.15fr 0.85fr", gap: 16 }}>
+          <div className="card">
+            <div className="card-head">
+              <h3>Remote Summary</h3>
+              <span className={`badge ${syncState === "clean" ? "ok" : ""}`}>{syncState}</span>
+            </div>
+            <div className="card-body">
+              <div className="kv" style={{ gridTemplateColumns: "140px 1fr" }}>
+                <div className="k">remote</div>
+                <div className="v">{remote?.remote ?? "—"}</div>
+                <div className="k">url</div>
+                <div className="v mono">{remote?.url ?? "not configured"}</div>
+                <div className="k">tracking ref</div>
+                <div className="v">{remote?.tracking_ref ? "present" : "missing"}</div>
+                <div className="k">registered targets</div>
+                <div className="v">{workspaceStatus?.registered_targets?.count ?? 0}</div>
+                <div className="k">source dirs</div>
+                <div className="v">{workspaceStatus?.skill_sources?.count ?? 0}</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-head">
+              <h3>Operator Notes</h3>
+            </div>
+            <div className="card-body" style={{ display: "grid", gap: 10, fontSize: 12 }}>
+              <InfoBlock
+                title="Push"
+                body="Publish your local registry history and current branch to the configured remote."
+              />
+              <InfoBlock
+                title="Pull"
+                body="Fetch remote updates, rebase local state, then replay pending ops if needed."
+              />
+              <InfoBlock
+                title="Replay"
+                body="Re-attempt pending operations without changing the remote state."
+              />
+              {workspaceWarnings.length > 0 && (
+                <div style={warningStyle}>
+                  {workspaceWarnings.map((warning, index) => (
+                    <div key={`${warning}-${index}`}>{warning}</div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Metric({ label, value, meta }: { label: string; value: string; meta: string }) {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div style={labelStyle}>{label}</div>
+        <div style={{ fontFamily: "var(--font-display)", fontSize: 24, color: "var(--ink-0)" }}>{value}</div>
+        <div style={{ fontSize: 11, color: "var(--ink-2)", marginTop: 10 }}>{meta}</div>
+      </div>
+    </div>
+  );
+}
+
+function InfoBlock({ title, body }: { title: string; body: string }) {
+  return (
+    <div style={{ border: "1px solid var(--line)", borderRadius: 10, padding: "10px 12px", background: "var(--bg-1)" }}>
+      <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 4 }}>
+        {title}
+      </div>
+      <div style={{ color: "var(--ink-1)" }}>{body}</div>
+    </div>
+  );
+}
+
+const labelStyle = {
+  fontSize: 10.5,
+  color: "var(--ink-3)",
+  letterSpacing: "0.1em",
+  textTransform: "uppercase" as const,
+  fontWeight: 500,
+};
+
+const warningStyle = {
+  padding: "10px 12px",
+  borderRadius: 10,
+  border: "1px solid rgba(216,90,90,0.25)",
+  background: "rgba(216,90,90,0.08)",
+  color: "var(--err)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+};

--- a/panel/src/pages/panel/TargetsPage.tsx
+++ b/panel/src/pages/panel/TargetsPage.tsx
@@ -3,6 +3,8 @@ import type { Skill, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon } from "../../components/icons/nav_icons";
 import { TargetAddForm } from "../../components/panel/forms/TargetAddForm";
+import { api } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
 
 interface TargetsPageProps {
   targets: Target[];
@@ -15,6 +17,8 @@ interface TargetsPageProps {
 
 export function TargetsPage({ targets, skills, selectedTarget, onSelectTarget, onMutation, readOnly }: TargetsPageProps) {
   const [addOpen, setAddOpen] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const remove = useMutation();
   return (
     <>
       <div className="page-header">
@@ -37,6 +41,23 @@ export function TargetsPage({ targets, skills, selectedTarget, onSelectTarget, o
         </div>
       </div>
       <div className="page-body">
+        {(remove.error || remove.success) && (
+          <div
+            style={{
+              marginBottom: 12,
+              padding: "8px 12px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              border: "1px solid",
+              borderColor: remove.error ? "rgba(216,90,90,0.28)" : "rgba(111,183,138,0.28)",
+              color: remove.error ? "var(--err)" : "var(--ok)",
+              background: remove.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
+              borderRadius: 10,
+            }}
+          >
+            {remove.error ?? `✓ ${remove.success}`}
+          </div>
+        )}
         {addOpen && (
           <TargetAddForm
             onCancel={() => setAddOpen(false)}
@@ -91,6 +112,53 @@ export function TargetsPage({ targets, skills, selectedTarget, onSelectTarget, o
                     <b style={{ color: "var(--ink-0)" }}>{inbound}</b> inbound bindings
                   </span>
                   <span style={{ marginLeft: "auto", color: "var(--ink-3)" }}>synced {t.lastSync}</span>
+                </div>
+                <div
+                  style={{
+                    padding: "10px 16px",
+                    borderTop: "1px solid var(--line-soft)",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    gap: 10,
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <span style={{ fontSize: 11, color: "var(--ink-3)" }} className="mono">
+                    {t.id}
+                  </span>
+                  {confirmingId === t.id ? (
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ fontSize: 11, color: "var(--ink-2)" }}>
+                        remove this target?
+                      </span>
+                      <button className="btn sm" onClick={() => setConfirmingId(null)} disabled={remove.busy}>
+                        Cancel
+                      </button>
+                      <button
+                        className="btn sm"
+                        style={{ color: "var(--err)", borderColor: "rgba(216,90,90,0.3)" }}
+                        disabled={remove.busy || readOnly}
+                        onClick={() =>
+                          remove.run(`remove ${t.id}`, () => api.targetRemove(t.id), () => {
+                            setConfirmingId(null);
+                            onMutation();
+                          })
+                        }
+                      >
+                        {remove.busy ? "removing…" : "Remove"}
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      className="btn sm"
+                      disabled={readOnly}
+                      onClick={() => setConfirmingId(t.id)}
+                      title={readOnly ? "registry offline" : undefined}
+                    >
+                      Remove
+                    </button>
+                  )}
                 </div>
               </div>
             );

--- a/panel/src/types.ts
+++ b/panel/src/types.ts
@@ -28,6 +28,50 @@ export type HealthPayload = {
   service?: string;
 };
 
+export type WorkspaceStatusPayload = {
+  ok: boolean;
+  data?: {
+    state_model?: string;
+    skills?: string[];
+    backup_skills?: string[];
+    skill_sources?: {
+      dirs?: string[];
+      count?: number;
+    };
+    backup_dir?: string;
+    git?: {
+      head?: string;
+      branch?: string;
+      status_short?: string;
+    };
+    agent_dir_defaults?: {
+      claude_dir?: string;
+      codex_dir?: string;
+    };
+    registered_targets?: {
+      count?: number;
+      target_ids?: string[];
+    };
+    remote?: RemotePayload;
+    pending_ops?: number;
+    v3?: {
+      available?: boolean;
+      error?: {
+        code?: string;
+        message?: string;
+      };
+    };
+  };
+  meta?: {
+    warnings?: string[];
+    sync_state?: string;
+  };
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
 export type InfoPayload = {
   root?: string;
   state_dir?: string;

--- a/panel/src/types.ts
+++ b/panel/src/types.ts
@@ -72,6 +72,27 @@ export type WorkspaceStatusPayload = {
   };
 };
 
+export type HistoryEntryPayload = {
+  scope?: string;
+  path?: string;
+  blob?: string;
+  line_count?: number;
+  first_at?: string | null;
+  last_at?: string | null;
+};
+
+export type HistoryListPayload = {
+  ok: boolean;
+  data?: {
+    count?: number;
+    entries?: HistoryEntryPayload[];
+  };
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
 export type InfoPayload = {
   root?: string;
   state_dir?: string;

--- a/src/gitops/history.rs
+++ b/src/gitops/history.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 use crate::state::AppContext;
@@ -9,8 +10,8 @@ use crate::state::AppContext;
 use super::{
     HISTORY_BRANCH, HISTORY_BRANCH_REF, HISTORY_COMPACT_AFTER_SEGMENTS, HISTORY_RETAIN_ARCHIVES,
     HISTORY_RETAIN_RECENT_SEGMENTS, ORIGIN_HISTORY_BRANCH_REF, ahead_behind_refs,
-    ensure_local_identity, hash_object_file, remote_exists, remote_tracking_history_exists,
-    repo_is_initialized,
+    ensure_local_identity, hash_object_file, read_blob, remote_exists,
+    remote_tracking_history_exists, repo_is_initialized,
 };
 
 use super::history_impl::{
@@ -77,6 +78,16 @@ pub struct HistoryRepairReport {
     pub conflicts: Vec<HistoryConflictReport>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct HistoryEntrySummary {
+    pub scope: String,
+    pub path: String,
+    pub blob: String,
+    pub line_count: usize,
+    pub first_at: Option<DateTime<Utc>>,
+    pub last_at: Option<DateTime<Utc>>,
+}
+
 pub fn history_status(ctx: &AppContext) -> Result<HistoryStatusReport> {
     if !repo_is_initialized(ctx)? {
         return Ok(HistoryStatusReport {
@@ -121,6 +132,52 @@ pub fn history_status(ctx: &AppContext) -> Result<HistoryStatusReport> {
         retain_recent_segments: HISTORY_RETAIN_RECENT_SEGMENTS,
         retain_archives: HISTORY_RETAIN_ARCHIVES,
         conflicts,
+    })
+}
+
+pub fn history_entries(ctx: &AppContext) -> Result<Vec<HistoryEntrySummary>> {
+    if !repo_is_initialized(ctx)? {
+        return Ok(Vec::new());
+    }
+
+    let Some(local) = load_history_branch_state(ctx, HISTORY_BRANCH_REF)? else {
+        return Ok(Vec::new());
+    };
+
+    let mut entries = Vec::with_capacity(local.archives.len() + local.segments.len());
+
+    for (path, blob) in &local.archives {
+        entries.push(build_history_entry(ctx, "archive", path, blob)?);
+    }
+    for (path, blob) in &local.segments {
+        entries.push(build_history_entry(ctx, "segment", path, blob)?);
+    }
+
+    entries.sort_by(|left, right| {
+        right
+            .last_at
+            .cmp(&left.last_at)
+            .then_with(|| right.first_at.cmp(&left.first_at))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    Ok(entries)
+}
+
+fn build_history_entry(
+    ctx: &AppContext,
+    scope: &str,
+    path: &str,
+    blob: &str,
+) -> Result<HistoryEntrySummary> {
+    let body = read_blob(ctx, blob)?;
+    let summary = crate::state::summarize_history_body(&body)?;
+    Ok(HistoryEntrySummary {
+        scope: scope.to_string(),
+        path: path.to_string(),
+        blob: blob.chars().take(8).collect(),
+        line_count: body.lines().filter(|line| !line.trim().is_empty()).count(),
+        first_at: summary.first_at,
+        last_at: summary.last_at,
     })
 }
 

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -8,8 +8,9 @@ use axum::{
 use serde_json::json;
 
 use crate::cli::{
-    CaptureArgs, Command, ProjectArgs, ProjectionMethod, SyncCommand, TargetCommand,
-    TargetOwnership, WorkspaceBindingCommand, WorkspaceCommand,
+    CaptureArgs, Command, HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand, ProjectArgs,
+    ProjectionMethod, SyncCommand, TargetCommand, TargetOwnership, WorkspaceBindingCommand,
+    WorkspaceCommand,
 };
 use crate::commands::{collect_skill_inventory, remote_status_payload};
 use crate::state::resolve_agent_skill_dirs;
@@ -19,7 +20,10 @@ use super::auth::{
     ensure_mutation_authorized, error_envelope, load_v3_snapshot, run_panel_command,
     status_for_v3_error_payload, v3_error, v3_ok,
 };
-use super::{BindingAddRequest, CaptureRequest, PanelState, ProjectRequest, TargetAddRequest};
+use super::{
+    BindingAddRequest, CaptureRequest, HistoryRepairRequest, PanelState, ProjectRequest,
+    TargetAddRequest,
+};
 
 /// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The backend does not
 /// maintain a closed whitelist (users may extend profiles over time),
@@ -53,6 +57,19 @@ pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Va
         "codex_dir": target_dirs.codex.display().to_string(),
         "remote_url": remote_url,
     }))
+}
+
+pub(super) async fn workspace_status(
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    run_panel_command(
+        &state,
+        "workspace.status",
+        StatusCode::OK,
+        Command::Workspace {
+            command: WorkspaceCommand::Status,
+        },
+    )
 }
 
 pub(super) async fn skills(State(state): State<PanelState>) -> Json<serde_json::Value> {
@@ -396,4 +413,93 @@ pub(super) async fn pending(State(state): State<PanelState>) -> Json<serde_json:
         })),
         Err(err) => Json(json!({"count": 0, "ops": [], "error": err.to_string()})),
     }
+}
+
+pub(super) async fn ops_history_diagnose(
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    run_panel_command(
+        &state,
+        "ops.history.diagnose",
+        StatusCode::OK,
+        Command::Ops {
+            command: OpsCommand::History {
+                command: OpsHistoryCommand::Diagnose,
+            },
+        },
+    )
+}
+
+pub(super) async fn ops_retry(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "ops.retry") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "ops.retry",
+        StatusCode::OK,
+        Command::Ops {
+            command: OpsCommand::Retry,
+        },
+    )
+}
+
+pub(super) async fn ops_purge(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "ops.purge") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "ops.purge",
+        StatusCode::OK,
+        Command::Ops {
+            command: OpsCommand::Purge,
+        },
+    )
+}
+
+pub(super) async fn ops_history_repair(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<HistoryRepairRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "ops.history.repair")
+    {
+        return response;
+    }
+    let strategy = match req.strategy.as_str() {
+        "local" => HistoryRepairStrategyArg::Local,
+        "remote" => HistoryRepairStrategyArg::Remote,
+        _ => {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(error_envelope(
+                    "ops.history.repair",
+                    &request_id,
+                    "ARG_INVALID",
+                    "strategy must be 'local' or 'remote'",
+                )),
+            );
+        }
+    };
+    run_panel_command(
+        &state,
+        "ops.history.repair",
+        StatusCode::OK,
+        Command::Ops {
+            command: OpsCommand::History {
+                command: OpsHistoryCommand::Repair(crate::cli::HistoryRepairArgs { strategy }),
+            },
+        },
+    )
 }

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -415,6 +415,33 @@ pub(super) async fn pending(State(state): State<PanelState>) -> Json<serde_json:
     }
 }
 
+pub(super) async fn ops_history_list(
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match crate::gitops::history_entries(&state.ctx) {
+        Ok(entries) => (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "data": {
+                    "count": entries.len(),
+                    "entries": entries,
+                }
+            })),
+        ),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "ok": false,
+                "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": err.to_string(),
+                }
+            })),
+        ),
+    }
+}
+
 pub(super) async fn ops_history_diagnose(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -4,7 +4,6 @@ mod skill_diff;
 mod static_serve;
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -24,7 +23,6 @@ use static_serve::{ensure_panel_dist, frontend_index, frontend_static_asset};
 #[derive(Clone)]
 pub(crate) struct PanelState {
     pub(crate) ctx: Arc<AppContext>,
-    pub(crate) dist_dir: PathBuf,
     pub(crate) panel_origin: String,
 }
 
@@ -79,12 +77,10 @@ pub(super) struct DiffParams {
 
 pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    let dist_dir = ctx.root.join("panel/dist");
-    ensure_panel_dist(&dist_dir)?;
+    ensure_panel_dist()?;
 
     let state = PanelState {
         ctx: Arc::new(ctx),
-        dist_dir,
         panel_origin: format!("http://{}", addr),
     };
 
@@ -169,7 +165,6 @@ mod tests {
         let ctx = AppContext::new(Some(root.clone())).expect("build app context");
         let state = PanelState {
             ctx: Arc::new(ctx),
-            dist_dir: root.join("panel/dist"),
             panel_origin: "http://127.0.0.1:43117".to_string(),
         };
         (root, state)
@@ -260,18 +255,16 @@ mod tests {
 
     #[test]
     fn resolve_panel_asset_path_rejects_invalid_components() {
-        let dist_dir = Path::new("/tmp/panel-dist");
-
         assert_eq!(
-            resolve_panel_asset_path(dist_dir, "assets/index.js"),
-            Some(dist_dir.join("assets/index.js"))
+            resolve_panel_asset_path("assets/index.js"),
+            Some(Path::new("assets/index.js").to_path_buf())
         );
         assert_eq!(
-            resolve_panel_asset_path(dist_dir, "./assets/index.css"),
-            Some(dist_dir.join("assets/index.css"))
+            resolve_panel_asset_path("./assets/index.css"),
+            Some(Path::new("assets/index.css").to_path_buf())
         );
-        assert_eq!(resolve_panel_asset_path(dist_dir, "../secret.txt"), None);
-        assert_eq!(resolve_panel_asset_path(dist_dir, "/etc/passwd"), None);
+        assert_eq!(resolve_panel_asset_path("../secret.txt"), None);
+        assert_eq!(resolve_panel_asset_path("/etc/passwd"), None);
     }
 
     #[test]

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -75,6 +75,11 @@ pub(super) struct DiffParams {
     pub(super) rev_b: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct HistoryRepairRequest {
+    pub(super) strategy: String,
+}
+
 pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     ensure_panel_dist()?;
@@ -88,6 +93,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/", get(frontend_index))
         .route("/api/health", get(health))
         .route("/api/info", get(info))
+        .route("/api/workspace/status", get(workspace_status))
         .route("/api/skills", get(skills))
         .route("/api/v3/status", get(v3_status))
         .route("/api/v3/bindings", get(v3_bindings))
@@ -106,6 +112,10 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v3/skills/{skill_name}/diff", get(v3_skill_diff))
         .route("/api/remote/status", get(remote_status))
         .route("/api/pending", get(pending))
+        .route("/api/ops/history/diagnose", get(ops_history_diagnose))
+        .route("/api/ops/retry", post(ops_retry))
+        .route("/api/ops/purge", post(ops_purge))
+        .route("/api/ops/history/repair", post(ops_history_repair))
         .route("/api/sync/push", post(sync_push))
         .route("/api/sync/pull", post(sync_pull))
         .route("/api/sync/replay", post(sync_replay))

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -361,6 +361,9 @@ mod tests {
             "sync.push",
             "sync.pull",
             "sync.replay",
+            "ops.retry",
+            "ops.purge",
+            "ops.history.repair",
         ] {
             let response = ensure_mutation_authorized(&state, peer, &headers, cmd)
                 .unwrap_or_else(|| panic!("guard should reject {cmd} without origin headers"));

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -112,6 +112,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v3/skills/{skill_name}/diff", get(v3_skill_diff))
         .route("/api/remote/status", get(remote_status))
         .route("/api/pending", get(pending))
+        .route("/api/ops/history/list", get(ops_history_list))
         .route("/api/ops/history/diagnose", get(ops_history_diagnose))
         .route("/api/ops/retry", post(ops_retry))
         .route("/api/ops/purge", post(ops_purge))

--- a/src/panel/skill_diff.rs
+++ b/src/panel/skill_diff.rs
@@ -425,7 +425,6 @@ mod tests {
         let ctx = AppContext::new(Some(root.to_path_buf())).expect("AppContext");
         PanelState {
             ctx: Arc::new(ctx),
-            dist_dir: root.join("panel/dist"),
             panel_origin: "http://127.0.0.1:43117".to_string(),
         }
     }

--- a/src/panel/static_serve.rs
+++ b/src/panel/static_serve.rs
@@ -1,25 +1,28 @@
-use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use axum::{
-    body::Body,
     extract::{Path as AxumPath, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use include_dir::{Dir, include_dir};
 
 use super::PanelState;
 
+static PANEL_DIST: Dir<'_> = include_dir!("$OUT_DIR/panel-dist");
+
 pub(super) async fn frontend_index(State(state): State<PanelState>) -> Response {
-    serve_panel_asset(state.dist_dir.join("index.html"))
+    let _ = state;
+    serve_panel_asset("index.html")
 }
 
 pub(super) async fn frontend_static_asset(
     AxumPath(path): AxumPath<String>,
     State(state): State<PanelState>,
 ) -> Response {
-    let asset_path = match resolve_panel_asset_path(&state.dist_dir, &path) {
+    let _ = state;
+    let asset_path = match resolve_panel_asset_path(&path) {
         Some(path) => path,
         None => {
             return (
@@ -32,19 +35,17 @@ pub(super) async fn frontend_static_asset(
     serve_panel_asset(asset_path)
 }
 
-pub(super) fn ensure_panel_dist(dist_dir: &Path) -> Result<()> {
-    let index_path = dist_dir.join("index.html");
-    if index_path.is_file() {
+pub(super) fn ensure_panel_dist() -> Result<()> {
+    if PANEL_DIST.get_file("index.html").is_some() {
         Ok(())
     } else {
         Err(anyhow!(
-            "panel frontend not built; expected {}",
-            index_path.display()
+            "panel frontend assets are unavailable in this build; rebuild with Bun installed or run from a checkout that has panel/dist"
         ))
     }
 }
 
-pub(crate) fn resolve_panel_asset_path(dist_dir: &Path, requested: &str) -> Option<PathBuf> {
+pub(crate) fn resolve_panel_asset_path(requested: &str) -> Option<PathBuf> {
     let mut relative = PathBuf::new();
     for component in PathBuf::from(requested).components() {
         match component {
@@ -53,15 +54,16 @@ pub(crate) fn resolve_panel_asset_path(dist_dir: &Path, requested: &str) -> Opti
             _ => return None,
         }
     }
-    Some(dist_dir.join(relative))
+    Some(relative)
 }
 
-fn serve_panel_asset(path: PathBuf) -> Response {
-    match fs::read(&path) {
-        Ok(bytes) => Response::builder()
+fn serve_panel_asset(path: impl AsRef<Path>) -> Response {
+    let path = path.as_ref();
+    match PANEL_DIST.get_file(path) {
+        Some(file) => Response::builder()
             .status(StatusCode::OK)
-            .header("content-type", content_type_for(path.as_path()))
-            .body(Body::from(bytes))
+            .header("content-type", content_type_for(path))
+            .body(axum::body::Body::from(file.contents()))
             .unwrap_or_else(|err| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -69,14 +71,9 @@ fn serve_panel_asset(path: PathBuf) -> Response {
                 )
                     .into_response()
             }),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => (
+        None => (
             StatusCode::NOT_FOUND,
             format!("panel asset not found: {}", path.display()),
-        )
-            .into_response(),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to read panel asset {}: {}", path.display(), err),
         )
             .into_response(),
     }


### PR DESCRIPTION
## Summary
- Appends `ops.retry`, `ops.purge`, and `ops.history.repair` to the command iteration list in `ensure_mutation_authorized_rejects_invalid_context_with_envelope` (mod.rs:354)
- Mirrors the pattern used when sync commands were added in the same batch
- Closes the test gap identified in U-22: a future refactor removing one of these guards would have shipped silently

## Test plan
- [ ] `cargo test` passes — all 51 unit tests green, including the updated mutation auth test
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` applied