### PR TITLE
[codex] Add observed skill import command

### DIFF
--- a/docs/LOOM_V3_CLI_CONTRACT.md
+++ b/docs/LOOM_V3_CLI_CONTRACT.md
@@ -337,7 +337,23 @@ Rules:
 1. adds canonical source under `skills/<skill-id>`
 2. must fail when target skill already exists
 
-### 11.2 `skill project`
+### 11.2 `skill import-observed`
+
+```bash
+loom --json --root <root> skill import-observed [--target <target-id>]
+```
+
+Write command.
+
+Rules:
+
+1. imports real skill directories from observed targets into canonical `skills/<skill-id>`
+2. only directories containing `SKILL.md` are treated as skills
+3. existing canonical skills are skipped, not overwritten
+4. `--target` must reference an observed target when supplied
+5. this is not the removed legacy `skill import` command; it is an explicit bridge from discovered observed targets into the source registry
+
+### 11.3 `skill project`
 
 ```bash
 loom --json --root <root> skill project <skill-id> --binding <binding-id> [--target <target-id>] [--method <symlink|copy|materialize>]
@@ -367,7 +383,7 @@ Rules:
 2. if `--target` is absent, Loom may use `default_target_id` from binding metadata
 3. if multiple targets are possible and no default exists, the command must fail explicitly
 
-### 11.3 `skill capture`
+### 11.4 `skill capture`
 
 ```bash
 loom --json --root <root> skill capture <skill-id> --binding <binding-id>
@@ -399,7 +415,7 @@ Rules:
 1. capture is always explicit
 2. capture must fail if drift cannot be reconciled safely
 
-### 11.4 `skill save`
+### 11.5 `skill save`
 
 ```bash
 loom --json --root <root> skill save <skill-id>
@@ -407,7 +423,7 @@ loom --json --root <root> skill save <skill-id>
 
 Acts on canonical source only.
 
-### 11.5 `skill snapshot`
+### 11.6 `skill snapshot`
 
 ```bash
 loom --json --root <root> skill snapshot <skill-id>
@@ -415,7 +431,7 @@ loom --json --root <root> skill snapshot <skill-id>
 
 Acts on canonical source only.
 
-### 11.6 `skill release`
+### 11.7 `skill release`
 
 ```bash
 loom --json --root <root> skill release <skill-id> <version>
@@ -423,7 +439,7 @@ loom --json --root <root> skill release <skill-id> <version>
 
 Acts on canonical source only.
 
-### 11.7 `skill rollback`
+### 11.8 `skill rollback`
 
 ```bash
 loom --json --root <root> skill rollback <skill-id> --to <ref>
@@ -532,10 +548,11 @@ Examples:
 
 1. `workspace binding add`
 2. `target add`
-3. `skill project`
-4. `skill capture`
-5. `skill save`
-6. `sync push`
+3. `skill import-observed`
+4. `skill project`
+5. `skill capture`
+6. `skill save`
+7. `sync push`
 
 Requirements:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,6 +87,7 @@ pub enum TargetCommand {
 #[derive(Debug, Clone, Subcommand)]
 pub enum SkillCommand {
     Add(AddArgs),
+    ImportObserved(ImportObservedArgs),
     Project(ProjectArgs),
     Capture(CaptureArgs),
     Save(SaveArgs),
@@ -131,6 +132,12 @@ pub struct AddArgs {
 
     #[arg(long)]
     pub name: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ImportObservedArgs {
+    #[arg(long)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -110,6 +110,7 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
         },
         Command::Skill { command } => match command {
             SkillCommand::Add(_) => "skill.add",
+            SkillCommand::ImportObserved(_) => "skill.import_observed",
             SkillCommand::Project(_) => "skill.project",
             SkillCommand::Capture(_) => "skill.capture",
             SkillCommand::Save(_) => "skill.save",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,6 +80,7 @@ impl App {
             Command::Target { command } => self.cmd_target(command, &request_id),
             Command::Skill { command } => match command {
                 SkillCommand::Add(args) => self.cmd_add(args, &request_id),
+                SkillCommand::ImportObserved(args) => self.cmd_import_observed(args, &request_id),
                 SkillCommand::Project(args) => self.cmd_project(args, &request_id),
                 SkillCommand::Capture(args) => self.cmd_capture(args, &request_id),
                 SkillCommand::Save(args) => self.cmd_save(args, &request_id),

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -5,11 +5,11 @@ use chrono::Utc;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::cli::{AddArgs, CaptureArgs, ProjectArgs, SaveArgs, SkillOnlyArgs};
+use crate::cli::{AddArgs, CaptureArgs, ImportObservedArgs, ProjectArgs, SaveArgs, SkillOnlyArgs};
 use crate::envelope::Meta;
 use crate::gitops;
 use crate::state::remove_path_if_exists;
-use crate::state_model::{V3BindingRule, V3ProjectionInstance};
+use crate::state_model::{V3BindingRule, V3ProjectionInstance, V3ProjectionTarget};
 use crate::types::ErrorCode;
 
 use super::fs_probe::probe_symlink;
@@ -129,6 +129,246 @@ impl App {
         }
 
         Ok((json!({"skill": args.name, "path": dst}), meta))
+    }
+
+    pub fn cmd_import_observed(
+        &self,
+        args: &ImportObservedArgs,
+        request_id: &str,
+    ) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
+        let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
+        self.ensure_write_repo_ready()?;
+        let paths = self.ensure_v3_layout()?;
+        let snapshot = paths.load_snapshot().map_err(map_v3_state)?;
+
+        let targets = observed_import_targets(&snapshot.targets.targets, args)?;
+        let staging_root = self
+            .ctx
+            .state_dir
+            .join(format!("tmp-import-observed-{}", Uuid::new_v4()));
+        let cleanup_staging = || {
+            let _ = remove_path_if_exists(&staging_root);
+        };
+
+        remove_path_if_exists(&staging_root).map_err(map_io)?;
+        fs::create_dir_all(&staging_root).map_err(map_io)?;
+
+        let mut imported = Vec::new();
+        let mut skipped = Vec::new();
+        let mut imported_rels = Vec::new();
+
+        for target in targets {
+            let target_path = PathBuf::from(&target.path);
+            if !target_path.exists() {
+                skipped.push(json!({
+                    "target_id": target.target_id,
+                    "path": target.path,
+                    "reason": "target-missing",
+                }));
+                continue;
+            }
+            if !target_path.is_dir() {
+                skipped.push(json!({
+                    "target_id": target.target_id,
+                    "path": target.path,
+                    "reason": "target-not-directory",
+                }));
+                continue;
+            }
+
+            let mut entries = match fs::read_dir(&target_path) {
+                Ok(entries) => entries
+                    .filter_map(|entry| match entry {
+                        Ok(entry) => Some(entry),
+                        Err(err) => {
+                            skipped.push(json!({
+                                "target_id": target.target_id,
+                                "path": target.path,
+                                "reason": "entry-read-failed",
+                                "error": err.to_string(),
+                            }));
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+                Err(err) => {
+                    skipped.push(json!({
+                        "target_id": target.target_id,
+                        "path": target.path,
+                        "reason": "target-read-failed",
+                        "error": err.to_string(),
+                    }));
+                    continue;
+                }
+            };
+            entries.sort_by_key(|entry| entry.file_name());
+
+            for entry in entries {
+                let source_path = entry.path();
+                let file_type = match entry.file_type() {
+                    Ok(file_type) => file_type,
+                    Err(err) => {
+                        skipped.push(json!({
+                            "target_id": target.target_id,
+                            "source": source_path.display().to_string(),
+                            "reason": "file-type-failed",
+                            "error": err.to_string(),
+                        }));
+                        continue;
+                    }
+                };
+                if !file_type.is_dir() || file_type.is_symlink() {
+                    continue;
+                }
+                if !source_path.join("SKILL.md").is_file() {
+                    continue;
+                }
+
+                let skill_id = match entry.file_name().into_string() {
+                    Ok(name) => name,
+                    Err(name) => {
+                        skipped.push(json!({
+                            "target_id": target.target_id,
+                            "source": source_path.display().to_string(),
+                            "name": name.to_string_lossy(),
+                            "reason": "non-utf8-name",
+                        }));
+                        continue;
+                    }
+                };
+
+                if let Err(err) = validate_skill_name(&skill_id) {
+                    skipped.push(json!({
+                        "target_id": target.target_id,
+                        "skill": skill_id,
+                        "source": source_path.display().to_string(),
+                        "reason": "invalid-skill-name",
+                        "error": err.to_string(),
+                    }));
+                    continue;
+                }
+
+                let dst = self.ctx.skill_path(&skill_id);
+                if dst.exists() {
+                    skipped.push(json!({
+                        "target_id": target.target_id,
+                        "skill": skill_id,
+                        "source": source_path.display().to_string(),
+                        "reason": "already-exists",
+                    }));
+                    continue;
+                }
+
+                let staging_skill = staging_root.join(&skill_id);
+                let _ = remove_path_if_exists(&staging_skill);
+                match copy_dir_recursive_without_symlinks(&source_path, &staging_skill) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        let _ = remove_path_if_exists(&staging_skill);
+                        skipped.push(json!({
+                            "target_id": target.target_id,
+                            "skill": skill_id,
+                            "source": source_path.display().to_string(),
+                            "reason": "copy-failed",
+                            "error": err.to_string(),
+                        }));
+                        continue;
+                    }
+                }
+
+                if let Err(err) = fs::rename(&staging_skill, &dst) {
+                    cleanup_staging();
+                    rollback_imported_skills(&self.ctx, &imported_rels);
+                    return Err(map_io(err));
+                }
+
+                let skill_rel = format!("skills/{}", skill_id);
+                if let Err(err) = gitops::stage_path(&self.ctx, Path::new(&skill_rel)) {
+                    cleanup_staging();
+                    rollback_imported_skills(&self.ctx, &imported_rels);
+                    rollback_added_skill(&self.ctx, &skill_rel, &dst);
+                    return Err(map_git(err));
+                }
+                imported_rels.push(skill_rel);
+                imported.push(json!({
+                    "target_id": target.target_id,
+                    "skill": skill_id,
+                    "source": source_path.display().to_string(),
+                    "path": dst.display().to_string(),
+                }));
+            }
+        }
+
+        cleanup_staging();
+
+        let mut meta = Meta::default();
+        let mut changed = false;
+        for skill_rel in &imported_rels {
+            match gitops::has_staged_changes_for_path(&self.ctx, Path::new(skill_rel)) {
+                Ok(true) => {
+                    changed = true;
+                    break;
+                }
+                Ok(false) => {}
+                Err(err) => {
+                    rollback_imported_skills(&self.ctx, &imported_rels);
+                    return Err(map_git(err));
+                }
+            }
+        }
+
+        let commit = if changed {
+            let message = match imported.len() {
+                1 => format!(
+                    "import-observed({}): from observed target",
+                    imported[0]["skill"].as_str().unwrap_or("skill")
+                ),
+                count => format!("import-observed: {} skills", count),
+            };
+            let commit = match gitops::commit(&self.ctx, &message) {
+                Ok(commit) => commit,
+                Err(err) => {
+                    rollback_imported_skills(&self.ctx, &imported_rels);
+                    return Err(map_git(err));
+                }
+            };
+            let op_id = record_v3_operation(
+                &paths,
+                "skill.import_observed",
+                json!({
+                    "target": args.target,
+                    "request_id": request_id
+                }),
+                json!({
+                    "commit": commit,
+                    "imported": imported,
+                    "skipped": skipped
+                }),
+            )
+            .map_err(map_v3_state)?;
+            meta.op_id = Some(op_id);
+            maybe_autosync_or_queue(
+                &self.ctx,
+                "import-observed",
+                request_id,
+                json!({"commit": commit, "count": imported.len()}),
+                &mut meta,
+            )?;
+            Some(commit)
+        } else {
+            None
+        };
+
+        Ok((
+            json!({
+                "count": imported.len(),
+                "imported": imported,
+                "skipped": skipped,
+                "commit": commit,
+                "noop": !changed,
+            }),
+            meta,
+        ))
     }
 
     pub fn cmd_project(
@@ -424,5 +664,46 @@ impl App {
         )?;
 
         Ok((json!({"skill": args.skill, "tag": tag}), meta))
+    }
+}
+
+fn observed_import_targets(
+    targets: &[V3ProjectionTarget],
+    args: &ImportObservedArgs,
+) -> std::result::Result<Vec<V3ProjectionTarget>, CommandFailure> {
+    if let Some(target_id) = args.target.as_deref() {
+        let target = targets
+            .iter()
+            .find(|target| target.target_id == target_id)
+            .cloned()
+            .ok_or_else(|| {
+                CommandFailure::new(
+                    ErrorCode::TargetNotFound,
+                    format!("target '{}' not found", target_id),
+                )
+            })?;
+        if target.ownership != "observed" {
+            return Err(CommandFailure::new(
+                ErrorCode::ArgInvalid,
+                format!(
+                    "target '{}' has ownership '{}' and cannot be imported as observed",
+                    target.target_id, target.ownership
+                ),
+            ));
+        }
+        return Ok(vec![target]);
+    }
+
+    Ok(targets
+        .iter()
+        .filter(|target| target.ownership == "observed")
+        .cloned()
+        .collect())
+}
+
+fn rollback_imported_skills(ctx: &crate::state::AppContext, skill_rels: &[String]) {
+    for skill_rel in skill_rels {
+        let dst = ctx.root.join(skill_rel);
+        rollback_added_skill(ctx, skill_rel, &dst);
     }
 }

--- a/tests/import_observed.rs
+++ b/tests/import_observed.rs
@@ -1,0 +1,163 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+mod common;
+
+use common::actions::target_add;
+use common::{TestDir, run_loom, write_file};
+
+fn git_path_exists(root: &Path, path: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .arg("cat-file")
+        .arg("-e")
+        .arg(format!("HEAD:{path}"))
+        .status()
+        .expect("run git cat-file")
+        .success()
+}
+
+fn imported_skill_names(env: &Value) -> Vec<String> {
+    let mut names = env["data"]["imported"]
+        .as_array()
+        .expect("imported array")
+        .iter()
+        .map(|item| item["skill"].as_str().expect("skill name").to_string())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
+fn skipped_reasons(env: &Value) -> Vec<String> {
+    let mut reasons = env["data"]["skipped"]
+        .as_array()
+        .expect("skipped array")
+        .iter()
+        .filter_map(|item| item["reason"].as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    reasons.sort();
+    reasons
+}
+
+#[test]
+fn skill_import_observed_imports_real_skill_dirs_and_commits_them() {
+    let root = TestDir::new("import-observed");
+    let observed = root.path().join("observed-skills");
+    let managed = root.path().join("managed-skills");
+
+    write_file(&observed.join("alpha/SKILL.md"), "# alpha\n");
+    write_file(&observed.join("alpha/nested/config.txt"), "alpha config\n");
+    write_file(&observed.join("beta/SKILL.md"), "# beta\n");
+    write_file(&observed.join("not-a-skill/README.md"), "ignore me\n");
+    write_file(&observed.join("plain-file.txt"), "ignore me\n");
+
+    write_file(&managed.join("managed-only/SKILL.md"), "# managed only\n");
+
+    let (observed_output, observed_env) = target_add(root.path(), "claude", &observed, "observed");
+    assert!(
+        observed_output.status.success(),
+        "target add failed: {}",
+        String::from_utf8_lossy(&observed_output.stderr)
+    );
+    let observed_target_id = observed_env["data"]["target"]["target_id"]
+        .as_str()
+        .expect("observed target id")
+        .to_string();
+
+    let (managed_output, _) = target_add(root.path(), "codex", &managed, "managed");
+    assert!(managed_output.status.success(), "managed target add failed");
+
+    let (import_output, import_env) = run_loom(root.path(), &["skill", "import-observed"]);
+    assert!(
+        import_output.status.success(),
+        "import failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&import_output.stderr),
+        String::from_utf8_lossy(&import_output.stdout)
+    );
+
+    assert_eq!(import_env["ok"], Value::Bool(true));
+    assert_eq!(
+        import_env["cmd"],
+        Value::String("skill.import_observed".into())
+    );
+    assert_eq!(import_env["data"]["count"], Value::from(2));
+    assert_eq!(imported_skill_names(&import_env), vec!["alpha", "beta"]);
+    assert_eq!(
+        import_env["meta"]["op_id"]
+            .as_str()
+            .map(|op_id| op_id.starts_with("op_")),
+        Some(true)
+    );
+
+    assert_eq!(
+        fs::read_to_string(root.path().join("skills/alpha/SKILL.md")).expect("read alpha"),
+        "# alpha\n"
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("skills/alpha/nested/config.txt"))
+            .expect("read alpha nested"),
+        "alpha config\n"
+    );
+    assert!(root.path().join("skills/beta/SKILL.md").is_file());
+    assert!(!root.path().join("skills/not-a-skill").exists());
+    assert!(!root.path().join("skills/managed-only").exists());
+
+    assert!(git_path_exists(root.path(), "skills/alpha/SKILL.md"));
+    assert!(git_path_exists(
+        root.path(),
+        "skills/alpha/nested/config.txt"
+    ));
+    assert!(git_path_exists(root.path(), "skills/beta/SKILL.md"));
+
+    let (repeat_output, repeat_env) = run_loom(
+        root.path(),
+        &["skill", "import-observed", "--target", &observed_target_id],
+    );
+    assert!(
+        repeat_output.status.success(),
+        "repeat import failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&repeat_output.stderr),
+        String::from_utf8_lossy(&repeat_output.stdout)
+    );
+    assert_eq!(repeat_env["data"]["count"], Value::from(0));
+    assert_eq!(
+        skipped_reasons(&repeat_env),
+        vec!["already-exists", "already-exists"]
+    );
+    assert_eq!(repeat_env["data"]["noop"], Value::Bool(true));
+}
+
+#[test]
+fn skill_import_observed_rejects_non_observed_target_filter() {
+    let root = TestDir::new("import-observed-managed-target");
+    let managed = root.path().join("managed-skills");
+    write_file(&managed.join("managed-only/SKILL.md"), "# managed only\n");
+
+    let (target_output, target_env) = target_add(root.path(), "codex", &managed, "managed");
+    assert!(target_output.status.success(), "managed target add failed");
+    let target_id = target_env["data"]["target"]["target_id"]
+        .as_str()
+        .expect("target id");
+
+    let (output, env) = run_loom(
+        root.path(),
+        &["skill", "import-observed", "--target", target_id],
+    );
+
+    assert!(
+        !output.status.success(),
+        "managed target unexpectedly imported"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        env["error"]["code"],
+        Value::String("ARG_INVALID".to_string())
+    );
+    assert!(!root.path().join("skills/managed-only").exists());
+}


### PR DESCRIPTION
## Summary

Closes #51.

This adds an explicit `loom skill import-observed` bridge from registered observed targets into the canonical source registry. The command scans observed target directories, imports only child directories that contain `SKILL.md`, writes them under `skills/<skill-id>/`, stages and commits those canonical skill files, and skips existing registry skills instead of overwriting them.

The intent is to make registry remotes useful: after discovery, users can explicitly import actual skill contents so `sync push` carries recoverable `skills/<name>/...` content instead of only target/control-plane metadata.

## Details

- Added CLI surface and command dispatch for `skill import-observed [--target <target-id>]`.
- Restricted `--target` to observed targets and ignored managed/external targets during bulk import.
- Ignored non-skill child directories without `SKILL.md`.
- Skipped invalid, unreadable, symlink-containing, or already-existing skills with structured reasons.
- Updated the v3 CLI contract to document the explicit import-observed command separately from the removed legacy `skill import`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test import_observed -- --nocapture`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`