### PR TITLE
[codex] Add Panel remote configuration

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -250,6 +250,10 @@ export interface HistoryRepairBody {
   strategy: "local" | "remote";
 }
 
+export interface RemoteSetBody {
+  url: string;
+}
+
 export interface SkillDiffFile {
   path: string;
   added: number;
@@ -313,6 +317,7 @@ export const api = {
 
   opsRetry: () => postJson("/api/ops/retry", {}),
   opsPurge: () => postJson("/api/ops/purge", {}),
+  remoteSet: (body: RemoteSetBody) => postJson("/api/remote/set", body),
 
   targetAdd: (body: TargetAddBody) => postJson("/api/v3/targets", body),
   targetRemove: (targetId: string) => postJson(`/api/v3/targets/${encodeURIComponent(targetId)}/remove`, {}),

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -1,5 +1,7 @@
 import type { RemotePayload } from "../../types";
-import { PlayIcon, RefreshIcon, SyncIcon } from "../../components/icons/nav_icons";
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+import { GitIcon, PlayIcon, RefreshIcon, SyncIcon } from "../../components/icons/nav_icons";
 import { api } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
 
@@ -15,15 +17,29 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
   const push = useMutation();
   const pull = useMutation();
   const replay = useMutation();
-  const syncBusy = push.busy || pull.busy || replay.busy;
+  const setRemote = useMutation();
+  const [remoteUrl, setRemoteUrl] = useState(remote?.url ?? "");
+  const syncBusy = push.busy || pull.busy || replay.busy || setRemote.busy;
   const configured = remote?.configured === true;
   const state = remote?.sync_state ?? (configured ? "unknown" : "not configured");
   const rootDisplay = registryRoot ? registryRoot.replace(/^\/Users\/[^/]+/, "~") : "—";
 
+  useEffect(() => {
+    setRemoteUrl(remote?.url ?? "");
+  }, [remote?.url]);
+
+  const submitRemote = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const url = remoteUrl.trim();
+    if (!url || readOnly || syncBusy) return;
+    setRemote.run(configured ? "remote update" : "remote set", () => api.remoteSet({ url }), onMutation);
+  };
+
   const banner =
-    push.error ?? pull.error ?? replay.error ??
-    push.success ?? pull.success ?? replay.success ?? null;
-  const bannerType = push.error || pull.error || replay.error ? "err" : banner ? "ok" : null;
+    setRemote.error ?? push.error ?? pull.error ?? replay.error ??
+    setRemote.success ?? push.success ?? pull.success ?? replay.success ?? null;
+  const bannerType =
+    setRemote.error || push.error || pull.error || replay.error ? "err" : banner ? "ok" : null;
 
   return (
     <>
@@ -95,6 +111,31 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
                 ⚠ Local-only — no upstream tracking branch configured.
               </div>
             )}
+            <form
+              onSubmit={submitRemote}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "minmax(0, 1fr) auto",
+                gap: 8,
+                marginTop: 12,
+              }}
+            >
+              <input
+                value={remoteUrl}
+                onChange={(event) => setRemoteUrl(event.target.value)}
+                placeholder="https://github.com/org/registry.git"
+                disabled={readOnly || setRemote.busy}
+                aria-label="Remote URL"
+                style={inputStyle}
+              />
+              <button
+                className="btn"
+                disabled={readOnly || syncBusy || remoteUrl.trim().length === 0}
+                title={readOnly ? "registry offline" : "set origin remote URL"}
+              >
+                <GitIcon /> {setRemote.busy ? "saving…" : configured ? "Update" : "Set"}
+              </button>
+            </form>
           </div>
         </div>
 
@@ -141,6 +182,20 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
     </>
   );
 }
+
+const inputStyle = {
+  width: "100%",
+  minWidth: 0,
+  height: 32,
+  border: "1px solid var(--line)",
+  borderRadius: 6,
+  background: "var(--bg)",
+  color: "var(--ink-0)",
+  padding: "0 10px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  outline: "none",
+};
 
 function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {
   const color = tone === "pending" ? "var(--pending)" : tone === "err" ? "var(--err)" : "var(--ink-0)";

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -10,8 +10,8 @@ use serde_json::json;
 
 use crate::cli::{
     CaptureArgs, Command, HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand, ProjectArgs,
-    ProjectionMethod, SyncCommand, TargetCommand, TargetOwnership, WorkspaceBindingCommand,
-    WorkspaceCommand,
+    ProjectionMethod, RemoteCommand, SyncCommand, TargetCommand, TargetOwnership,
+    WorkspaceBindingCommand, WorkspaceCommand,
 };
 use crate::commands::{collect_skill_inventory, remote_status_payload};
 use crate::state::resolve_agent_skill_dirs;
@@ -23,7 +23,7 @@ use super::auth::{
 };
 use super::{
     BindingAddRequest, CaptureRequest, HistoryRepairRequest, PanelState, ProjectRequest,
-    TargetAddRequest,
+    RemoteSetRequest, TargetAddRequest,
 };
 
 /// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The backend does not
@@ -518,6 +518,44 @@ pub(super) async fn sync_replay(
         StatusCode::OK,
         Command::Sync {
             command: SyncCommand::Replay,
+        },
+    )
+}
+
+pub(super) async fn remote_set(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<RemoteSetRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) =
+        ensure_mutation_authorized(&state, peer, &headers, "workspace.remote.set")
+    {
+        return response;
+    }
+
+    let url = req.url.trim().to_string();
+    if url.is_empty() {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(error_envelope(
+                "workspace.remote.set",
+                &request_id,
+                "ARG_INVALID",
+                "remote url is required",
+            )),
+        );
+    }
+
+    run_panel_command(
+        &state,
+        "workspace.remote.set",
+        StatusCode::OK,
+        Command::Workspace {
+            command: WorkspaceCommand::Remote {
+                command: RemoteCommand::Set { url },
+            },
         },
     )
 }

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -75,6 +75,11 @@ pub(super) struct HistoryRepairRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct RemoteSetRequest {
+    pub(super) url: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct DiffParams {
     #[serde(default)]
     pub(super) rev_a: Option<String>,
@@ -115,6 +120,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v3/skills/{skill_name}/diff", get(v3_skill_diff))
         .route("/api/v3/skills/{skill_name}/history", get(v3_skill_history))
         .route("/api/remote/status", get(remote_status))
+        .route("/api/remote/set", post(remote_set))
         .route("/api/pending", get(pending))
         .route("/api/ops/retry", post(ops_retry))
         .route("/api/ops/purge", post(ops_purge))
@@ -144,12 +150,12 @@ mod tests {
             ensure_mutation_authorized, error_envelope, request_origin_matches, run_panel_command,
             status_for_error_code, status_for_v3_error_payload, status_for_v3_state_load_error,
         },
-        handlers::{OpsQuery, pending, remote_status, v3_ops, v3_status},
+        handlers::{OpsQuery, pending, remote_set, remote_status, v3_ops, v3_status},
         static_serve::{content_type_for, resolve_panel_asset_path},
     };
     use crate::cli::{
         BindingAddArgs, CaptureArgs, Command, OpsCommand, ProjectArgs, ProjectionMethod,
-        SkillCommand, SyncCommand, TargetAddArgs, TargetCommand, TargetOwnership,
+        RemoteCommand, SkillCommand, SyncCommand, TargetAddArgs, TargetCommand, TargetOwnership,
         WorkspaceBindingCommand, WorkspaceCommand, WorkspaceMatcherKind,
     };
     use crate::state::AppContext;
@@ -159,7 +165,7 @@ mod tests {
     };
     use axum::{
         Json,
-        extract::{Query, State},
+        extract::{ConnectInfo, Query, State},
         http::{HeaderMap, HeaderValue, StatusCode},
     };
     use chrono::{Duration as ChrDuration, Utc};
@@ -363,6 +369,7 @@ mod tests {
             "ops.retry",
             "ops.purge",
             "ops.history.repair",
+            "workspace.remote.set",
             "sync.push",
             "sync.pull",
             "sync.replay",
@@ -411,6 +418,33 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_panel_command_exposes_workspace_remote_set() {
+        let (root, state) = make_test_state();
+        let url = "https://example.com/loom-registry.git";
+
+        let (status, Json(payload)) = run_panel_command(
+            &state,
+            "workspace.remote.set",
+            StatusCode::OK,
+            Command::Workspace {
+                command: WorkspaceCommand::Remote {
+                    command: RemoteCommand::Set {
+                        url: url.to_string(),
+                    },
+                },
+            },
+        );
+
+        assert_eq!(status, StatusCode::OK, "{payload}");
+        assert_eq!(payload["ok"], json!(true));
+        assert_eq!(payload["cmd"], json!("workspace.remote"));
+        assert_eq!(payload["data"]["remote"], json!("origin"));
+        assert_eq!(payload["data"]["url"], json!(url));
+
+        cleanup_root(root);
     }
 
     #[test]
@@ -720,6 +754,63 @@ mod tests {
         assert!(payload["warnings"].is_array());
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn remote_set_rejects_empty_url() {
+        let (root, state) = make_test_state();
+        let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000);
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", HeaderValue::from_static("http://127.0.0.1:43117"));
+
+        let (status, Json(payload)) = remote_set(
+            ConnectInfo(peer),
+            headers,
+            State(state),
+            Json(super::RemoteSetRequest {
+                url: "   ".to_string(),
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(payload["ok"], json!(false));
+        assert_eq!(payload["cmd"], json!("workspace.remote.set"));
+        assert_eq!(payload["error"]["code"], json!("ARG_INVALID"));
+
+        cleanup_root(root);
+    }
+
+    #[tokio::test]
+    async fn remote_set_configures_origin_from_authorized_panel_request() {
+        let (root, state) = make_test_state();
+        let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000);
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", HeaderValue::from_static("http://127.0.0.1:43117"));
+        let url = "https://example.com/loom-registry.git";
+
+        let (status, Json(payload)) = remote_set(
+            ConnectInfo(peer),
+            headers,
+            State(state.clone()),
+            Json(super::RemoteSetRequest {
+                url: format!("  {url}  "),
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{payload}");
+        assert_eq!(payload["ok"], json!(true));
+        assert_eq!(payload["cmd"], json!("workspace.remote"));
+        assert_eq!(payload["data"]["remote"], json!("origin"));
+        assert_eq!(payload["data"]["url"], json!(url));
+
+        let (remote_status_code, Json(remote_payload)) = remote_status(State(state)).await;
+        assert_eq!(remote_status_code, StatusCode::OK);
+        assert_eq!(remote_payload["remote"]["configured"], json!(true));
+        assert_eq!(remote_payload["remote"]["url"], json!(url));
+
+        cleanup_root(root);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Closes #49.
- Adds a guarded `POST /api/remote/set` Panel endpoint that delegates to the existing `workspace remote set` command.
- Adds a Remote URL input and Set/Update action on the Git sync page.
- Covers empty URL validation, mutation auth, and authorized success behavior in Rust tests.

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test remote_set`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `npm run typecheck`
- `npm run build`
- `bash -n scripts/demo.sh && bash -n scripts/e2e-agent-flow.sh`
- `./scripts/e2e-agent-flow.sh`
- Panel API smoke test: authorized `POST /api/remote/set` returned 200 and configured `origin`; missing Origin returned 403.