### PR TITLE
feat(panel): add ops.history.repair handler and auth guard test coverage

### DIFF
--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -9,8 +9,9 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::cli::{
-    CaptureArgs, Command, OpsCommand, ProjectArgs, ProjectionMethod, SyncCommand, TargetCommand,
-    TargetOwnership, WorkspaceBindingCommand, WorkspaceCommand,
+    CaptureArgs, Command, HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand, ProjectArgs,
+    ProjectionMethod, SyncCommand, TargetCommand, TargetOwnership, WorkspaceBindingCommand,
+    WorkspaceCommand,
 };
 use crate::commands::{collect_skill_inventory, remote_status_payload};
 use crate::state::resolve_agent_skill_dirs;
@@ -20,7 +21,10 @@ use super::auth::{
     ensure_mutation_authorized, error_envelope, load_v3_snapshot, run_panel_command,
     status_for_error_code, status_for_v3_error_payload, v3_error, v3_ok,
 };
-use super::{BindingAddRequest, CaptureRequest, PanelState, ProjectRequest, TargetAddRequest};
+use super::{
+    BindingAddRequest, CaptureRequest, HistoryRepairRequest, PanelState, ProjectRequest,
+    TargetAddRequest,
+};
 
 /// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The backend does not
 /// maintain a closed whitelist (users may extend profiles over time),
@@ -416,6 +420,44 @@ pub(super) async fn ops_purge(
         StatusCode::OK,
         Command::Ops {
             command: OpsCommand::Purge,
+        },
+    )
+}
+
+pub(super) async fn ops_history_repair(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<HistoryRepairRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "ops.history.repair")
+    {
+        return response;
+    }
+    let strategy = match req.strategy.as_str() {
+        "local" => HistoryRepairStrategyArg::Local,
+        "remote" => HistoryRepairStrategyArg::Remote,
+        _ => {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(error_envelope(
+                    "ops.history.repair",
+                    &request_id,
+                    "ARG_INVALID",
+                    "strategy must be 'local' or 'remote'",
+                )),
+            );
+        }
+    };
+    run_panel_command(
+        &state,
+        "ops.history.repair",
+        StatusCode::OK,
+        Command::Ops {
+            command: OpsCommand::History {
+                command: OpsHistoryCommand::Repair(crate::cli::HistoryRepairArgs { strategy }),
+            },
         },
     )
 }

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -72,6 +72,11 @@ pub(super) struct CaptureRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct HistoryRepairRequest {
+    pub(super) strategy: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct DiffParams {
     #[serde(default)]
     pub(super) rev_a: Option<String>,
@@ -116,6 +121,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/pending", get(pending))
         .route("/api/ops/retry", post(ops_retry))
         .route("/api/ops/purge", post(ops_purge))
+        .route("/api/ops/history/repair", post(ops_history_repair))
         .route("/api/sync/push", post(sync_push))
         .route("/api/sync/pull", post(sync_pull))
         .route("/api/sync/replay", post(sync_replay))
@@ -425,6 +431,7 @@ mod tests {
             "skill.capture",
             "ops.retry",
             "ops.purge",
+            "ops.history.repair",
             "sync.push",
             "sync.pull",
             "sync.replay",


### PR DESCRIPTION
## Summary

- Add `POST /api/ops/history/repair` panel endpoint backed by `OpsCommand::History::Repair`
- Endpoint calls `ensure_mutation_authorized` before dispatch, matching the pattern of `ops.retry` and `ops.purge`
- Add `HistoryRepairRequest { strategy: String }` for the `local`/`remote` strategy parameter
- Extend `ensure_mutation_authorized_rejects_invalid_context_with_envelope` to cover `ops.history.repair` so a future guard-removal is caught before ship

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — all pass, including the extended mutation auth guard test

Closes #31