### PR TITLE
fix(panel): use Promise.allSettled for ops history + diagnose fetch

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -37,6 +37,34 @@ export interface OpsPayload {
   error?: { code?: string; message?: string };
 }
 
+export interface OpsHistoryDiagnosePayload {
+  ok: boolean;
+  data?: {
+    local_branch: boolean;
+    remote_tracking: boolean;
+    ahead: number;
+    behind: number;
+    local_segments: number;
+    local_archives: number;
+    remote_segments: number;
+    remote_archives: number;
+    local_snapshot: boolean;
+    remote_snapshot: boolean;
+    compact_after_segments: number;
+    retain_recent_segments: number;
+    retain_archives: number;
+    conflicts: Array<{
+      scope: string;
+      path: string;
+      local_blob: string;
+      remote_blob: string;
+      local_rename_path: string;
+      remote_rename_path: string;
+    }>;
+  };
+  error?: { code?: string; message?: string };
+}
+
 export interface BindingShowPayload {
   ok: boolean;
   data?: {
@@ -262,6 +290,8 @@ export const api = {
   info: (signal?: AbortSignal) => getJson<InfoPayload>("/api/info", signal),
   skills: (signal?: AbortSignal) => getJson<SkillsPayload>("/api/skills", signal),
   v3Status: (signal?: AbortSignal) => getJson<V3Payload>("/api/v3/status", signal),
+  opsHistoryDiagnose: (signal?: AbortSignal) =>
+    getJson<OpsHistoryDiagnosePayload>("/api/v3/ops/diagnose", signal),
   ops: (options?: { limit?: number; offset?: number }, signal?: AbortSignal) => {
     const params = new URLSearchParams();
     if (typeof options?.limit === "number") params.set("limit", String(options.limit));

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
-import { api, ApiError, type OpsPayload, type V3OperationRecord } from "../../lib/api/client";
+import { api, ApiError, type OpsHistoryDiagnosePayload, type OpsPayload, type V3OperationRecord } from "../../lib/api/client";
 
 type FilterKey = "all" | "pending" | "ok" | "err";
+type DiagnoseData = NonNullable<OpsHistoryDiagnosePayload["data"]>;
 const HISTORY_PAGE_SIZE = 100;
 
 type LoadState =
@@ -20,6 +21,7 @@ interface HistoryPageProps {
 
 export function HistoryPage({ live, mode, mutationVersion, refreshKey }: HistoryPageProps) {
   const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [diagnose, setDiagnose] = useState<DiagnoseData | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
   const [offset, setOffset] = useState(0);
@@ -32,21 +34,31 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
 
     const controller = new AbortController();
     setState({ kind: "loading" });
-    api
-      .ops({ limit: HISTORY_PAGE_SIZE, offset }, controller.signal)
-      .then((res) => {
-        if (controller.signal.aborted) return;
-        if (!res.ok || !res.data) {
-          setState({ kind: "error", message: res.error?.message ?? "activity fetch returned ok=false" });
-          return;
-        }
-        setState({ kind: "ready", payload: res.data });
-      })
-      .catch((err) => {
-        if (controller.signal.aborted) return;
+    setDiagnose(null);
+    Promise.allSettled([
+      api.ops({ limit: HISTORY_PAGE_SIZE, offset }, controller.signal),
+      api.opsHistoryDiagnose(controller.signal),
+    ]).then(([opsResult, diagnoseResult]) => {
+      if (controller.signal.aborted) return;
+
+      if (opsResult.status === "rejected") {
+        const err = opsResult.reason;
         const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
         setState({ kind: "error", message });
-      });
+        return;
+      }
+
+      const res = opsResult.value;
+      if (!res.ok || !res.data) {
+        setState({ kind: "error", message: res.error?.message ?? "activity fetch returned ok=false" });
+        return;
+      }
+      setState({ kind: "ready", payload: res.data });
+
+      if (diagnoseResult.status === "fulfilled" && diagnoseResult.value.data) {
+        setDiagnose(diagnoseResult.value.data);
+      }
+    });
     return () => controller.abort();
   }, [live, mutationVersion, refreshKey, offset]);
 
@@ -126,6 +138,15 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
           </div>
         )}
         {!live && <div className="empty" style={{ marginBottom: 18 }}>{offlineHint}</div>}
+        {diagnose?.local_branch && (
+          <div style={{ display: "flex", gap: 12, padding: "4px 0", marginBottom: 12, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--ink-3)" }}>
+            <span>{diagnose.local_segments} segment{diagnose.local_segments === 1 ? "" : "s"}</span>
+            {diagnose.remote_tracking && diagnose.ahead > 0 && <span style={{ color: "var(--ok)" }}>↑ {diagnose.ahead} ahead</span>}
+            {diagnose.remote_tracking && diagnose.behind > 0 && <span style={{ color: "var(--pending)" }}>↓ {diagnose.behind} behind</span>}
+            {diagnose.remote_tracking && diagnose.ahead === 0 && diagnose.behind === 0 && <span>in sync</span>}
+            {diagnose.conflicts.length > 0 && <span style={{ color: "var(--err)" }}>{diagnose.conflicts.length} conflict{diagnose.conflicts.length === 1 ? "" : "s"} — run loom ops history repair</span>}
+          </div>
+        )}
         <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 18 }}>
           <Kpi label="Loaded changes" value={counts.all} />
           <Kpi label="Pending" value={counts.pending} tone={counts.pending > 0 ? "pending" : undefined} />

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -501,6 +501,13 @@ pub(super) async fn remote_status(
     }
 }
 
+pub(super) async fn v3_ops_diagnose(State(state): State<PanelState>) -> Json<serde_json::Value> {
+    match crate::gitops::history_status(&state.ctx) {
+        Ok(report) => v3_ok(serde_json::json!(report)),
+        Err(err) => v3_error("GIT_ERROR", err.to_string()),
+    }
+}
+
 pub(super) async fn pending(State(state): State<PanelState>) -> Json<serde_json::Value> {
     match state.ctx.read_pending_report() {
         Ok(report) => Json(json!({

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -97,6 +97,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/skills", get(skills))
         .route("/api/v3/status", get(v3_status))
         .route("/api/v3/ops", get(v3_ops))
+        .route("/api/v3/ops/diagnose", get(v3_ops_diagnose))
         .route("/api/v3/bindings", get(v3_bindings))
         .route("/api/v3/bindings/{binding_id}", get(v3_binding_show))
         .route("/api/v3/targets", get(v3_targets))


### PR DESCRIPTION
## Summary

- Adds `GET /api/v3/ops/diagnose` panel endpoint backed by `gitops::history_status`, returning the loom-history branch status report
- Adds `OpsHistoryDiagnosePayload` TypeScript type and `api.opsHistoryDiagnose()` client method
- Replaces the single `api.ops()` fetch in `HistoryPage` with `Promise.allSettled([api.ops(...), api.opsHistoryDiagnose(...)])` so a diagnose failure (missing loom-history branch, git error, transient network issue) never blanks the history list
- Diagnose metrics (segment count, ahead/behind, conflict warnings) render only when the diagnose call succeeds

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 67 unit + all integration tests pass
- [x] `bun run typecheck` — no TS errors
- [x] `bun run test` — 21 panel tests pass