### PR TITLE
feat(skill): materialize observed symlink imports

### DIFF
--- a/docs/LOOM_V3_CLI_CONTRACT.md
+++ b/docs/LOOM_V3_CLI_CONTRACT.md
@@ -348,10 +348,11 @@ Write command.
 Rules:
 
 1. imports real skill directories from observed targets into canonical `skills/<skill-id>`
-2. only directories containing `SKILL.md` are treated as skills
-3. existing canonical skills are skipped, not overwritten
-4. `--target` must reference an observed target when supplied
-5. this is not the removed legacy `skill import` command; it is an explicit bridge from discovered observed targets into the source registry
+2. top-level symlinks to skill directories are materialized into canonical `skills/<skill-id>` as real files
+3. only directories containing `SKILL.md` or `skill.md` are treated as skills
+4. existing canonical skills are skipped, not overwritten
+5. `--target` must reference an observed target when supplied
+6. this is not the removed legacy `skill import` command; it is an explicit bridge from discovered observed targets into the source registry
 
 ### 11.3 `skill project`
 

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -483,10 +483,16 @@ impl App {
                         continue;
                     }
                 };
-                if !file_type.is_dir() || file_type.is_symlink() {
-                    continue;
-                }
-                if !source_path.join("SKILL.md").is_file() {
+                let (copy_source, source_kind, resolved_source) = match observed_skill_copy_source(
+                    &source_path,
+                    &file_type,
+                    &mut skipped,
+                    &target,
+                ) {
+                    Some(source) => source,
+                    None => continue,
+                };
+                if !has_skill_entrypoint(&copy_source) {
                     continue;
                 }
 
@@ -527,7 +533,7 @@ impl App {
 
                 let staging_skill = staging_root.join(&skill_id);
                 let _ = remove_path_if_exists(&staging_skill);
-                match copy_dir_recursive_without_symlinks(&source_path, &staging_skill) {
+                match copy_dir_recursive_without_symlinks(&copy_source, &staging_skill) {
                     Ok(()) => {}
                     Err(err) => {
                         let _ = remove_path_if_exists(&staging_skill);
@@ -556,12 +562,17 @@ impl App {
                     return Err(map_git(err));
                 }
                 imported_rels.push(skill_rel);
-                imported.push(json!({
+                let mut imported_item = json!({
                     "target_id": target.target_id,
                     "skill": skill_id,
                     "source": source_path.display().to_string(),
+                    "source_kind": source_kind,
                     "path": dst.display().to_string(),
-                }));
+                });
+                if let Some(resolved_source) = resolved_source {
+                    imported_item["resolved_source"] = json!(resolved_source);
+                }
+                imported.push(imported_item);
             }
         }
 
@@ -699,6 +710,56 @@ fn observed_import_targets(
         .filter(|target| target.ownership == "observed")
         .cloned()
         .collect())
+}
+
+fn observed_skill_copy_source(
+    source_path: &Path,
+    file_type: &fs::FileType,
+    skipped: &mut Vec<serde_json::Value>,
+    target: &V3ProjectionTarget,
+) -> Option<(PathBuf, &'static str, Option<String>)> {
+    if file_type.is_dir() {
+        return Some((source_path.to_path_buf(), "directory", None));
+    }
+    if !file_type.is_symlink() {
+        return None;
+    }
+
+    let metadata = match fs::metadata(source_path) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            skipped.push(json!({
+                "target_id": target.target_id.clone(),
+                "source": source_path.display().to_string(),
+                "reason": "symlink-target-failed",
+                "error": err.to_string(),
+            }));
+            return None;
+        }
+    };
+    if !metadata.is_dir() {
+        return None;
+    }
+
+    match fs::canonicalize(source_path) {
+        Ok(resolved) => {
+            let display = resolved.display().to_string();
+            Some((resolved, "symlink", Some(display)))
+        }
+        Err(err) => {
+            skipped.push(json!({
+                "target_id": target.target_id.clone(),
+                "source": source_path.display().to_string(),
+                "reason": "symlink-resolve-failed",
+                "error": err.to_string(),
+            }));
+            None
+        }
+    }
+}
+
+fn has_skill_entrypoint(path: &Path) -> bool {
+    path.join("SKILL.md").is_file() || path.join("skill.md").is_file()
 }
 
 fn rollback_imported_skills(ctx: &crate::state::AppContext, skill_rels: &[String]) {

--- a/tests/import_observed.rs
+++ b/tests/import_observed.rs
@@ -9,6 +9,11 @@ use serde_json::Value;
 use common::actions::target_add;
 use common::{TestDir, run_loom, write_file};
 
+#[cfg(unix)]
+fn symlink_dir(src: &Path, dst: &Path) {
+    std::os::unix::fs::symlink(src, dst).expect("create symlink dir");
+}
+
 fn git_path_exists(root: &Path, path: &str) -> bool {
     Command::new("git")
         .arg("-C")
@@ -131,6 +136,72 @@ fn skill_import_observed_imports_real_skill_dirs_and_commits_them() {
         vec!["already-exists", "already-exists"]
     );
     assert_eq!(repeat_env["data"]["noop"], Value::Bool(true));
+}
+
+#[test]
+#[cfg(unix)]
+fn skill_import_observed_materializes_top_level_symlinked_skill_dirs() {
+    let root = TestDir::new("import-observed-symlink");
+    let observed = root.path().join("observed-skills");
+    let linked_source = root.path().join("linked-source");
+
+    fs::create_dir_all(&observed).expect("create observed dir");
+    write_file(&linked_source.join("skill.md"), "# linked\n");
+    write_file(&linked_source.join("nested/config.txt"), "linked config\n");
+    symlink_dir(&linked_source, &observed.join("linked-skill"));
+
+    let (target_output, _) = target_add(root.path(), "claude", &observed, "observed");
+    assert!(
+        target_output.status.success(),
+        "target add failed: {}",
+        String::from_utf8_lossy(&target_output.stderr)
+    );
+
+    let (import_output, import_env) = run_loom(root.path(), &["skill", "import-observed"]);
+    assert!(
+        import_output.status.success(),
+        "import failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&import_output.stderr),
+        String::from_utf8_lossy(&import_output.stdout)
+    );
+
+    assert_eq!(import_env["data"]["count"], Value::from(1));
+    assert_eq!(imported_skill_names(&import_env), vec!["linked-skill"]);
+    assert_eq!(
+        import_env["data"]["imported"][0]["source_kind"],
+        Value::String("symlink".to_string())
+    );
+    assert_eq!(
+        import_env["data"]["imported"][0]["resolved_source"],
+        Value::String(
+            fs::canonicalize(&linked_source)
+                .expect("canonical linked source")
+                .display()
+                .to_string()
+        )
+    );
+
+    let imported_path = root.path().join("skills/linked-skill");
+    assert!(
+        !fs::symlink_metadata(&imported_path)
+            .expect("imported path metadata")
+            .file_type()
+            .is_symlink(),
+        "registry skill should be materialized as a real directory"
+    );
+    assert_eq!(
+        fs::read_to_string(imported_path.join("skill.md")).expect("read linked skill"),
+        "# linked\n"
+    );
+    assert_eq!(
+        fs::read_to_string(imported_path.join("nested/config.txt")).expect("read nested config"),
+        "linked config\n"
+    );
+    assert!(git_path_exists(root.path(), "skills/linked-skill/skill.md"));
+    assert!(git_path_exists(
+        root.path(),
+        "skills/linked-skill/nested/config.txt"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make `skill import-observed` import top-level symlinks to skill directories by resolving and materializing their targets into canonical `skills/<skill-id>`
- include `source_kind` and `resolved_source` metadata for imported symlink skills
- accept `SKILL.md` and `skill.md` as observed skill entrypoints
- document the symlink materialization behavior in the v3 CLI contract

Fixes #54

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -q --test import_observed`
- `cargo test -q`
- `make lint`