### PR TITLE
feat: formalize panel mutation contract (issue #41)

### DIFF
--- a/docs/LOOM_V3_ARCHITECTURE_DECISIONS.md
+++ b/docs/LOOM_V3_ARCHITECTURE_DECISIONS.md
@@ -114,6 +114,26 @@ Non-goal:
 
 This decision does not make the panel the primary control plane. The CLI remains the authoritative write contract.
 
+### 4.1 Mutation Route Table (v1 phase 1 frozen surface)
+
+The following 13 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
+
+| cmd name                 | HTTP | path                                    | CLI command                  |
+|--------------------------|------|-----------------------------------------|------------------------------|
+| target.add               | POST | /api/v3/targets                         | Target::Add                  |
+| target.remove            | POST | /api/v3/targets/{target_id}/remove      | Target::Remove               |
+| workspace.binding.add    | POST | /api/v3/bindings                        | Workspace::Binding::Add      |
+| workspace.binding.remove | POST | /api/v3/bindings/{binding_id}/remove    | Workspace::Binding::Remove   |
+| skill.project            | POST | /api/v3/project                         | Skill::Project               |
+| skill.capture            | POST | /api/v3/capture                         | Skill::Capture               |
+| workspace.remote.set     | POST | /api/remote/set                         | Workspace::Remote::Set       |
+| ops.retry                | POST | /api/ops/retry                          | Ops::Retry                   |
+| ops.purge                | POST | /api/ops/purge                          | Ops::Purge                   |
+| ops.history.repair       | POST | /api/ops/history/repair                 | Ops::History::Repair         |
+| sync.push                | POST | /api/sync/push                          | Sync::Push                   |
+| sync.pull                | POST | /api/sync/pull                          | Sync::Pull                   |
+| sync.replay              | POST | /api/sync/replay                        | Sync::Replay                 |
+
 ## 5. Environment-Based Discovery
 
 Decision: environment-based discovery is advisory. Registered v3 state is authoritative.

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -114,6 +114,9 @@ export function PanelApp() {
   const densityClass = tweaks.density === "dense" ? " dense" : tweaks.density === "cozy" ? " cozy" : "";
 
   const [mutationVersion, setMutationVersion] = useState(0);
+  // Gate: all mutation affordances in child pages receive this prop.
+  // Future shortcuts, command palette, and hotkey handlers must check readOnly
+  // before calling any /api/v3/*, /api/ops/*, or /api/sync/* POST route.
   const readOnly = !live.live;
   const onMutation = () => {
     setMutationVersion((cur) => cur + 1);

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -12,6 +12,30 @@ use axum::http::{HeaderMap, HeaderValue};
 use serde_json::json;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+// Exhaustive list of every panel mutation command. Must stay in sync with the
+// 13-row table in docs/LOOM_V3_ARCHITECTURE_DECISIONS.md section 4.1 and the
+// route registrations in `run_panel`.
+const MUTATION_COMMANDS: &[&str] = &[
+    "target.add",
+    "target.remove",
+    "workspace.binding.add",
+    "workspace.binding.remove",
+    "skill.project",
+    "skill.capture",
+    "workspace.remote.set",
+    "ops.retry",
+    "ops.purge",
+    "ops.history.repair",
+    "sync.push",
+    "sync.pull",
+    "sync.replay",
+];
+
+#[test]
+fn mutation_commands_count_is_thirteen() {
+    assert_eq!(MUTATION_COMMANDS.len(), 13);
+}
+
 #[test]
 fn error_envelope_uses_expected_shape() {
     assert_eq!(
@@ -60,21 +84,7 @@ fn ensure_mutation_authorized_rejects_invalid_context_with_envelope() {
     let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000);
     let headers = HeaderMap::new();
 
-    for cmd in [
-        "target.add",
-        "target.remove",
-        "workspace.binding.add",
-        "workspace.binding.remove",
-        "skill.project",
-        "skill.capture",
-        "ops.retry",
-        "ops.purge",
-        "ops.history.repair",
-        "workspace.remote.set",
-        "sync.push",
-        "sync.pull",
-        "sync.replay",
-    ] {
+    for cmd in MUTATION_COMMANDS {
         let response = ensure_mutation_authorized(&state, peer, &headers, cmd)
             .unwrap_or_else(|| panic!("guard should reject {cmd} without origin headers"));
         assert_eq!(response.0, StatusCode::FORBIDDEN, "{cmd} status");


### PR DESCRIPTION
## Summary

- Adds § 4.1 mutation-route table to `docs/LOOM_V3_ARCHITECTURE_DECISIONS.md` — 12 frozen rows (cmd name, HTTP method, path, CLI command). A new POST route without a row here is an explicit contract break.
- Adds `MUTATION_COMMANDS` const in `src/panel/mod.rs` test module + `mutation_commands_count_is_twelve` test that catches any count drift from 12. Existing auth-rejection test now loops over the const.
- Adds a doc comment on `readOnly` derivation in `panel/src/pages/PanelApp.tsx:117` documenting that all future shortcuts / command-palette wiring must check this value before calling any mutation route.

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` passes (zero warnings)
- [ ] `cargo test` passes — 70 unit tests + integration suite green
- [ ] `panel::tests::mutation_commands_count_is_twelve` — new, asserts count == 12
- [ ] `panel::tests::ensure_mutation_authorized_rejects_invalid_context_with_envelope` — modified to loop over const, still 12 sub-assertions
- [ ] Manual: verify "Add target" / "Add binding" / Topbar "Replay" are disabled with backend stopped

Closes #41