### PR TITLE
fix: surface /api/pending backend failures (U-29)

### DIFF
--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -550,15 +550,29 @@ pub(super) async fn v3_ops_diagnose(State(state): State<PanelState>) -> Json<ser
     }
 }
 
-pub(super) async fn pending(State(state): State<PanelState>) -> Json<serde_json::Value> {
+pub(super) async fn pending(
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
     match state.ctx.read_pending_report() {
-        Ok(report) => Json(json!({
-            "count": report.ops.len(),
-            "ops": report.ops,
-            "journal_events": report.journal_events,
-            "history_events": report.history_events,
-            "warnings": report.warnings
-        })),
-        Err(err) => Json(json!({"count": 0, "ops": [], "error": err.to_string()})),
+        Ok(report) => (
+            StatusCode::OK,
+            Json(json!({
+                "count": report.ops.len(),
+                "ops": report.ops,
+                "journal_events": report.journal_events,
+                "history_events": report.history_events,
+                "warnings": report.warnings
+            })),
+        ),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "ok": false,
+                "error": {
+                    "code": "IO_ERROR",
+                    "message": err.to_string(),
+                }
+            })),
+        ),
     }
 }

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -148,7 +148,7 @@ mod tests {
             ensure_mutation_authorized, error_envelope, request_origin_matches, run_panel_command,
             status_for_error_code, status_for_v3_error_payload, status_for_v3_state_load_error,
         },
-        handlers::{OpsQuery, remote_status, v3_ops, v3_status},
+        handlers::{OpsQuery, pending, remote_status, v3_ops, v3_status},
         static_serve::{content_type_for, ensure_panel_dist, resolve_panel_asset_path},
     };
     use crate::cli::{
@@ -788,6 +788,43 @@ mod tests {
         assert_eq!(payload["remote"]["configured"], json!(false));
         assert!(payload["remote"].is_object());
         assert!(payload["warnings"].is_array());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn pending_returns_non_2xx_with_structured_error_body_on_failure() {
+        let (root, state) = make_test_state();
+        state
+            .ctx
+            .ensure_state_layout()
+            .expect("create pending ops layout");
+        fs::remove_file(&state.ctx.pending_ops_file).expect("remove pending ops file");
+        fs::create_dir_all(&state.ctx.pending_ops_file).expect("replace pending ops file with dir");
+
+        let (status, Json(payload)) = pending(State(state)).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(payload["ok"], json!(false));
+        assert_eq!(payload["error"]["code"], json!("IO_ERROR"));
+        assert!(payload["error"]["message"].as_str().is_some());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn pending_returns_ok_with_empty_report_on_success() {
+        let (root, state) = make_test_state();
+        state
+            .ctx
+            .ensure_state_layout()
+            .expect("create pending ops layout");
+
+        let (status, Json(payload)) = pending(State(state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["count"], json!(0));
+        assert!(payload["ops"].as_array().is_some());
 
         let _ = fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Summary

- `/api/pending` was returning HTTP 200 with `count=0, ops=[]` when `read_pending_report()` failed, hiding backend I/O errors from the panel UI (U-29 violation)
- Now returns HTTP 500 with `{"ok": false, "error": {"code": "IO_ERROR", "message": "..."}}` on failure, matching the pattern established by PR #25 and PR #26
- Success path shape is unchanged

## Test plan

- [x] `pending_returns_non_2xx_with_structured_error_body_on_failure` — corrupts `pending_ops_file` by replacing it with a directory, asserts HTTP 500 + `IO_ERROR` code
- [x] `pending_returns_ok_with_empty_report_on_success` — asserts HTTP 200 + `count=0` on a fresh state layout
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 69/69 passed

Closes #22