### PR TITLE
[codex] Fix command audit and rollback mutations

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde::Serialize;
 
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, Parser, Serialize)]
 #[command(name = "loom")]
 #[command(about = "Loom - Skill manager with Git-native backend")]
 pub struct Cli {
@@ -19,7 +20,7 @@ pub struct Cli {
     pub command: Command,
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum Command {
     #[command(about = "Inspect and configure registry workspace state")]
     Workspace {
@@ -50,7 +51,7 @@ pub enum Command {
     Panel(PanelArgs),
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum WorkspaceCommand {
     #[command(about = "Show registry status, targets, Git state, and pending ops")]
     Status,
@@ -70,7 +71,7 @@ pub enum WorkspaceCommand {
     },
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct WorkspaceInitArgs {
     /// Also scan default agent skill directories (~/.claude/skills,
     /// ~/.codex/skills) and auto-register any that exist as observed
@@ -79,7 +80,7 @@ pub struct WorkspaceInitArgs {
     pub scan_existing: bool,
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum WorkspaceBindingCommand {
     #[command(about = "Create a binding from a workspace matcher to a target")]
     Add(BindingAddArgs),
@@ -91,7 +92,7 @@ pub enum WorkspaceBindingCommand {
     Remove(BindingShowArgs),
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum TargetCommand {
     #[command(about = "Register an agent skill directory as a target")]
     Add(TargetAddArgs),
@@ -103,7 +104,7 @@ pub enum TargetCommand {
     Remove(TargetShowArgs),
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SkillCommand {
     #[command(about = "Import a skill source into the registry")]
     Add(AddArgs),
@@ -128,19 +129,19 @@ pub enum SkillCommand {
     },
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SkillOrphanCommand {
     Clean(OrphanCleanArgs),
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct OrphanCleanArgs {
     /// Also delete validated live projection directories.
     #[arg(long)]
     pub delete_live_paths: bool,
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum OpsCommand {
     #[command(about = "List pending operations")]
     List,
@@ -155,7 +156,7 @@ pub enum OpsCommand {
     },
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum OpsHistoryCommand {
     #[command(about = "Report local and remote operation-history health")]
     Diagnose,
@@ -163,19 +164,19 @@ pub enum OpsHistoryCommand {
     Repair(HistoryRepairArgs),
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct HistoryRepairArgs {
     #[arg(long, value_enum)]
     pub strategy: HistoryRepairStrategyArg,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize)]
 pub enum HistoryRepairStrategyArg {
     Local,
     Remote,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct AddArgs {
     pub source: String,
 
@@ -183,7 +184,7 @@ pub struct AddArgs {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct ProjectArgs {
     pub skill: String,
 
@@ -197,7 +198,7 @@ pub struct ProjectArgs {
     pub method: ProjectionMethod,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct CaptureArgs {
     pub skill: Option<String>,
 
@@ -211,7 +212,7 @@ pub struct CaptureArgs {
     pub message: Option<String>,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct SaveArgs {
     pub skill: String,
 
@@ -219,18 +220,18 @@ pub struct SaveArgs {
     pub message: Option<String>,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct SkillOnlyArgs {
     pub skill: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct ReleaseArgs {
     pub skill: String,
     pub version: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct RollbackArgs {
     pub skill: String,
 
@@ -241,31 +242,31 @@ pub struct RollbackArgs {
     pub steps: Option<u32>,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct DiffArgs {
     pub skill: String,
     pub from: String,
     pub to: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct ImportObservedArgs {
     #[arg(long)]
     pub target: Option<String>,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct PanelArgs {
     #[arg(long, default_value_t = 43117)]
     pub port: u16,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct BindingShowArgs {
     pub binding_id: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct BindingAddArgs {
     #[arg(long, value_enum)]
     pub agent: AgentKind,
@@ -286,12 +287,12 @@ pub struct BindingAddArgs {
     pub policy_profile: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct TargetShowArgs {
     pub target_id: String,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Serialize)]
 pub struct TargetAddArgs {
     #[arg(long, value_enum)]
     pub agent: AgentKind,
@@ -303,7 +304,7 @@ pub struct TargetAddArgs {
     pub ownership: TargetOwnership,
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum RemoteCommand {
     #[command(about = "Set the registry Git remote URL")]
     Set { url: String },
@@ -311,7 +312,7 @@ pub enum RemoteCommand {
     Status,
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SyncCommand {
     #[command(about = "Show Git sync state")]
     Status,

--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -1,0 +1,143 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::cli::Cli;
+use crate::envelope::Envelope;
+use crate::state::AppContext;
+
+#[derive(Debug, Serialize)]
+struct CommandEvent {
+    event_id: String,
+    request_id: String,
+    cmd: String,
+    status: String,
+    exit_code: i32,
+    input: serde_json::Value,
+    output: serde_json::Value,
+    error: serde_json::Value,
+    side_effects: serde_json::Value,
+    created_at: DateTime<Utc>,
+}
+
+pub(crate) fn command_event_input(cli: &Cli) -> serde_json::Value {
+    let mut input = serde_json::to_value(cli).unwrap_or_else(|err| {
+        json!({
+            "serialization_error": err.to_string(),
+            "command": format!("{:?}", cli.command),
+            "json": cli.json,
+            "root": cli.root.as_ref().map(|root| root.display().to_string()),
+        })
+    });
+    redact_sensitive_strings(&mut input);
+    input
+}
+
+pub(crate) fn append_command_event(
+    ctx: &AppContext,
+    cmd: &str,
+    input: serde_json::Value,
+    envelope: &Envelope,
+    exit_code: i32,
+) -> Result<()> {
+    let event = CommandEvent {
+        event_id: format!("evt_{}", Uuid::new_v4().simple()),
+        request_id: envelope.request_id.clone(),
+        cmd: cmd.to_string(),
+        status: if envelope.ok {
+            "succeeded".to_string()
+        } else {
+            "failed".to_string()
+        },
+        exit_code,
+        input,
+        output: envelope.data.clone(),
+        error: envelope
+            .error
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?
+            .unwrap_or(serde_json::Value::Null),
+        side_effects: serde_json::to_value(&envelope.meta)?,
+        created_at: Utc::now(),
+    };
+
+    let path = ctx.state_dir.join("events/commands.jsonl");
+    let parent = path
+        .parent()
+        .context("command event path must have a parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create command event dir {}", parent.display()))?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("failed to open command event log {}", path.display()))?;
+    let raw = serde_json::to_string(&event).context("failed to encode command event")?;
+    writeln!(file, "{raw}")
+        .with_context(|| format!("failed to append command event {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync command event {}", path.display()))?;
+    Ok(())
+}
+
+fn redact_sensitive_strings(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(raw) => {
+            *raw = redact_url_userinfo(raw);
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                redact_sensitive_strings(item);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            for value in fields.values_mut() {
+                redact_sensitive_strings(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_url_userinfo(raw: &str) -> String {
+    let Some(scheme_end) = raw.find("://") else {
+        return raw.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let rest = &raw[authority_start..];
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let Some(at) = authority.rfind('@') else {
+        return raw.to_string();
+    };
+
+    format!(
+        "{}://<redacted>@{}{}",
+        &raw[..scheme_end],
+        &authority[at + 1..],
+        &rest[authority_end..]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_url_userinfo;
+
+    #[test]
+    fn redacts_url_userinfo_without_changing_plain_urls() {
+        assert_eq!(
+            redact_url_userinfo("https://token@example.com/org/repo.git"),
+            "https://<redacted>@example.com/org/repo.git"
+        );
+        assert_eq!(
+            redact_url_userinfo("https://example.com/org/repo.git"),
+            "https://example.com/org/repo.git"
+        );
+    }
+}

--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -73,6 +73,31 @@ pub(crate) fn append_command_finished(
     envelope: &Envelope,
     exit_code: i32,
 ) -> Result<()> {
+    append_command_finished_with_fault_tags(
+        ctx,
+        cmd,
+        envelope,
+        exit_code,
+        &["command_event_append_finished", "command_event_append"],
+    )
+}
+
+pub(crate) fn append_command_audit_failure(
+    ctx: &AppContext,
+    cmd: &str,
+    envelope: &Envelope,
+    exit_code: i32,
+) -> Result<()> {
+    append_command_finished_with_fault_tags(ctx, cmd, envelope, exit_code, &[])
+}
+
+fn append_command_finished_with_fault_tags(
+    ctx: &AppContext,
+    cmd: &str,
+    envelope: &Envelope,
+    exit_code: i32,
+    fault_tags: &[&str],
+) -> Result<()> {
     let event = CommandEvent {
         event_id: format!("evt_{}", Uuid::new_v4().simple()),
         request_id: envelope.request_id.clone(),
@@ -84,20 +109,17 @@ pub(crate) fn append_command_finished(
         },
         exit_code: Some(exit_code),
         input: None,
-        output: Some(envelope.data.clone()),
+        output: Some(redacted_value(envelope.data.clone())),
         error: envelope
             .error
             .as_ref()
             .map(serde_json::to_value)
-            .transpose()?,
-        side_effects: Some(serde_json::to_value(&envelope.meta)?),
+            .transpose()?
+            .map(redacted_value),
+        side_effects: Some(redacted_value(serde_json::to_value(&envelope.meta)?)),
         created_at: Utc::now(),
     };
-    append_command_event(
-        ctx,
-        &event,
-        &["command_event_append_finished", "command_event_append"],
-    )
+    append_command_event(ctx, &event, fault_tags)
 }
 
 fn append_command_event(ctx: &AppContext, event: &CommandEvent, fault_tags: &[&str]) -> Result<()> {
@@ -150,7 +172,7 @@ fn maybe_fault_inject(tags: &[&str]) -> Result<()> {
 fn redact_sensitive_strings(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::String(raw) => {
-            *raw = redact_url_userinfo(raw);
+            *raw = redact_sensitive_string(raw);
         }
         serde_json::Value::Array(items) => {
             for item in items {
@@ -158,12 +180,28 @@ fn redact_sensitive_strings(value: &mut serde_json::Value) {
             }
         }
         serde_json::Value::Object(fields) => {
-            for value in fields.values_mut() {
-                redact_sensitive_strings(value);
+            for (key, value) in fields.iter_mut() {
+                if key_is_sensitive(key) {
+                    *value = serde_json::Value::String("<redacted>".to_string());
+                } else {
+                    redact_sensitive_strings(value);
+                }
             }
         }
         _ => {}
     }
+}
+
+fn redact_sensitive_string(raw: &str) -> String {
+    if looks_like_secret(raw) {
+        return "<redacted>".to_string();
+    }
+    redact_url_sensitive_parts(&redact_url_userinfo(raw))
+}
+
+fn redacted_value(mut value: serde_json::Value) -> serde_json::Value {
+    redact_sensitive_strings(&mut value);
+    value
 }
 
 fn redact_url_userinfo(raw: &str) -> String {
@@ -186,9 +224,98 @@ fn redact_url_userinfo(raw: &str) -> String {
     )
 }
 
+fn redact_url_sensitive_parts(raw: &str) -> String {
+    if raw.find("://").is_none() {
+        return raw.to_string();
+    }
+
+    let (without_fragment, fragment) = match raw.split_once('#') {
+        Some((base, fragment)) => (base, Some(fragment)),
+        None => (raw, None),
+    };
+    let (base, query) = match without_fragment.split_once('?') {
+        Some((base, query)) => (base, Some(query)),
+        None => (without_fragment, None),
+    };
+
+    let mut redacted = base.to_string();
+    if let Some(query) = query {
+        redacted.push('?');
+        redacted.push_str(&redact_query(query));
+    }
+    if let Some(fragment) = fragment {
+        redacted.push('#');
+        if fragment.is_empty() {
+            redacted.push_str(fragment);
+        } else {
+            redacted.push_str("<redacted>");
+        }
+    }
+    redacted
+}
+
+fn redact_query(query: &str) -> String {
+    query
+        .split('&')
+        .map(|part| {
+            let Some((key, value)) = part.split_once('=') else {
+                return if looks_like_secret(part) {
+                    "<redacted>".to_string()
+                } else {
+                    part.to_string()
+                };
+            };
+            if key_is_sensitive(key) || looks_like_secret(value) {
+                format!("{key}=<redacted>")
+            } else {
+                part.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn key_is_sensitive(key: &str) -> bool {
+    let normalized = key
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    [
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "credential",
+        "authorization",
+        "apikey",
+        "accesskey",
+        "privatekey",
+        "signature",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn looks_like_secret(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    trimmed.starts_with("Bearer ")
+        || trimmed.starts_with("ghp_")
+        || trimmed.starts_with("github_pat_")
+        || trimmed.starts_with("glpat-")
+        || trimmed.starts_with("sk-")
+        || trimmed.starts_with("xoxb-")
+        || trimmed.starts_with("xoxp-")
+        || trimmed.starts_with("xoxa-")
+        || trimmed.starts_with("ya29.")
+        || (trimmed.starts_with("AKIA") && trimmed.len() >= 20)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::redact_url_userinfo;
+    use serde_json::json;
+
+    use super::{redact_sensitive_string, redact_sensitive_strings, redact_url_userinfo};
 
     #[test]
     fn redacts_url_userinfo_without_changing_plain_urls() {
@@ -200,5 +327,41 @@ mod tests {
             redact_url_userinfo("https://example.com/org/repo.git"),
             "https://example.com/org/repo.git"
         );
+    }
+
+    #[test]
+    fn redacts_url_query_fragments_and_token_like_values() {
+        assert_eq!(
+            redact_sensitive_string(
+                "https://user:pass@example.com/org/repo.git?access_token=ghp_secret&ref=main#ghp_fragment"
+            ),
+            "https://<redacted>@example.com/org/repo.git?access_token=<redacted>&ref=main#<redacted>"
+        );
+        assert_eq!(
+            redact_sensitive_string("github_pat_abcdefghijklmnopqrstuvwxyz1234567890"),
+            "<redacted>"
+        );
+    }
+
+    #[test]
+    fn redacts_sensitive_object_fields() {
+        let mut value = json!({
+            "source": "https://example.com/repo.git?token=secret&ref=main",
+            "api_key": "sk-secret",
+            "nested": {
+                "password": "p@ssw0rd",
+                "plain": "visible"
+            }
+        });
+
+        redact_sensitive_strings(&mut value);
+
+        assert_eq!(
+            value["source"],
+            json!("https://example.com/repo.git?token=<redacted>&ref=main")
+        );
+        assert_eq!(value["api_key"], json!("<redacted>"));
+        assert_eq!(value["nested"]["password"], json!("<redacted>"));
+        assert_eq!(value["nested"]["plain"], json!("visible"));
     }
 }

--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -45,6 +45,7 @@ pub(crate) fn append_command_event(
     envelope: &Envelope,
     exit_code: i32,
 ) -> Result<()> {
+    maybe_fault_inject("command_event_append")?;
     let event = CommandEvent {
         event_id: format!("evt_{}", Uuid::new_v4().simple()),
         request_id: envelope.request_id.clone(),
@@ -83,6 +84,31 @@ pub(crate) fn append_command_event(
         .with_context(|| format!("failed to append command event {}", path.display()))?;
     file.sync_all()
         .with_context(|| format!("failed to sync command event {}", path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn prepare_command_event_store(ctx: &AppContext) -> Result<()> {
+    maybe_fault_inject("command_event_prepare")?;
+    let path = ctx.state_dir.join("events/commands.jsonl");
+    let parent = path
+        .parent()
+        .context("command event path must have a parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create command event dir {}", parent.display()))?;
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("failed to open command event log {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync command event {}", path.display()))?;
+    Ok(())
+}
+
+fn maybe_fault_inject(tag: &str) -> Result<()> {
+    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
+        return Err(anyhow::anyhow!("fault injected at {}", tag));
+    }
     Ok(())
 }
 

--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -17,18 +17,26 @@ struct CommandEvent {
     request_id: String,
     cmd: String,
     status: String,
-    exit_code: i32,
-    input: serde_json::Value,
-    output: serde_json::Value,
-    error: serde_json::Value,
-    side_effects: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    side_effects: Option<serde_json::Value>,
     created_at: DateTime<Utc>,
 }
 
-pub(crate) fn command_event_input(cli: &Cli) -> serde_json::Value {
-    let mut input = serde_json::to_value(cli).unwrap_or_else(|err| {
+pub(crate) fn command_event_input(cli: &Cli, request_id: &str) -> serde_json::Value {
+    let mut audit_cli = cli.clone();
+    audit_cli.request_id = Some(request_id.to_string());
+    let mut input = serde_json::to_value(audit_cli).unwrap_or_else(|err| {
         json!({
             "serialization_error": err.to_string(),
+            "request_id": request_id,
             "command": format!("{:?}", cli.command),
             "json": cli.json,
             "root": cli.root.as_ref().map(|root| root.display().to_string()),
@@ -38,14 +46,33 @@ pub(crate) fn command_event_input(cli: &Cli) -> serde_json::Value {
     input
 }
 
-pub(crate) fn append_command_event(
+pub(crate) fn append_command_started(
     ctx: &AppContext,
     cmd: &str,
     input: serde_json::Value,
+    request_id: &str,
+) -> Result<()> {
+    let event = CommandEvent {
+        event_id: format!("evt_{}", Uuid::new_v4().simple()),
+        request_id: request_id.to_string(),
+        cmd: cmd.to_string(),
+        status: "started".to_string(),
+        exit_code: None,
+        input: Some(input),
+        output: None,
+        error: None,
+        side_effects: None,
+        created_at: Utc::now(),
+    };
+    append_command_event(ctx, &event, &["command_event_append_started"])
+}
+
+pub(crate) fn append_command_finished(
+    ctx: &AppContext,
+    cmd: &str,
     envelope: &Envelope,
     exit_code: i32,
 ) -> Result<()> {
-    maybe_fault_inject("command_event_append")?;
     let event = CommandEvent {
         event_id: format!("evt_{}", Uuid::new_v4().simple()),
         request_id: envelope.request_id.clone(),
@@ -55,19 +82,26 @@ pub(crate) fn append_command_event(
         } else {
             "failed".to_string()
         },
-        exit_code,
-        input,
-        output: envelope.data.clone(),
+        exit_code: Some(exit_code),
+        input: None,
+        output: Some(envelope.data.clone()),
         error: envelope
             .error
             .as_ref()
             .map(serde_json::to_value)
-            .transpose()?
-            .unwrap_or(serde_json::Value::Null),
-        side_effects: serde_json::to_value(&envelope.meta)?,
+            .transpose()?,
+        side_effects: Some(serde_json::to_value(&envelope.meta)?),
         created_at: Utc::now(),
     };
+    append_command_event(
+        ctx,
+        &event,
+        &["command_event_append_finished", "command_event_append"],
+    )
+}
 
+fn append_command_event(ctx: &AppContext, event: &CommandEvent, fault_tags: &[&str]) -> Result<()> {
+    maybe_fault_inject(fault_tags)?;
     let path = ctx.state_dir.join("events/commands.jsonl");
     let parent = path
         .parent()
@@ -79,7 +113,7 @@ pub(crate) fn append_command_event(
         .append(true)
         .open(&path)
         .with_context(|| format!("failed to open command event log {}", path.display()))?;
-    let raw = serde_json::to_string(&event).context("failed to encode command event")?;
+    let raw = serde_json::to_string(event).context("failed to encode command event")?;
     writeln!(file, "{raw}")
         .with_context(|| format!("failed to append command event {}", path.display()))?;
     file.sync_all()
@@ -88,7 +122,7 @@ pub(crate) fn append_command_event(
 }
 
 pub(crate) fn prepare_command_event_store(ctx: &AppContext) -> Result<()> {
-    maybe_fault_inject("command_event_prepare")?;
+    maybe_fault_inject(&["command_event_prepare"])?;
     let path = ctx.state_dir.join("events/commands.jsonl");
     let parent = path
         .parent()
@@ -105,8 +139,9 @@ pub(crate) fn prepare_command_event_store(ctx: &AppContext) -> Result<()> {
     Ok(())
 }
 
-fn maybe_fault_inject(tag: &str) -> Result<()> {
-    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
+fn maybe_fault_inject(tags: &[&str]) -> Result<()> {
+    let active = std::env::var("LOOM_FAULT_INJECT").ok();
+    if let Some(tag) = active.as_deref().filter(|tag| tags.contains(tag)) {
         return Err(anyhow::anyhow!("fault injected at {}", tag));
     }
     Ok(())

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -40,6 +40,40 @@ pub(crate) fn rollback_added_skill(ctx: &AppContext, skill_rel: &str, dst: &Path
     let _ = gitops::run_git_allow_failure(ctx, &["reset", "HEAD", "--", skill_rel]);
 }
 
+pub(crate) fn restore_path_from_backup(path: &Path, backup: &serde_json::Value) -> Result<()> {
+    let backup_path = backup
+        .get("backup_path")
+        .and_then(serde_json::Value::as_str)
+        .map(Path::new)
+        .ok_or_else(|| anyhow!("backup record missing backup_path"))?;
+    let kind = backup
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("backup record missing kind"))?;
+
+    remove_path_if_exists(path)?;
+    match kind {
+        "dir" => copy_dir_recursive(backup_path, path),
+        "file" => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!("failed to create restore parent {}", parent.display())
+                })?;
+            }
+            fs::copy(backup_path, path).with_context(|| {
+                format!(
+                    "failed to restore file backup {} to {}",
+                    backup_path.display(),
+                    path.display()
+                )
+            })?;
+            Ok(())
+        }
+        "symlink" => restore_symlink_backup(backup_path, path),
+        other => Err(anyhow!("unsupported backup kind '{}'", other)),
+    }
+}
+
 pub(crate) fn backup_path_if_exists(
     ctx: &AppContext,
     path: &Path,
@@ -118,6 +152,26 @@ fn backup_symlink_metadata(src: &Path, dst: &Path) -> Result<()> {
         )
     })?;
     Ok(())
+}
+
+fn restore_symlink_backup(backup_path: &Path, dst: &Path) -> Result<()> {
+    let raw = fs::read_to_string(backup_path.join("symlink.json")).with_context(|| {
+        format!(
+            "failed to read symlink backup metadata under {}",
+            backup_path.display()
+        )
+    })?;
+    let payload: serde_json::Value =
+        serde_json::from_str(&raw).context("failed to parse symlink backup metadata")?;
+    let target = payload
+        .get("target")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("symlink backup missing target"))?;
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create restore parent {}", parent.display()))?;
+    }
+    create_symlink_dir(Path::new(target), dst)
 }
 
 pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -17,7 +17,7 @@ use super::CommandFailure;
 // Re-export items from sibling modules so existing `use super::helpers::*` paths keep working.
 pub(crate) use super::file_ops::{
     backup_path_if_exists, copy_dir_recursive, copy_dir_recursive_without_symlinks, read_git_field,
-    rollback_added_skill,
+    restore_path_from_backup, rollback_added_skill,
 };
 pub use super::projections::{collect_skill_inventory, remote_status_payload};
 pub(crate) use super::projections::{

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,7 +20,7 @@ use crate::types::ErrorCode;
 
 pub use helpers::{collect_skill_inventory, remote_status_payload};
 
-use event_store::{append_command_event, command_event_input};
+use event_store::{append_command_event, command_event_input, prepare_command_event_store};
 use helpers::{command_name, ensure_initial_commit, map_git, map_io};
 
 use crate::gitops;
@@ -70,6 +70,16 @@ impl App {
         let cmd = command_name(&cli.command);
         let input = command_event_input(&cli);
         let request_id = cli.request_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+        if let Err(err) = prepare_command_event_store(&self.ctx) {
+            let env = Envelope::err(
+                cmd,
+                request_id,
+                ErrorCode::InternalError,
+                format!("failed to prepare command event log: {}", err),
+                json!({}),
+            );
+            return Ok((env, ErrorCode::InternalError.exit_code()));
+        }
 
         let result = match &cli.command {
             Command::Workspace { command } => match command {
@@ -103,14 +113,22 @@ impl App {
 
         match result {
             Ok((data, meta)) => {
-                let env = Envelope::ok(cmd, request_id, data, meta);
-                append_command_event(&self.ctx, cmd, input, &env, 0)?;
+                let mut env = Envelope::ok(cmd, request_id, data, meta);
+                if let Err(err) = append_command_event(&self.ctx, cmd, input, &env, 0) {
+                    env.meta
+                        .warnings
+                        .push(format!("failed to append command event: {}", err));
+                }
                 Ok((env, 0))
             }
             Err(f) => {
                 let exit_code = f.code.exit_code();
-                let env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
-                append_command_event(&self.ctx, cmd, input, &env, exit_code)?;
+                let mut env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
+                if let Err(err) = append_command_event(&self.ctx, cmd, input, &env, exit_code) {
+                    env.meta
+                        .warnings
+                        .push(format!("failed to append command event: {}", err));
+                }
                 Ok((env, exit_code))
             }
         }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,7 +13,10 @@ use anyhow::Result;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::cli::{Cli, Command, SkillCommand, SkillOrphanCommand, WorkspaceCommand};
+use crate::cli::{
+    Cli, Command, OpsCommand, OpsHistoryCommand, RemoteCommand, SkillCommand, SkillOrphanCommand,
+    SyncCommand, TargetCommand, WorkspaceBindingCommand, WorkspaceCommand,
+};
 use crate::envelope::{Envelope, Meta};
 use crate::state::AppContext;
 use crate::types::ErrorCode;
@@ -76,25 +79,39 @@ impl App {
             .clone()
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         let input = command_event_input(&cli, &request_id);
-        if let Err(err) = prepare_command_event_store(&self.ctx) {
-            let env = Envelope::err(
-                cmd,
-                request_id,
-                ErrorCode::InternalError,
-                format!("failed to prepare command event log: {}", err),
-                json!({}),
-            );
-            return Ok((env, ErrorCode::InternalError.exit_code()));
-        }
-        if let Err(err) = append_command_started(&self.ctx, cmd, input, &request_id) {
-            let env = Envelope::err(
-                cmd,
-                request_id,
-                ErrorCode::InternalError,
-                format!("failed to append command event: {}", err),
-                json!({}),
-            );
-            return Ok((env, ErrorCode::InternalError.exit_code()));
+        let audit_required = command_requires_durable_audit(&cli.command);
+        let mut audit_started = false;
+        let mut audit_warning = None;
+        match prepare_command_event_store(&self.ctx) {
+            Ok(()) => match append_command_started(&self.ctx, cmd, input, &request_id) {
+                Ok(()) => audit_started = true,
+                Err(err) if audit_required => {
+                    let env = Envelope::err(
+                        cmd,
+                        request_id,
+                        ErrorCode::InternalError,
+                        format!("failed to append command event: {}", err),
+                        json!({}),
+                    );
+                    return Ok((env, ErrorCode::InternalError.exit_code()));
+                }
+                Err(err) => {
+                    audit_warning = Some(format!("failed to append command event: {}", err));
+                }
+            },
+            Err(err) if audit_required => {
+                let env = Envelope::err(
+                    cmd,
+                    request_id,
+                    ErrorCode::InternalError,
+                    format!("failed to prepare command event log: {}", err),
+                    json!({}),
+                );
+                return Ok((env, ErrorCode::InternalError.exit_code()));
+            }
+            Err(err) => {
+                audit_warning = Some(format!("failed to prepare command event log: {}", err));
+            }
         }
 
         let result = match &cli.command {
@@ -130,20 +147,30 @@ impl App {
         match result {
             Ok((data, meta)) => {
                 let mut env = Envelope::ok(cmd, request_id, data, meta);
-                if let Err(err) = append_command_finished(&self.ctx, cmd, &env, 0) {
-                    env.meta
-                        .warnings
-                        .push(format!("failed to append command event: {}", err));
+                if let Some(warning) = audit_warning.take() {
+                    env.meta.warnings.push(warning);
+                }
+                if audit_started {
+                    if let Err(err) = append_command_finished(&self.ctx, cmd, &env, 0) {
+                        env.meta
+                            .warnings
+                            .push(format!("failed to append command event: {}", err));
+                    }
                 }
                 Ok((env, 0))
             }
             Err(f) => {
                 let exit_code = f.code.exit_code();
                 let mut env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
-                if let Err(err) = append_command_finished(&self.ctx, cmd, &env, exit_code) {
-                    env.meta
-                        .warnings
-                        .push(format!("failed to append command event: {}", err));
+                if let Some(warning) = audit_warning.take() {
+                    env.meta.warnings.push(warning);
+                }
+                if audit_started {
+                    if let Err(err) = append_command_finished(&self.ctx, cmd, &env, exit_code) {
+                        env.meta
+                            .warnings
+                            .push(format!("failed to append command event: {}", err));
+                    }
                 }
                 Ok((env, exit_code))
             }
@@ -167,5 +194,43 @@ impl App {
         let paths = V3StatePaths::from_app_context(&self.ctx);
         paths.ensure_layout().map_err(helpers::map_v3_state)?;
         Ok(paths)
+    }
+}
+
+fn command_requires_durable_audit(command: &Command) -> bool {
+    match command {
+        Command::Workspace { command } => match command {
+            WorkspaceCommand::Status | WorkspaceCommand::Doctor => false,
+            WorkspaceCommand::Init(_) => true,
+            WorkspaceCommand::Binding { command } => !matches!(
+                command,
+                WorkspaceBindingCommand::List | WorkspaceBindingCommand::Show(_)
+            ),
+            WorkspaceCommand::Remote { command } => !matches!(command, RemoteCommand::Status),
+        },
+        Command::Target { command } => {
+            !matches!(command, TargetCommand::List | TargetCommand::Show(_))
+        }
+        Command::Skill { command } => matches!(
+            command,
+            SkillCommand::Add(_)
+                | SkillCommand::ImportObserved(_)
+                | SkillCommand::Project(_)
+                | SkillCommand::Capture(_)
+                | SkillCommand::Save(_)
+                | SkillCommand::Snapshot(_)
+                | SkillCommand::Release(_)
+                | SkillCommand::Rollback(_)
+                | SkillCommand::Orphan {
+                    command: SkillOrphanCommand::Clean(_)
+                }
+        ),
+        Command::Sync { command } => !matches!(command, SyncCommand::Status),
+        Command::Ops { command } => match command {
+            OpsCommand::List => false,
+            OpsCommand::Retry | OpsCommand::Purge => true,
+            OpsCommand::History { command } => !matches!(command, OpsHistoryCommand::Diagnose),
+        },
+        Command::Panel(_) => false,
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod event_store;
 mod file_ops;
 mod fs_probe;
 mod helpers;
@@ -19,6 +20,7 @@ use crate::types::ErrorCode;
 
 pub use helpers::{collect_skill_inventory, remote_status_payload};
 
+use event_store::{append_command_event, command_event_input};
 use helpers::{command_name, ensure_initial_commit, map_git, map_io};
 
 use crate::gitops;
@@ -65,6 +67,8 @@ impl App {
     }
 
     pub fn execute(&self, cli: Cli) -> Result<(Envelope, i32)> {
+        let cmd = command_name(&cli.command);
+        let input = command_event_input(&cli);
         let request_id = cli.request_id.unwrap_or_else(|| Uuid::new_v4().to_string());
 
         let result = match &cli.command {
@@ -99,18 +103,15 @@ impl App {
 
         match result {
             Ok((data, meta)) => {
-                let env = Envelope::ok(command_name(&cli.command), request_id, data, meta);
+                let env = Envelope::ok(cmd, request_id, data, meta);
+                append_command_event(&self.ctx, cmd, input, &env, 0)?;
                 Ok((env, 0))
             }
             Err(f) => {
-                let env = Envelope::err(
-                    command_name(&cli.command),
-                    request_id,
-                    f.code,
-                    f.message,
-                    f.details,
-                );
-                Ok((env, f.code.exit_code()))
+                let exit_code = f.code.exit_code();
+                let env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
+                append_command_event(&self.ctx, cmd, input, &env, exit_code)?;
+                Ok((env, exit_code))
             }
         }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,7 +20,10 @@ use crate::types::ErrorCode;
 
 pub use helpers::{collect_skill_inventory, remote_status_payload};
 
-use event_store::{append_command_event, command_event_input, prepare_command_event_store};
+use event_store::{
+    append_command_finished, append_command_started, command_event_input,
+    prepare_command_event_store,
+};
 use helpers::{command_name, ensure_initial_commit, map_git, map_io};
 
 use crate::gitops;
@@ -68,14 +71,27 @@ impl App {
 
     pub fn execute(&self, cli: Cli) -> Result<(Envelope, i32)> {
         let cmd = command_name(&cli.command);
-        let input = command_event_input(&cli);
-        let request_id = cli.request_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+        let request_id = cli
+            .request_id
+            .clone()
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let input = command_event_input(&cli, &request_id);
         if let Err(err) = prepare_command_event_store(&self.ctx) {
             let env = Envelope::err(
                 cmd,
                 request_id,
                 ErrorCode::InternalError,
                 format!("failed to prepare command event log: {}", err),
+                json!({}),
+            );
+            return Ok((env, ErrorCode::InternalError.exit_code()));
+        }
+        if let Err(err) = append_command_started(&self.ctx, cmd, input, &request_id) {
+            let env = Envelope::err(
+                cmd,
+                request_id,
+                ErrorCode::InternalError,
+                format!("failed to append command event: {}", err),
                 json!({}),
             );
             return Ok((env, ErrorCode::InternalError.exit_code()));
@@ -114,7 +130,7 @@ impl App {
         match result {
             Ok((data, meta)) => {
                 let mut env = Envelope::ok(cmd, request_id, data, meta);
-                if let Err(err) = append_command_event(&self.ctx, cmd, input, &env, 0) {
+                if let Err(err) = append_command_finished(&self.ctx, cmd, &env, 0) {
                     env.meta
                         .warnings
                         .push(format!("failed to append command event: {}", err));
@@ -124,7 +140,7 @@ impl App {
             Err(f) => {
                 let exit_code = f.code.exit_code();
                 let mut env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
-                if let Err(err) = append_command_event(&self.ctx, cmd, input, &env, exit_code) {
+                if let Err(err) = append_command_finished(&self.ctx, cmd, &env, exit_code) {
                     env.meta
                         .warnings
                         .push(format!("failed to append command event: {}", err));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,8 +24,8 @@ use crate::types::ErrorCode;
 pub use helpers::{collect_skill_inventory, remote_status_payload};
 
 use event_store::{
-    append_command_finished, append_command_started, command_event_input,
-    prepare_command_event_store,
+    append_command_audit_failure, append_command_finished, append_command_started,
+    command_event_input, prepare_command_event_store,
 };
 use helpers::{command_name, ensure_initial_commit, map_git, map_io};
 
@@ -150,14 +150,7 @@ impl App {
                 if let Some(warning) = audit_warning.take() {
                     env.meta.warnings.push(warning);
                 }
-                if audit_started {
-                    if let Err(err) = append_command_finished(&self.ctx, cmd, &env, 0) {
-                        env.meta
-                            .warnings
-                            .push(format!("failed to append command event: {}", err));
-                    }
-                }
-                Ok((env, 0))
+                Ok(self.finish_command_audit(cmd, env, 0, audit_started, audit_required))
             }
             Err(f) => {
                 let exit_code = f.code.exit_code();
@@ -165,16 +158,61 @@ impl App {
                 if let Some(warning) = audit_warning.take() {
                     env.meta.warnings.push(warning);
                 }
-                if audit_started {
-                    if let Err(err) = append_command_finished(&self.ctx, cmd, &env, exit_code) {
-                        env.meta
-                            .warnings
-                            .push(format!("failed to append command event: {}", err));
-                    }
-                }
-                Ok((env, exit_code))
+                Ok(self.finish_command_audit(cmd, env, exit_code, audit_started, audit_required))
             }
         }
+    }
+
+    fn finish_command_audit(
+        &self,
+        cmd: &str,
+        mut env: Envelope,
+        exit_code: i32,
+        audit_started: bool,
+        audit_required: bool,
+    ) -> (Envelope, i32) {
+        if !audit_started {
+            return (env, exit_code);
+        }
+
+        if let Err(err) = append_command_finished(&self.ctx, cmd, &env, exit_code) {
+            let warning = format!("failed to append command event: {}", err);
+            if !audit_required {
+                env.meta.warnings.push(warning);
+                return (env, exit_code);
+            }
+
+            let failure_exit = ErrorCode::InternalError.exit_code();
+            let mut failure_env = Envelope::err(
+                cmd,
+                env.request_id.clone(),
+                ErrorCode::InternalError,
+                warning,
+                json!({
+                    "audit_stage": "finish",
+                    "original_ok": env.ok,
+                    "original_exit_code": exit_code,
+                    "original_error": env.error.as_ref().map(|error| {
+                        json!({
+                            "code": error.code,
+                            "message": error.message,
+                        })
+                    }),
+                }),
+            );
+            failure_env.meta.warnings = env.meta.warnings;
+            if let Err(recovery_err) =
+                append_command_audit_failure(&self.ctx, cmd, &failure_env, failure_exit)
+            {
+                failure_env.meta.warnings.push(format!(
+                    "failed to append audit failure event after terminal append failure: {}",
+                    recovery_err
+                ));
+            }
+            return (failure_env, failure_exit);
+        }
+
+        (env, exit_code)
     }
 
     pub(crate) fn require_v3_snapshot(

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -220,13 +220,72 @@ pub(crate) fn record_v3_operation(
         created_at: now,
         updated_at: now,
     };
-    paths.append_operation(&record)?;
+    let operations_backup = fs::read(&paths.operations_file).with_context(|| {
+        format!(
+            "failed to snapshot operations log {} before append",
+            paths.operations_file.display()
+        )
+    })?;
+    let checkpoint_backup = fs::read(&paths.checkpoint_file).with_context(|| {
+        format!(
+            "failed to snapshot checkpoint {} before update",
+            paths.checkpoint_file.display()
+        )
+    })?;
 
-    let mut checkpoint = paths.load_checkpoint()?;
-    checkpoint.last_scanned_op_id = Some(op_id.clone());
-    checkpoint.updated_at = now;
-    paths.save_checkpoint(&checkpoint)?;
+    let persist_result: Result<()> = (|| -> Result<()> {
+        paths.append_operation(&record)?;
+        maybe_projection_fault("record_v3_operation_after_append")?;
+
+        let mut checkpoint = paths.load_checkpoint()?;
+        checkpoint.last_scanned_op_id = Some(op_id.clone());
+        checkpoint.updated_at = now;
+        paths.save_checkpoint(&checkpoint)?;
+        maybe_projection_fault("record_v3_operation_after_checkpoint")?;
+        Ok(())
+    })();
+
+    if let Err(err) = persist_result {
+        if let Err(rollback_err) =
+            rollback_record_v3_operation(paths, &operations_backup, &checkpoint_backup)
+        {
+            return Err(err.context(format!(
+                "failed to rollback v3 operation record after partial write: {}",
+                rollback_err
+            )));
+        }
+        return Err(err);
+    }
+
     Ok(op_id)
+}
+
+fn maybe_projection_fault(tag: &str) -> Result<()> {
+    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
+        return Err(anyhow::anyhow!("fault injected at {}", tag));
+    }
+    Ok(())
+}
+
+fn rollback_record_v3_operation(
+    paths: &V3StatePaths,
+    operations_backup: &[u8],
+    checkpoint_backup: &[u8],
+) -> Result<()> {
+    restore_raw_file(&paths.operations_file, operations_backup)?;
+    restore_raw_file(&paths.checkpoint_file, checkpoint_backup)?;
+    Ok(())
+}
+
+fn restore_raw_file(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("cannot restore file without parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create restore dir {}", parent.display()))?;
+    fs::write(path, contents)
+        .with_context(|| format!("failed to restore file {}", path.display()))?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -9,7 +9,10 @@ use crate::cli::{AddArgs, CaptureArgs, ImportObservedArgs, ProjectArgs, SaveArgs
 use crate::envelope::Meta;
 use crate::gitops;
 use crate::state::remove_path_if_exists;
-use crate::state_model::{V3BindingRule, V3ProjectionInstance, V3ProjectionTarget};
+use crate::state_model::{
+    V3BindingRule, V3BindingsFile, V3ProjectionInstance, V3ProjectionTarget, V3ProjectionsFile,
+    V3RulesFile, V3StatePaths,
+};
 use crate::types::ErrorCode;
 
 use super::fs_probe::probe_symlink;
@@ -18,8 +21,8 @@ use super::helpers::{
     ensure_skill_exists, map_arg, map_git, map_io, map_lock, map_project_io, map_v3_state,
     maybe_autosync_or_queue, project_skill_to_target, projection_instance_id,
     projection_method_as_str, record_v3_operation, resolve_capture_projection,
-    rollback_added_skill, update_projection_after_capture, upsert_projection, upsert_rule,
-    validate_projection_method, validate_skill_name,
+    restore_path_from_backup, rollback_added_skill, update_projection_after_capture,
+    upsert_projection, upsert_rule, validate_projection_method, validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -201,11 +204,33 @@ impl App {
         let replaced_projection_backup =
             backup_path_if_exists(&self.ctx, &materialized_path, "project.replace_projection")
                 .map_err(map_io)?;
-        remove_path_if_exists(&materialized_path).map_err(map_io)?;
-        project_skill_to_target(&skill_src, &materialized_path, args.method)
-            .map_err(map_project_io(args.method))?;
+        if let Err(err) = remove_path_if_exists(&materialized_path) {
+            rollback_project_mutation(
+                &paths,
+                &materialized_path,
+                replaced_projection_backup.as_ref(),
+                &snapshot.bindings,
+                &snapshot.rules,
+                &snapshot.projections,
+            );
+            return Err(map_io(err));
+        }
+        if let Err(err) = project_skill_to_target(&skill_src, &materialized_path, args.method) {
+            rollback_project_mutation(
+                &paths,
+                &materialized_path,
+                replaced_projection_backup.as_ref(),
+                &snapshot.bindings,
+                &snapshot.rules,
+                &snapshot.projections,
+            );
+            return Err(map_project_io(args.method)(err));
+        }
 
-        let mut rules = snapshot.rules;
+        let original_bindings = snapshot.bindings.clone();
+        let original_rules = snapshot.rules.clone();
+        let original_projections = snapshot.projections.clone();
+        let mut rules = original_rules.clone();
         upsert_rule(
             &mut rules,
             V3BindingRule {
@@ -217,9 +242,8 @@ impl App {
                 created_at: Some(Utc::now()),
             },
         );
-        paths.save_rules(&rules).map_err(map_v3_state)?;
 
-        let mut projections = snapshot.projections;
+        let mut projections = original_projections.clone();
         let instance_id =
             projection_instance_id(&args.skill, &binding.binding_id, &target.target_id);
         let projection = V3ProjectionInstance {
@@ -235,23 +259,44 @@ impl App {
             updated_at: Some(Utc::now()),
         };
         upsert_projection(&mut projections, projection.clone());
-        paths.save_projections(&projections).map_err(map_v3_state)?;
 
-        let op_id = record_v3_operation(
-            &paths,
-            "skill.project",
-            json!({
-                "skill_id": args.skill,
-                "binding_id": binding.binding_id,
-                "target_id": target.target_id,
-                "method": projection_method_as_str(args.method),
-                "request_id": request_id
-            }),
-            json!({
-                "instance_id": instance_id
-            }),
-        )
-        .map_err(map_v3_state)?;
+        let post_materialize = (|| {
+            maybe_skill_fault("skill_project_after_materialize")?;
+            paths
+                .save_bindings_rules_projections(&original_bindings, &rules, &projections)
+                .map_err(map_v3_state)?;
+            maybe_skill_fault("skill_project_after_state_save")?;
+            record_v3_operation(
+                &paths,
+                "skill.project",
+                json!({
+                    "skill_id": args.skill,
+                    "binding_id": binding.binding_id,
+                    "target_id": target.target_id,
+                    "method": projection_method_as_str(args.method),
+                    "request_id": request_id
+                }),
+                json!({
+                    "instance_id": instance_id
+                }),
+            )
+            .map_err(map_v3_state)
+        })();
+
+        let op_id = match post_materialize {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                rollback_project_mutation(
+                    &paths,
+                    &materialized_path,
+                    replaced_projection_backup.as_ref(),
+                    &original_bindings,
+                    &original_rules,
+                    &original_projections,
+                );
+                return Err(err);
+            }
+        };
 
         Ok((
             json!({"projection": projection, "backup": replaced_projection_backup, "noop": false}),
@@ -284,55 +329,143 @@ impl App {
             ));
         }
 
+        let original_bindings = snapshot.bindings.clone();
+        let original_rules = snapshot.rules.clone();
+        let original_projections = snapshot.projections.clone();
+        let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
         let mut source_backup = None;
+        let mut source_replaced = false;
         if projection.method != "symlink" {
             let tmp_path = self
                 .ctx
                 .state_dir
                 .join(format!("tmp-capture-{}", Uuid::new_v4()));
             let _ = remove_path_if_exists(&tmp_path);
-            copy_dir_recursive(&live_path, &tmp_path).map_err(map_io)?;
-            source_backup = backup_path_if_exists(&self.ctx, &skill_path, "capture.replace_source")
-                .map_err(map_io)?;
-            remove_path_if_exists(&skill_path).map_err(map_io)?;
-            fs::rename(&tmp_path, &skill_path).map_err(map_io)?;
+            if let Err(err) = copy_dir_recursive(&live_path, &tmp_path) {
+                let _ = remove_path_if_exists(&tmp_path);
+                return Err(map_io(err));
+            }
+            source_backup =
+                match backup_path_if_exists(&self.ctx, &skill_path, "capture.replace_source") {
+                    Ok(backup) => backup,
+                    Err(err) => {
+                        let _ = remove_path_if_exists(&tmp_path);
+                        return Err(map_io(err));
+                    }
+                };
+            if let Err(err) = remove_path_if_exists(&skill_path) {
+                rollback_capture_mutation(
+                    &self.ctx,
+                    &skill_rel,
+                    &skill_path,
+                    source_backup.as_ref(),
+                    true,
+                    &previous_head,
+                    false,
+                );
+                rollback_v3_state(
+                    &paths,
+                    &original_bindings,
+                    &original_rules,
+                    &original_projections,
+                );
+                let _ = remove_path_if_exists(&tmp_path);
+                return Err(map_io(err));
+            }
+            if let Err(err) = fs::rename(&tmp_path, &skill_path) {
+                rollback_capture_mutation(
+                    &self.ctx,
+                    &skill_rel,
+                    &skill_path,
+                    source_backup.as_ref(),
+                    true,
+                    &previous_head,
+                    false,
+                );
+                rollback_v3_state(
+                    &paths,
+                    &original_bindings,
+                    &original_rules,
+                    &original_projections,
+                );
+                let _ = remove_path_if_exists(&tmp_path);
+                return Err(map_io(err));
+            }
+            source_replaced = true;
         }
 
-        gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
-        let changed = gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel))
-            .map_err(map_git)?;
-        let commit = if changed {
-            let message = args.message.clone().unwrap_or_else(|| {
-                format!(
-                    "capture({}): from {}",
-                    projection.skill_id, projection.instance_id
-                )
-            });
-            Some(gitops::commit(&self.ctx, &message).map_err(map_git)?)
-        } else {
-            None
+        let mut commit_created = false;
+        let post_replace = (|| {
+            maybe_skill_fault("skill_capture_after_source_replace")?;
+            gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
+            let changed = gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel))
+                .map_err(map_git)?;
+            let commit = if changed {
+                let message = args.message.clone().unwrap_or_else(|| {
+                    format!(
+                        "capture({}): from {}",
+                        projection.skill_id, projection.instance_id
+                    )
+                });
+                let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
+                commit_created = true;
+                Some(commit)
+            } else {
+                None
+            };
+            maybe_skill_fault("skill_capture_after_commit")?;
+            let current_rev = gitops::head(&self.ctx).map_err(map_git)?;
+
+            let mut projections = original_projections.clone();
+            update_projection_after_capture(
+                &mut projections,
+                &projection.instance_id,
+                &current_rev,
+            )?;
+            paths
+                .save_bindings_rules_projections(&original_bindings, &original_rules, &projections)
+                .map_err(map_v3_state)?;
+            maybe_skill_fault("skill_capture_after_state_save")?;
+
+            let op_id = record_v3_operation(
+                &paths,
+                "skill.capture",
+                json!({
+                    "skill_id": projection.skill_id,
+                    "binding_id": projection.binding_id,
+                    "instance_id": projection.instance_id,
+                    "request_id": request_id
+                }),
+                json!({
+                    "instance_id": projection.instance_id,
+                    "commit": commit
+                }),
+            )
+            .map_err(map_v3_state)?;
+            Ok((commit, op_id, changed))
+        })();
+
+        let (commit, op_id, changed) = match post_replace {
+            Ok(result) => result,
+            Err(err) => {
+                rollback_capture_mutation(
+                    &self.ctx,
+                    &skill_rel,
+                    &skill_path,
+                    source_backup.as_ref(),
+                    source_replaced,
+                    &previous_head,
+                    commit_created,
+                );
+                rollback_v3_state(
+                    &paths,
+                    &original_bindings,
+                    &original_rules,
+                    &original_projections,
+                );
+                return Err(err);
+            }
         };
-        let current_rev = gitops::head(&self.ctx).map_err(map_git)?;
-
-        let mut projections = snapshot.projections;
-        update_projection_after_capture(&mut projections, &projection.instance_id, &current_rev)?;
-        paths.save_projections(&projections).map_err(map_v3_state)?;
-
-        let op_id = record_v3_operation(
-            &paths,
-            "skill.capture",
-            json!({
-                "skill_id": projection.skill_id,
-                "binding_id": projection.binding_id,
-                "instance_id": projection.instance_id,
-                "request_id": request_id
-            }),
-            json!({
-                "instance_id": projection.instance_id,
-                "commit": commit
-            }),
-        )
-        .map_err(map_v3_state)?;
 
         Ok((
             json!({
@@ -676,6 +809,75 @@ impl App {
 
         Ok((json!({"skill": args.skill, "tag": tag}), meta))
     }
+}
+
+fn maybe_skill_fault(tag: &str) -> std::result::Result<(), CommandFailure> {
+    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
+        return Err(CommandFailure::new(
+            ErrorCode::InternalError,
+            format!("fault injected at {}", tag),
+        ));
+    }
+    Ok(())
+}
+
+fn rollback_project_mutation(
+    paths: &V3StatePaths,
+    materialized_path: &Path,
+    backup: Option<&serde_json::Value>,
+    original_bindings: &V3BindingsFile,
+    original_rules: &V3RulesFile,
+    original_projections: &V3ProjectionsFile,
+) {
+    if let Some(backup) = backup {
+        let _ = restore_path_from_backup(materialized_path, backup);
+    } else {
+        let _ = remove_path_if_exists(materialized_path);
+    }
+    rollback_v3_state(
+        paths,
+        original_bindings,
+        original_rules,
+        original_projections,
+    );
+}
+
+fn rollback_capture_mutation(
+    ctx: &crate::state::AppContext,
+    skill_rel: &str,
+    skill_path: &Path,
+    source_backup: Option<&serde_json::Value>,
+    source_replaced: bool,
+    previous_head: &str,
+    commit_created: bool,
+) {
+    if commit_created {
+        // Preserve worktree content while removing only the command-created commit.
+        let _ = gitops::run_git_allow_failure(ctx, &["reset", "--soft", previous_head]);
+    }
+
+    if source_replaced {
+        if let Some(backup) = source_backup {
+            let _ = restore_path_from_backup(skill_path, backup);
+        } else {
+            let _ = remove_path_if_exists(skill_path);
+        }
+    }
+
+    let _ = gitops::run_git_allow_failure(ctx, &["reset", "HEAD", "--", skill_rel]);
+}
+
+fn rollback_v3_state(
+    paths: &V3StatePaths,
+    original_bindings: &V3BindingsFile,
+    original_rules: &V3RulesFile,
+    original_projections: &V3ProjectionsFile,
+) {
+    let _ = paths.save_bindings_rules_projections(
+        original_bindings,
+        original_rules,
+        original_projections,
+    );
 }
 
 fn observed_import_targets(

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 mod common;
 
 use common::actions::{binding_add, save_skill, skill_project, target_add};
-use common::{TestDir, run_loom, write_skill};
+use common::{TestDir, run_loom, run_loom_with_env, write_skill};
 
 #[test]
 fn skill_capture_copies_live_projection_back_into_source_and_commits() {
@@ -109,6 +109,88 @@ fn skill_capture_copies_live_projection_back_into_source_and_commits() {
     let source_file = root.path().join("skills/model-onboarding/SKILL.md");
     let source_body = fs::read_to_string(source_file).expect("read source skill");
     assert!(source_body.contains("captured from live copy"));
+}
+
+#[test]
+fn skill_capture_rolls_back_source_after_post_replace_failure() {
+    let root = TestDir::new("v3-capture-rollback");
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v1\n",
+    );
+
+    let (save_output, _) = save_skill(root.path(), "model-onboarding");
+    assert!(save_output.status.success(), "save should succeed");
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+    assert!(
+        skill_project(
+            root.path(),
+            "model-onboarding",
+            "bind_claude_project_a",
+            Some("copy"),
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let live_file = target_path.join("model-onboarding").join("SKILL.md");
+    fs::write(
+        &live_file,
+        "# model-onboarding\n\ncaptured from live copy\n",
+    )
+    .expect("edit live projection");
+
+    let (capture_output, capture_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_capture_after_source_replace")],
+        &[
+            "skill",
+            "capture",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+        ],
+    );
+
+    assert!(
+        !capture_output.status.success(),
+        "capture unexpectedly succeeded"
+    );
+    assert_eq!(capture_env["ok"], Value::Bool(false));
+
+    let source_file = root.path().join("skills/model-onboarding/SKILL.md");
+    let source_body = fs::read_to_string(source_file).expect("read source skill");
+    assert!(
+        source_body.contains("source v1"),
+        "source skill should be restored after failed capture"
+    );
+    let live_body = fs::read_to_string(live_file).expect("read live projection");
+    assert!(
+        live_body.contains("captured from live copy"),
+        "live projection edit should be preserved for retry"
+    );
 }
 
 #[test]

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -8,6 +8,14 @@ mod common;
 use common::actions::{binding_add, save_skill, skill_project, target_add};
 use common::{TestDir, run_loom, run_loom_with_env, write_skill};
 
+fn read_operations_log(root: &std::path::Path) -> String {
+    fs::read_to_string(root.join("state/v3/ops/operations.jsonl")).expect("read operations log")
+}
+
+fn read_checkpoint(root: &std::path::Path) -> String {
+    fs::read_to_string(root.join("state/v3/ops/checkpoint.json")).expect("read checkpoint")
+}
+
 #[test]
 fn skill_capture_copies_live_projection_back_into_source_and_commits() {
     let root = TestDir::new("v3-capture");
@@ -203,4 +211,95 @@ fn skill_capture_requires_explicit_selector() {
         env["error"]["code"],
         Value::String("ARG_INVALID".to_string())
     );
+}
+
+#[test]
+fn skill_capture_rolls_back_operation_log_after_append_failure() {
+    let root = TestDir::new("v3-capture-oplog-rollback");
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v1\n",
+    );
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+    assert!(
+        skill_project(
+            root.path(),
+            "model-onboarding",
+            "bind_claude_project_a",
+            Some("copy"),
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let live_file = target_path.join("model-onboarding").join("SKILL.md");
+    fs::write(
+        &live_file,
+        "# model-onboarding\n\ncaptured from live copy\n",
+    )
+    .expect("edit live projection");
+
+    let operations_before = read_operations_log(root.path());
+    let checkpoint_before = read_checkpoint(root.path());
+
+    let (capture_output, capture_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "record_v3_operation_after_append")],
+        &[
+            "skill",
+            "capture",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+        ],
+    );
+
+    assert!(
+        !capture_output.status.success(),
+        "capture unexpectedly succeeded"
+    );
+    assert_eq!(capture_env["ok"], Value::Bool(false));
+
+    let source_file = root.path().join("skills/model-onboarding/SKILL.md");
+    let source_body = fs::read_to_string(source_file).expect("read source skill");
+    assert!(
+        source_body.contains("source v1"),
+        "source skill should be restored after operation-log failure"
+    );
+    let live_body = fs::read_to_string(live_file).expect("read live projection");
+    assert!(
+        live_body.contains("captured from live copy"),
+        "live projection edit should be preserved for retry"
+    );
+    assert_eq!(read_operations_log(root.path()), operations_before);
+    assert_eq!(read_checkpoint(root.path()), checkpoint_before);
 }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 mod common;
 
 use common::actions::{binding_add, save_skill, skill_project, target_add};
-use common::{TestDir, run_loom, write_skill};
+use common::{TestDir, run_loom, run_loom_with_env, write_skill};
 
 fn write_example_skill(root: &std::path::Path, skill: &str) {
     write_skill(root, skill, &format!("# {}\n\nexample skill\n", skill));
@@ -189,5 +189,83 @@ fn skill_project_backs_up_existing_projection_path_before_replace() {
     assert!(
         backup_path.join("legacy.txt").exists(),
         "backup should preserve replaced content"
+    );
+}
+
+#[test]
+fn skill_project_rolls_back_projection_after_post_materialize_failure() {
+    let root = TestDir::new("v3-skill-project-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+
+    let (save_output, _) = save_skill(root.path(), "model-onboarding");
+    assert!(save_output.status.success(), "save should succeed");
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let existing_projection = target_path.join("model-onboarding");
+    fs::create_dir_all(&existing_projection).expect("create existing projection path");
+    fs::write(
+        existing_projection.join("legacy.txt"),
+        "legacy projection content",
+    )
+    .expect("write legacy projection marker");
+
+    let (project_output, project_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_project_after_materialize")],
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+            "--method",
+            "copy",
+        ],
+    );
+
+    assert!(
+        !project_output.status.success(),
+        "project unexpectedly succeeded"
+    );
+    assert_eq!(project_env["ok"], Value::Bool(false));
+    assert!(
+        existing_projection.join("legacy.txt").exists(),
+        "legacy projection should be restored after failure"
+    );
+    assert!(
+        !existing_projection.join("SKILL.md").exists(),
+        "failed projection should not leave copied skill files"
+    );
+
+    let rules = fs::read_to_string(root.path().join("state/v3/rules.json")).expect("read rules");
+    let projections = fs::read_to_string(root.path().join("state/v3/projections.json"))
+        .expect("read projections");
+    assert!(
+        !rules.contains("model-onboarding"),
+        "rules state should roll back"
+    );
+    assert!(
+        !projections.contains("model-onboarding"),
+        "projection state should roll back"
     );
 }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -269,3 +269,139 @@ fn skill_project_rolls_back_projection_after_post_materialize_failure() {
         "projection state should roll back"
     );
 }
+
+#[test]
+fn skill_project_eventstore_preflight_failure_blocks_mutation() {
+    let root = TestDir::new("v3-skill-project-eventstore-preflight");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let events_dir = root.path().join("state/events");
+    fs::remove_dir_all(&events_dir).expect("remove command events dir");
+    fs::write(&events_dir, "not a directory\n").expect("block command event dir");
+
+    let (project_output, project_env) = run_loom_with_env(
+        root.path(),
+        &[],
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+            "--method",
+            "copy",
+        ],
+    );
+
+    assert!(
+        !project_output.status.success(),
+        "project unexpectedly succeeded"
+    );
+    assert_eq!(project_env["ok"], Value::Bool(false));
+    assert_eq!(
+        project_env["error"]["code"],
+        Value::String("INTERNAL_ERROR".to_string())
+    );
+    assert!(
+        !target_path.join("model-onboarding/SKILL.md").exists(),
+        "projection should not be materialized when audit preflight fails"
+    );
+
+    let rules = fs::read_to_string(root.path().join("state/v3/rules.json")).expect("read rules");
+    let projections = fs::read_to_string(root.path().join("state/v3/projections.json"))
+        .expect("read projections");
+    assert!(!rules.contains("model-onboarding"));
+    assert!(!projections.contains("model-onboarding"));
+}
+
+#[test]
+fn skill_project_append_failure_does_not_report_failed_mutation() {
+    let root = TestDir::new("v3-skill-project-eventstore-append");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let (project_output, project_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "command_event_append")],
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+            "--method",
+            "copy",
+        ],
+    );
+
+    assert!(
+        project_output.status.success(),
+        "append failure should not turn completed mutation into command failure"
+    );
+    assert_eq!(project_env["ok"], Value::Bool(true));
+    assert!(
+        project_env["meta"]["warnings"][0]
+            .as_str()
+            .unwrap_or_default()
+            .contains("failed to append command event")
+    );
+    assert!(
+        target_path.join("model-onboarding/SKILL.md").exists(),
+        "successful mutation should remain materialized"
+    );
+}

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -12,6 +12,14 @@ fn write_example_skill(root: &std::path::Path, skill: &str) {
     write_skill(root, skill, &format!("# {}\n\nexample skill\n", skill));
 }
 
+fn read_operations_log(root: &std::path::Path) -> String {
+    fs::read_to_string(root.join("state/v3/ops/operations.jsonl")).expect("read operations log")
+}
+
+fn read_checkpoint(root: &std::path::Path) -> String {
+    fs::read_to_string(root.join("state/v3/ops/checkpoint.json")).expect("read checkpoint")
+}
+
 #[test]
 fn skill_project_creates_projection_rule_and_instance() {
     let root = TestDir::new("v3-skill-project");
@@ -404,4 +412,85 @@ fn skill_project_append_failure_does_not_report_failed_mutation() {
         target_path.join("model-onboarding/SKILL.md").exists(),
         "successful mutation should remain materialized"
     );
+}
+
+#[test]
+fn skill_project_rolls_back_operation_log_after_append_failure() {
+    let root = TestDir::new("v3-skill-project-oplog-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let existing_projection = target_path.join("model-onboarding");
+    fs::create_dir_all(&existing_projection).expect("create existing projection path");
+    fs::write(
+        existing_projection.join("legacy.txt"),
+        "legacy projection content",
+    )
+    .expect("write legacy projection marker");
+
+    let operations_before = read_operations_log(root.path());
+    let checkpoint_before = read_checkpoint(root.path());
+
+    let (project_output, project_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "record_v3_operation_after_append")],
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+            "--method",
+            "copy",
+        ],
+    );
+
+    assert!(
+        !project_output.status.success(),
+        "project unexpectedly succeeded"
+    );
+    assert_eq!(project_env["ok"], Value::Bool(false));
+    assert!(
+        existing_projection.join("legacy.txt").exists(),
+        "legacy projection should be restored after operation-log failure"
+    );
+    assert!(
+        !existing_projection.join("SKILL.md").exists(),
+        "failed projection should not leave copied skill files"
+    );
+
+    let rules = fs::read_to_string(root.path().join("state/v3/rules.json")).expect("read rules");
+    let projections = fs::read_to_string(root.path().join("state/v3/projections.json"))
+        .expect("read projections");
+    assert!(!rules.contains("model-onboarding"));
+    assert!(!projections.contains("model-onboarding"));
+    assert_eq!(read_operations_log(root.path()), operations_before);
+    assert_eq!(read_checkpoint(root.path()), checkpoint_before);
 }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -351,7 +351,7 @@ fn skill_project_eventstore_preflight_failure_blocks_mutation() {
 }
 
 #[test]
-fn skill_project_append_failure_does_not_report_failed_mutation() {
+fn skill_project_terminal_audit_failure_reports_error_after_mutation() {
     let root = TestDir::new("v3-skill-project-eventstore-append");
     write_example_skill(root.path(), "model-onboarding");
 
@@ -385,7 +385,7 @@ fn skill_project_append_failure_does_not_report_failed_mutation() {
 
     let (project_output, project_env) = run_loom_with_env(
         root.path(),
-        &[("LOOM_FAULT_INJECT", "command_event_append")],
+        &[("LOOM_FAULT_INJECT", "command_event_append_finished")],
         &[
             "skill",
             "project",
@@ -398,19 +398,17 @@ fn skill_project_append_failure_does_not_report_failed_mutation() {
     );
 
     assert!(
-        project_output.status.success(),
-        "append failure should not turn completed mutation into command failure"
+        !project_output.status.success(),
+        "terminal audit failure should fail an audit-required command"
     );
-    assert_eq!(project_env["ok"], Value::Bool(true));
-    assert!(
-        project_env["meta"]["warnings"][0]
-            .as_str()
-            .unwrap_or_default()
-            .contains("failed to append command event")
+    assert_eq!(project_env["ok"], Value::Bool(false));
+    assert_eq!(
+        project_env["error"]["code"],
+        Value::String("INTERNAL_ERROR".to_string())
     );
     assert!(
         target_path.join("model-onboarding/SKILL.md").exists(),
-        "successful mutation should remain materialized"
+        "mutation completed before terminal audit failure and should remain materialized"
     );
 }
 

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -22,6 +22,14 @@ fn run_loom_ok(root: &Path, args: &[&str]) -> Value {
     env
 }
 
+fn read_command_events(root: &Path) -> Vec<Value> {
+    let raw = fs::read_to_string(root.join("state/events/commands.jsonl"))
+        .expect("read command event log");
+    raw.lines()
+        .map(|line| serde_json::from_str(line).expect("parse command event"))
+        .collect()
+}
+
 fn run_git<I, S>(args: I) -> Output
 where
     I: IntoIterator<Item = S>,
@@ -208,8 +216,45 @@ fn workspace_status_is_read_only_in_empty_dir() {
 
     assert_eq!(env["ok"], true);
     assert!(!root.path().join(".git").exists());
-    assert!(!root.path().join("state").exists());
+    assert!(!root.path().join("state/v3").exists());
     assert!(!root.path().join("skills").exists());
+
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]["cmd"],
+        Value::String("workspace.status".to_string())
+    );
+    assert_eq!(events[0]["status"], Value::String("succeeded".to_string()));
+    assert_eq!(events[0]["exit_code"], Value::from(0));
+    assert_eq!(
+        events[0]["output"]["state_model"],
+        Value::String("v3".to_string())
+    );
+}
+
+#[test]
+fn failed_command_emits_durable_command_event() {
+    let root = TestDir::new("failed-command-event");
+
+    let (output, env) = run_loom_with_env(root.path(), &[], &["skill", "capture"]);
+
+    assert!(!output.status.success(), "capture unexpectedly succeeded");
+    assert_eq!(env["ok"], Value::Bool(false));
+
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["cmd"], Value::String("skill.capture".to_string()));
+    assert_eq!(events[0]["status"], Value::String("failed".to_string()));
+    assert_eq!(events[0]["exit_code"], Value::from(2));
+    assert_eq!(
+        events[0]["error"]["code"],
+        Value::String("ARG_INVALID".to_string())
+    );
+    assert!(
+        events[0]["input"]["command"]["Skill"]["command"]["Capture"].is_object(),
+        "command input should preserve structured capture args"
+    );
 }
 
 #[test]

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -220,15 +220,17 @@ fn workspace_status_is_read_only_in_empty_dir() {
     assert!(!root.path().join("skills").exists());
 
     let events = read_command_events(root.path());
-    assert_eq!(events.len(), 1);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
     assert_eq!(
         events[0]["cmd"],
         Value::String("workspace.status".to_string())
     );
-    assert_eq!(events[0]["status"], Value::String("succeeded".to_string()));
-    assert_eq!(events[0]["exit_code"], Value::from(0));
+    assert!(events[0]["input"]["request_id"].as_str().is_some());
+    assert_eq!(events[1]["status"], Value::String("succeeded".to_string()));
+    assert_eq!(events[1]["exit_code"], Value::from(0));
     assert_eq!(
-        events[0]["output"]["state_model"],
+        events[1]["output"]["state_model"],
         Value::String("v3".to_string())
     );
 }
@@ -243,18 +245,51 @@ fn failed_command_emits_durable_command_event() {
     assert_eq!(env["ok"], Value::Bool(false));
 
     let events = read_command_events(root.path());
-    assert_eq!(events.len(), 1);
+    assert_eq!(events.len(), 2);
     assert_eq!(events[0]["cmd"], Value::String("skill.capture".to_string()));
-    assert_eq!(events[0]["status"], Value::String("failed".to_string()));
-    assert_eq!(events[0]["exit_code"], Value::from(2));
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
+    assert!(events[0]["input"]["request_id"].as_str().is_some());
+    assert_eq!(events[1]["status"], Value::String("failed".to_string()));
+    assert_eq!(events[1]["exit_code"], Value::from(2));
     assert_eq!(
-        events[0]["error"]["code"],
+        events[1]["error"]["code"],
         Value::String("ARG_INVALID".to_string())
     );
     assert!(
         events[0]["input"]["command"]["Skill"]["command"]["Capture"].is_object(),
         "command input should preserve structured capture args"
     );
+}
+
+#[test]
+fn finish_append_failure_still_leaves_started_audit_record() {
+    let root = TestDir::new("finish-append-failure");
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "command_event_append_finished")],
+        &["workspace", "status"],
+    );
+
+    assert!(output.status.success(), "status should still succeed");
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert!(
+        env["meta"]["warnings"]
+            .as_array()
+            .expect("warnings array")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .any(|warning| warning.contains("failed to append command event"))
+    );
+
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]["cmd"],
+        Value::String("workspace.status".to_string())
+    );
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
+    assert!(events[0]["input"]["request_id"].as_str().is_some());
 }
 
 #[test]

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -236,6 +236,33 @@ fn workspace_status_is_read_only_in_empty_dir() {
 }
 
 #[test]
+fn workspace_status_warns_when_command_audit_preflight_is_unavailable() {
+    let root = TestDir::new("status-audit-warning");
+    let events_dir = root.path().join("state/events");
+    if let Some(parent) = events_dir.parent() {
+        fs::create_dir_all(parent).expect("create state dir");
+    }
+    fs::write(&events_dir, "not a directory\n").expect("block command event dir");
+
+    let (output, env) = run_loom_with_env(root.path(), &[], &["workspace", "status"]);
+
+    assert!(
+        output.status.success(),
+        "status should stay usable when audit preflight cannot write"
+    );
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert!(
+        env["meta"]["warnings"]
+            .as_array()
+            .expect("warnings array")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .any(|warning| warning.contains("failed to prepare command event log"))
+    );
+    assert!(!root.path().join("state/v3").exists());
+}
+
+#[test]
 fn failed_command_emits_durable_command_event() {
     let root = TestDir::new("failed-command-event");
 

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -320,6 +320,45 @@ fn finish_append_failure_still_leaves_started_audit_record() {
 }
 
 #[test]
+fn audit_required_finish_append_failure_records_failure_and_returns_error() {
+    let root = TestDir::new("finish-append-required-failure");
+    let remote = root.path().join("remote.git");
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "command_event_append_finished")],
+        &["workspace", "remote", "set", remote.to_str().unwrap()],
+    );
+
+    assert!(
+        !output.status.success(),
+        "audit-required command should fail when terminal audit append fails"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        env["error"]["code"],
+        Value::String("INTERNAL_ERROR".to_string())
+    );
+    assert_eq!(
+        env["error"]["details"]["audit_stage"],
+        Value::String("finish".to_string())
+    );
+
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 2);
+    assert_eq!(
+        events[0]["cmd"],
+        Value::String("workspace.remote".to_string())
+    );
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
+    assert_eq!(events[1]["status"], Value::String("failed".to_string()));
+    assert_eq!(
+        events[1]["error"]["code"],
+        Value::String("INTERNAL_ERROR".to_string())
+    );
+}
+
+#[test]
 fn remote_set_initializes_repo_and_local_identity() {
     let root = TestDir::new("remote-set");
     let remote = root.path().join("remote.git");
@@ -353,6 +392,23 @@ fn remote_set_initializes_repo_and_local_identity() {
         .trim(),
         "loom@local"
     );
+}
+
+#[test]
+fn command_audit_redacts_sensitive_input_values() {
+    let root = TestDir::new("audit-redaction");
+    let remote = "https://user:pass@example.com/org/repo.git?access_token=ghp_secretvalue&ref=main#ghp_fragment";
+
+    let env = run_loom_ok(root.path(), &["workspace", "remote", "set", remote]);
+
+    assert_eq!(env["ok"], true);
+    let raw = fs::read_to_string(root.path().join("state/events/commands.jsonl"))
+        .expect("read command event log");
+    assert!(!raw.contains("user:pass"));
+    assert!(!raw.contains("ghp_secretvalue"));
+    assert!(!raw.contains("ghp_fragment"));
+    assert!(raw.contains("<redacted>"));
+    assert!(raw.contains("ref=main"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the two remaining P1 review issues:

- Adds a durable append-only command EventStore at `state/events/commands.jsonl` around `App::execute` for both successful and failed commands.
- Makes `skill project` and `skill capture` compensate after filesystem mutation failures by restoring backed-up paths, restoring v3 metadata, and cleaning staged/created commits where needed.
- Adds reliability coverage for successful/failed command events and injected post-mutation failures.

## Root Cause

`record_v3_operation` only covered a subset of successful domain mutations, so read-only commands and failed commands had no durable audit record. `skill project` and `skill capture` also crossed destructive filesystem boundaries before state and operation records were safely written, which could leave live files, v3 state, and Git history out of sync after an error.

## Validation

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #56.
Closes #57.
