### PR TITLE
Add release distribution workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,259 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Check tag matches Cargo version
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo_version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          test "v${cargo_version}" = "$GITHUB_REF_NAME"
+
+      - name: Format
+        run: make fmt-check
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test
+
+      - name: Panel build
+        run: make panel-build
+
+      - name: Panel tests
+        run: make panel-test
+
+      - name: Agent E2E
+        run: make e2e
+
+      - name: Crate package dry-run
+        run: cargo publish --dry-run --locked
+
+  build-assets:
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build release binary
+        run: cargo build --release --locked --target "${{ matrix.target }}"
+
+      - name: Package archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          archive="skillloom-${version}-${{ matrix.target }}.tar.gz"
+          staging="dist/skillloom-${version}-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp "target/${{ matrix.target }}/release/loom" "$staging/loom"
+          cp README.md LICENSE "$staging/"
+          tar -C dist -czf "dist/$archive" "skillloom-${version}-${{ matrix.target }}"
+          (cd dist && shasum -a 256 "$archive" > "$archive.sha256")
+
+      - name: Upload release asset
+        uses: actions/upload-artifact@v4
+        with:
+          name: skillloom-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+
+  github-release:
+    needs: build-assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Create checksums file
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat release-assets/*.sha256 > release-assets/SHA256SUMS
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            release-assets/*.tar.gz \
+            release-assets/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "skillloom ${GITHUB_REF_NAME#v}" \
+            --notes "Release ${GITHUB_REF_NAME}."
+
+  crates-io:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Skip when crates.io token is not configured
+        if: env.CARGO_REGISTRY_TOKEN == ''
+        run: echo "CARGO_REGISTRY_TOKEN is not configured; skipping crates.io publish."
+
+      - name: Checkout
+        if: env.CARGO_REGISTRY_TOKEN != ''
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        if: env.CARGO_REGISTRY_TOKEN != ''
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Bun
+        if: env.CARGO_REGISTRY_TOKEN != ''
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Publish crate
+        if: env.CARGO_REGISTRY_TOKEN != ''
+        run: cargo publish --locked
+
+  homebrew-tap:
+    needs: github-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      TAP_REPO: majiayu000/homebrew-tap
+    steps:
+      - name: Skip when Homebrew tap token is not configured
+        if: env.HOMEBREW_TAP_TOKEN == ''
+        run: echo "HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap PR."
+
+      - name: Download release assets
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Checkout Homebrew tap
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TAP_REPO }}
+          token: ${{ env.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          version="${tag#v}"
+          base_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
+          arm_archive="skillloom-${version}-aarch64-apple-darwin.tar.gz"
+          intel_archive="skillloom-${version}-x86_64-apple-darwin.tar.gz"
+          arm_sha="$(shasum -a 256 "release-assets/${arm_archive}" | awk '{print $1}')"
+          intel_sha="$(shasum -a 256 "release-assets/${intel_archive}" | awk '{print $1}')"
+          mkdir -p homebrew-tap/Formula
+          cat > homebrew-tap/Formula/skillloom.rb <<FORMULA
+          class Skillloom < Formula
+            desc "Git-backed skill manager and registry for AI coding agents"
+            homepage "https://github.com/majiayu000/loom"
+            version "${version}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "${base_url}/${arm_archive}"
+                sha256 "${arm_sha}"
+              else
+                url "${base_url}/${intel_archive}"
+                sha256 "${intel_sha}"
+              end
+            end
+
+            def install
+              bin.install "loom"
+            end
+
+            test do
+              assert_match "Skill manager", shell_output("#{bin}/loom --help")
+            end
+          end
+          FORMULA
+
+      - name: Open Homebrew tap PR
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        working-directory: homebrew-tap
+        env:
+          GH_TOKEN: ${{ env.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="skillloom-${GITHUB_REF_NAME}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add Formula/skillloom.rb
+          git commit -m "Update skillloom to ${GITHUB_REF_NAME}" || exit 0
+          git push --force-with-lease origin "$branch"
+          gh pr create \
+            --repo "$TAP_REPO" \
+            --head "$branch" \
+            --base main \
+            --title "Update skillloom to ${GITHUB_REF_NAME}" \
+            --body "Updates the skillloom formula for ${GITHUB_REF_NAME}."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,23 @@ name = "skillloom"
 version = "0.1.0"
 edition = "2024"
 build = "build.rs"
+description = "Git-backed skill manager and registry for AI coding agents"
+license = "MIT"
+repository = "https://github.com/majiayu000/loom"
+homepage = "https://github.com/majiayu000/loom"
+readme = "README.md"
+keywords = ["agents", "skills", "registry", "git", "cli"]
+categories = ["command-line-utilities", "development-tools"]
+exclude = [
+    "/.claude/",
+    "/.omx/",
+    "/docs/artifacts/",
+    "/panel/dist/",
+    "/panel/node_modules/",
+    "/skills/",
+    "/state/",
+    "/target/",
+]
 
 [[bin]]
 name = "loom"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 majiayu000
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ## Quick Start
 
 ```bash
-# 1. Install from source
+# 1. Install (available after the first tagged release)
+cargo install skillloom
+
+# or install from the Homebrew tap
+brew tap majiayu000/tap
+brew install skillloom
+
+# or install from source
 git clone https://github.com/majiayu000/loom.git
 cd loom && cargo install --path .
 

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ use std::time::SystemTime;
 const FRONTEND_INPUT_FILES: &[&str] = &[
     "package.json",
     "bun.lock",
+    "package-lock.json",
     "index.html",
     "landing.html",
     "vite.config.ts",
@@ -24,6 +25,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=panel/package.json");
     println!("cargo:rerun-if-changed=panel/bun.lock");
+    println!("cargo:rerun-if-changed=panel/package-lock.json");
     println!("cargo:rerun-if-changed=panel/index.html");
     println!("cargo:rerun-if-changed=panel/landing.html");
     println!("cargo:rerun-if-changed=panel/public");
@@ -36,13 +38,11 @@ fn main() {
     }
     fs::create_dir_all(&embedded_dist).expect("create embedded panel dir");
 
-    let dist_was_fresh = panel_dist_is_fresh(&panel_dir, &source_dist);
-    if !dist_was_fresh {
-        let _ = maybe_build_panel(&panel_dir);
-    }
-
     if panel_dist_is_fresh(&panel_dir, &source_dist) {
         copy_dir_recursive(&source_dist, &embedded_dist);
+        println!("cargo:rustc-env=LOOM_PANEL_EMBED_STATUS=ready");
+    } else if let Some(built_dist) = maybe_build_panel_in_out_dir(&panel_dir, &out_dir) {
+        copy_dir_recursive(&built_dist, &embedded_dist);
         println!("cargo:rustc-env=LOOM_PANEL_EMBED_STATUS=ready");
     } else {
         println!(
@@ -52,28 +52,63 @@ fn main() {
     }
 }
 
-fn maybe_build_panel(panel_dir: &Path) -> bool {
+fn maybe_build_panel_in_out_dir(panel_dir: &Path, out_dir: &Path) -> Option<PathBuf> {
     let bun = if cfg!(windows) { "bun.exe" } else { "bun" };
+    let build_dir = out_dir.join("panel-build");
+    if build_dir.exists() {
+        fs::remove_dir_all(&build_dir).ok()?;
+    }
+    fs::create_dir_all(&build_dir).ok()?;
+
+    copy_panel_inputs(panel_dir, &build_dir).ok()?;
 
     let install_status = Command::new(bun)
         .arg("install")
         .arg("--frozen-lockfile")
-        .current_dir(panel_dir)
+        .current_dir(&build_dir)
         .status();
 
     let Ok(install_status) = install_status else {
-        return false;
+        return None;
     };
     if !install_status.success() {
-        return false;
+        return None;
     }
 
-    Command::new(bun)
+    let build_ok = Command::new(bun)
         .arg("run")
         .arg("build")
-        .current_dir(panel_dir)
+        .current_dir(&build_dir)
         .status()
-        .is_ok_and(|status| status.success())
+        .is_ok_and(|status| status.success());
+    if !build_ok {
+        return None;
+    }
+
+    let built_dist = build_dir.join("dist");
+    if panel_dist_is_fresh(&build_dir, &built_dist) {
+        Some(built_dist)
+    } else {
+        None
+    }
+}
+
+fn copy_panel_inputs(source: &Path, destination: &Path) -> std::io::Result<()> {
+    for file in FRONTEND_INPUT_FILES {
+        let source_file = source.join(file);
+        if source_file.is_file() {
+            fs::copy(&source_file, destination.join(file))?;
+        }
+    }
+    for dir in FRONTEND_INPUT_DIRS {
+        let source_dir = source.join(dir);
+        if source_dir.is_dir() {
+            let destination_dir = destination.join(dir);
+            fs::create_dir_all(&destination_dir)?;
+            copy_dir_recursive_result(&source_dir, &destination_dir)?;
+        }
+    }
+    Ok(())
 }
 
 fn panel_dist_is_fresh(panel_dir: &Path, dist_dir: &Path) -> bool {
@@ -131,34 +166,42 @@ fn path_mtime(path: &Path) -> Option<SystemTime> {
 }
 
 fn copy_dir_recursive(source: &Path, destination: &Path) {
-    let entries = fs::read_dir(source).expect("read source dist dir");
+    copy_dir_recursive_result(source, destination).unwrap_or_else(|err| {
+        panic!(
+            "copy '{}' -> '{}' failed: {}",
+            display_path(source),
+            display_path(destination),
+            err
+        )
+    });
+}
+
+fn copy_dir_recursive_result(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let entries = fs::read_dir(source)?;
     for entry in entries {
-        let entry = entry.expect("read dist entry");
+        let entry = entry?;
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
-        let file_type = entry.file_type().expect("read dist file type");
+        let file_type = entry.file_type()?;
         if file_type.is_symlink() {
-            panic!(
-                "refusing to embed symlinked panel asset '{}'",
-                display_path(&source_path)
-            );
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "refusing to embed symlinked panel asset '{}'",
+                    display_path(&source_path)
+                ),
+            ));
         }
         if file_type.is_dir() {
-            fs::create_dir_all(&destination_path).expect("create embedded subdir");
-            copy_dir_recursive(&source_path, &destination_path);
+            fs::create_dir_all(&destination_path)?;
+            copy_dir_recursive_result(&source_path, &destination_path)?;
             continue;
         }
         if file_type.is_file() {
-            fs::copy(&source_path, &destination_path).unwrap_or_else(|err| {
-                panic!(
-                    "copy panel asset '{}' -> '{}' failed: {}",
-                    display_path(&source_path),
-                    display_path(&destination_path),
-                    err
-                )
-            });
+            fs::copy(&source_path, &destination_path)?;
         }
     }
+    Ok(())
 }
 
 fn display_path(path: &Path) -> String {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing Loom
+
+Loom is distributed as the `skillloom` crate with a `loom` binary.
+
+## Release Surfaces
+
+- GitHub Release: built from tags matching `v*.*.*`.
+- crates.io: published when `CARGO_REGISTRY_TOKEN` is configured.
+- Homebrew: opens a formula PR against `majiayu000/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured.
+
+The Homebrew formula installs the `loom` binary from GitHub Release archives. The crate name is `skillloom` because `loom` is already used by an unrelated crates.io package.
+
+## One-Time Setup
+
+Configure repository secrets:
+
+- `CARGO_REGISTRY_TOKEN`: crates.io token allowed to publish `skillloom`.
+- `HOMEBREW_TAP_TOKEN`: GitHub token allowed to push branches and open PRs in `majiayu000/homebrew-tap`.
+
+## Release Steps
+
+1. Update `Cargo.toml` version.
+2. Run local verification:
+
+   ```bash
+   make fmt-check
+   make lint
+   make test
+   make panel-build
+   cargo publish --dry-run --locked
+   ```
+
+3. Commit the version bump.
+4. Tag and push:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin main --tags
+   ```
+
+5. Watch the `Release` workflow.
+6. Merge the Homebrew tap PR if the workflow opens one.
+
+## Install Checks
+
+After the release is published:
+
+```bash
+cargo install skillloom
+loom --help
+```
+
+After the Homebrew PR is merged:
+
+```bash
+brew tap majiayu000/tap
+brew install skillloom
+loom --help
+```


### PR DESCRIPTION
## Summary
- add crates.io package metadata and MIT license for the skillloom crate
- make panel asset build publish-safe by building frontend assets under OUT_DIR instead of mutating panel/dist or panel/node_modules
- add a tag-driven release workflow that builds GitHub Release archives, optionally publishes crates.io, and opens a Homebrew tap PR
- document release steps and install surfaces

## Validation
- cargo publish --dry-run --locked --allow-dirty
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- make panel-build
- make panel-test
- make e2e
- actionlint .github/workflows/release.yml
- cargo build --release --locked
- target/release/loom --help