### PR TITLE
test(panel): cover remote and pending read failures

### DIFF
--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -12,6 +12,43 @@ function jsonResponse(body: unknown): Response {
   } as unknown as Response;
 }
 
+function errorResponse(status: number, body: unknown): Response {
+  return {
+    ok: false,
+    status,
+    statusText: "Service Unavailable",
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function installFetchMock(failingPath: string, failingResponse: Response) {
+  fetchMock.mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    switch (url) {
+      case "/api/health":
+        return Promise.resolve(jsonResponse({ ok: true }));
+      case "/api/info":
+        return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
+      case "/api/skills":
+        return Promise.resolve(jsonResponse({ skills: ["typed-api-client"] }));
+      case "/api/v3/status":
+        return Promise.resolve(
+          url === failingPath
+            ? failingResponse
+            : jsonResponse({ ok: true, data: { counts: {}, projections: [], rules: [], targets: [], bindings: [] } }),
+        );
+      case "/api/remote/status":
+        return Promise.resolve(
+          url === failingPath ? failingResponse : jsonResponse({ remote: { sync_state: "CLEAN" }, warnings: [] }),
+        );
+      case "/api/pending":
+        return Promise.resolve(url === failingPath ? failingResponse : jsonResponse({ count: 0, ops: [] }));
+      default:
+        return Promise.reject(new Error(`unexpected fetch ${url}`));
+    }
+  });
+}
+
 describe("PanelApp status failure UI", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", fetchMock);
@@ -26,30 +63,15 @@ describe("PanelApp status failure UI", () => {
   });
 
   it("shows registry error state and offline banner when /api/v3/status fails", async () => {
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      switch (url) {
-        case "/api/health":
-          return Promise.resolve(jsonResponse({ ok: true }));
-        case "/api/info":
-          return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
-        case "/api/skills":
-          return Promise.resolve(jsonResponse({ skills: ["typed-api-client"] }));
-        case "/api/v3/status":
-          return Promise.resolve({
-            ok: false,
-            status: 503,
-            statusText: "Service Unavailable",
-            json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token < in JSON at position 0")),
-          } as unknown as Response);
-        case "/api/remote/status":
-          return Promise.resolve(jsonResponse({ remote: { sync_state: "CLEAN" } }));
-        case "/api/pending":
-          return Promise.resolve(jsonResponse({ count: 0, ops: [] }));
-        default:
-          return Promise.reject(new Error(`unexpected fetch ${url}`));
-      }
-    });
+    installFetchMock(
+      "/api/v3/status",
+      {
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token < in JSON at position 0")),
+      } as unknown as Response,
+    );
 
     render(<PanelApp />);
 
@@ -60,5 +82,41 @@ describe("PanelApp status failure UI", () => {
     });
 
     expect(screen.getByText(/GET \/api\/v3\/status returned 503/i)).toBeTruthy();
+  });
+
+  it("shows registry error state when /api/remote/status returns a structured backend failure", async () => {
+    installFetchMock(
+      "/api/remote/status",
+      errorResponse(500, {
+        ok: false,
+        error: { code: "IO_ERROR", message: "failed to read pending_ops.jsonl" },
+      }),
+    );
+
+    render(<PanelApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/registry error/i)).toBeTruthy();
+    });
+
+    expect(screen.getByText(/failed to read pending_ops\.jsonl/i)).toBeTruthy();
+  });
+
+  it("shows registry error state when /api/pending returns a structured backend failure", async () => {
+    installFetchMock(
+      "/api/pending",
+      errorResponse(500, {
+        ok: false,
+        error: { code: "IO_ERROR", message: "failed to read pending queue" },
+      }),
+    );
+
+    render(<PanelApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/registry error/i)).toBeTruthy();
+    });
+
+    expect(screen.getByText(/failed to read pending queue/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Signal report
- `src/panel/handlers.rs` already returns non-2xx plus `ok:false` for `remote_status` and `pending` failures on current `main`.
- `panel/src/lib/api/client.ts` already rejects both non-2xx GET responses and `ok:false` envelopes, which is what `usePanelData` relies on to enter the degraded path.
- The remaining regression risk was missing UI coverage for `/api/remote/status` and `/api/pending`; only `/api/v3/status` had an explicit degraded-state test.

## Change
- Added `PanelApp` regression tests that force structured backend failures from `/api/remote/status` and `/api/pending` and assert the app surfaces the registry error state.
- Refactored the existing fetch mock setup in that test file so all three degraded-state cases share the same fixture path.

## Validation
- `npm test -- PanelApp.test.tsx`
- `npm run typecheck`
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`