### PR TITLE
Simplify Loom CLI defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
             release-assets/SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
-            --title "skillloom ${GITHUB_REF_NAME#v}" \
+            --title "Loom ${GITHUB_REF_NAME}" \
             --notes "Release ${GITHUB_REF_NAME}."
 
   crates-io:
@@ -209,8 +209,8 @@ jobs:
           arm_sha="$(shasum -a 256 "release-assets/${arm_archive}" | awk '{print $1}')"
           intel_sha="$(shasum -a 256 "release-assets/${intel_archive}" | awk '{print $1}')"
           mkdir -p homebrew-tap/Formula
-          cat > homebrew-tap/Formula/skillloom.rb <<FORMULA
-          class Skillloom < Formula
+          cat > homebrew-tap/Formula/loom.rb <<FORMULA
+          class Loom < Formula
             desc "Git-backed skill manager and registry for AI coding agents"
             homepage "https://github.com/majiayu000/loom"
             version "${version}"
@@ -244,16 +244,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          branch="skillloom-${GITHUB_REF_NAME}"
+          branch="loom-${GITHUB_REF_NAME}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
-          git add Formula/skillloom.rb
-          git commit -m "Update skillloom to ${GITHUB_REF_NAME}" || exit 0
+          git add Formula/loom.rb
+          git commit -m "Update loom to ${GITHUB_REF_NAME}" || exit 0
           git push --force-with-lease origin "$branch"
           gh pr create \
             --repo "$TAP_REPO" \
             --head "$branch" \
             --base main \
-            --title "Update skillloom to ${GITHUB_REF_NAME}" \
-            --body "Updates the skillloom formula for ${GITHUB_REF_NAME}."
+            --title "Update loom to ${GITHUB_REF_NAME}" \
+            --body "Updates the loom formula for ${GITHUB_REF_NAME}."

--- a/README.md
+++ b/README.md
@@ -35,40 +35,50 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ## Quick Start
 
 ```bash
-# 1. Install (available after the first tagged release)
+# 1. Install
 cargo install skillloom
 
-# or install from the Homebrew tap
-brew tap majiayu000/tap
-brew install skillloom
+# or install from the Homebrew tap after its formula PR is merged
+brew install majiayu000/tap/loom
 
 # or install from source
 git clone https://github.com/majiayu000/loom.git
 cd loom && cargo install --path .
 
-# 2. Set up a registry directory (must be separate from the Loom tool repo)
-mkdir -p ~/.loom-registry
-loom --root ~/.loom-registry workspace init
+# 2. Initialize the default registry and auto-register existing agent skill dirs
+loom init
 
-# 3. Import a skill into the registry
-loom --root ~/.loom-registry skill add "$HOME/.claude/skills/my-skill" --name my-skill
+# 3. Import/update observed skills once, or keep watching in the foreground
+loom monitor --once
+loom monitor --interval-seconds 30
+```
 
-# 4. Register a managed Claude Code target
+Loom defaults to `~/.loom-registry`. Pass `--root <dir>` only when you want a different registry.
+
+For managed projection flows:
+
+```bash
+# Import a skill into the registry
+loom skill add "$HOME/.claude/skills/my-skill" --name my-skill
+
+# Register a managed Claude Code target
 mkdir -p "$HOME/.loom-targets/claude/skills"
-loom --root ~/.loom-registry target add \
-  --agent claude --path "$HOME/.loom-targets/claude/skills" --ownership managed
+TARGET_ID="$(
+  loom --json target add \
+    --agent claude --path "$HOME/.loom-targets/claude/skills" --ownership managed \
+    | jq -r '.data.target.target_id'
+)"
 
-# 5. Bind this project/workspace to that target
-TARGET_ID="$(loom --json --root ~/.loom-registry target list | jq -r '.data.targets[0].target_id')"
-loom --root ~/.loom-registry workspace binding add \
+# Bind this project/workspace to that target
+loom workspace binding add \
   --agent claude --profile home \
   --matcher-kind path-prefix --matcher-value "$PWD" \
   --target "$TARGET_ID"
 
-# 6. Project the skill, then open the control panel
-BINDING_ID="$(loom --json --root ~/.loom-registry workspace binding list | jq -r '.data.bindings[0].binding_id')"
-loom --root ~/.loom-registry skill project my-skill --binding "$BINDING_ID" --method symlink
-loom --root ~/.loom-registry panel        # → http://localhost:43117
+# Project the skill, then open the control panel
+BINDING_ID="$(loom --json workspace binding list | jq -r '.data.bindings[0].binding_id')"
+loom skill project my-skill --binding "$BINDING_ID" --method symlink
+loom panel        # -> http://localhost:43117
 ```
 
 `loom panel` now serves a frontend bundled into the Rust binary at build time, so it works even when `--root` points at a separate registry directory. If panel assets are unavailable in your build, reinstall from a checkout with `bun` available so Loom can package the frontend during compile.
@@ -164,8 +174,12 @@ Four core concepts:
 <summary><strong>Full CLI reference</strong> (click to expand)</summary>
 
 ```bash
+loom init
+loom monitor [--target <target-id>] [--once] [--interval-seconds <seconds>]
+
 loom workspace status
 loom workspace doctor
+loom workspace init [--scan-existing]
 loom workspace binding add --agent <claude|codex> --profile <id> --matcher-kind <path-prefix|exact-path|name> --matcher-value <value> --target <target-id> [--policy-profile <id>]
 loom workspace binding list
 loom workspace binding show <binding-id>
@@ -203,7 +217,7 @@ loom ops history repair --strategy <local|remote>
 loom panel [--port 43117]
 ```
 
-Most commands support `--json` for machine-readable output.
+Most commands support `--json` for machine-readable output. Commands default to `~/.loom-registry`; use `--root <dir>` to override that registry.
 
 </details>
 
@@ -220,11 +234,11 @@ loom target list
 Use this when the real source of truth is still an agent skill directory such as `~/.claude/skills` or `~/.codex/skills`.
 
 ```bash
-loom skill monitor-observed --once
-loom skill monitor-observed --interval-seconds 30
+loom monitor --once
+loom monitor --interval-seconds 30
 ```
 
-`monitor-observed` imports new observed skills and updates existing registry copies when file content changes. It does not delete registry skills when an observed directory disappears; deletion stays an explicit cleanup action.
+`loom monitor` is a short alias for `loom skill monitor-observed`. It imports new observed skills and updates existing registry copies when file content changes. It does not delete registry skills when an observed directory disappears; deletion stays an explicit cleanup action.
 
 ## Agent E2E (Recommended)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,9 +6,9 @@ Loom is distributed as the `skillloom` crate with a `loom` binary.
 
 - GitHub Release: built from tags matching `v*.*.*`.
 - crates.io: published when `CARGO_REGISTRY_TOKEN` is configured.
-- Homebrew: opens a formula PR against `majiayu000/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured.
+- Homebrew: opens a `loom` formula PR against `majiayu000/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured.
 
-The Homebrew formula installs the `loom` binary from GitHub Release archives. The crate name is `skillloom` because `loom` is already used by an unrelated crates.io package.
+The Homebrew formula installs the `loom` binary from GitHub Release archives. The crate name remains `skillloom` because `loom` is already used by an unrelated crates.io package.
 
 ## One-Time Setup
 
@@ -53,7 +53,6 @@ loom --help
 After the Homebrew PR is merged:
 
 ```bash
-brew tap majiayu000/tap
-brew install skillloom
+brew install majiayu000/tap/loom
 loom --help
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub request_id: Option<String>,
 
-    /// Registry root. Use a separate Git repo, not the Loom tool checkout.
+    /// Registry root. Defaults to ~/.loom-registry.
     #[arg(long, global = true)]
     pub root: Option<PathBuf>,
 
@@ -25,6 +25,10 @@ pub struct Cli {
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum Command {
+    #[command(about = "Initialize the default registry and scan existing agent skill directories")]
+    Init,
+    #[command(about = "Import and update skills from observed targets")]
+    Monitor(MonitorObservedArgs),
     #[command(about = "Inspect and configure registry workspace state")]
     Workspace {
         #[command(subcommand)]

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -92,6 +92,8 @@ pub(crate) fn validate_skill_name(skill: &str) -> Result<()> {
 
 pub(crate) fn command_name(command: &Command) -> &'static str {
     match command {
+        Command::Init => "init",
+        Command::Monitor(_) => "monitor",
         Command::Workspace { command } => match command {
             WorkspaceCommand::Status => "workspace.status",
             WorkspaceCommand::Doctor => "workspace.doctor",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use crate::cli::{
     Cli, Command, OpsCommand, OpsHistoryCommand, RemoteCommand, SkillCommand, SkillOrphanCommand,
-    SyncCommand, TargetCommand, WorkspaceBindingCommand, WorkspaceCommand,
+    SyncCommand, TargetCommand, WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs,
 };
 use crate::envelope::{Envelope, Meta};
 use crate::state::AppContext;
@@ -115,6 +115,13 @@ impl App {
         }
 
         let result = match &cli.command {
+            Command::Init => {
+                let args = WorkspaceInitArgs {
+                    scan_existing: true,
+                };
+                self.cmd_workspace_init(&args, &request_id)
+            }
+            Command::Monitor(args) => self.cmd_monitor_observed(args, &request_id),
             Command::Workspace { command } => match command {
                 WorkspaceCommand::Status => self.cmd_status(),
                 WorkspaceCommand::Doctor => self.cmd_doctor(),
@@ -246,6 +253,7 @@ impl App {
 
 fn command_requires_durable_audit(command: &Command) -> bool {
     match command {
+        Command::Init | Command::Monitor(_) => true,
         Command::Workspace { command } => match command {
             WorkspaceCommand::Status | WorkspaceCommand::Doctor => false,
             WorkspaceCommand::Init(_) => true,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -19,6 +19,7 @@ use anyhow::{Context, Result};
 use crate::types::PendingOp;
 
 const OPS_COMPACTION_THRESHOLD: usize = 16;
+pub const DEFAULT_REGISTRY_DIR: &str = ".loom-registry";
 
 type InProcMap = Arc<Mutex<HashMap<String, (PathBuf, std::thread::ThreadId, usize)>>>;
 
@@ -162,8 +163,10 @@ fn dedupe_paths_keep_order(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 
 impl AppContext {
     pub fn new(root: Option<PathBuf>) -> Result<Self> {
-        let root =
-            root.unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
+        let root = match root {
+            Some(root) => root,
+            None => default_registry_root()?,
+        };
         let skills_dir = root.join("skills");
         let state_dir = root.join("state");
         let locks_dir = state_dir.join("locks");
@@ -308,6 +311,26 @@ impl AppContext {
         write_atomic(&path, &content).context("failed to update .gitignore")?;
         Ok(())
     }
+}
+
+pub fn default_registry_root() -> Result<PathBuf> {
+    home_dir()
+        .map(|home| home.join(DEFAULT_REGISTRY_DIR))
+        .context("HOME is not set; pass --root <registry>")
+}
+
+fn home_dir() -> Option<PathBuf> {
+    non_empty_env_path("HOME").or_else(|| non_empty_env_path("USERPROFILE"))
+}
+
+fn non_empty_env_path(key: &str) -> Option<PathBuf> {
+    env::var_os(key).and_then(|value| {
+        if value.as_os_str().is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(value))
+        }
+    })
 }
 
 #[derive(Debug)]

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::process::Command;
 
 mod common;
@@ -20,6 +21,8 @@ fn top_level_help_describes_command_groups() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     for expected in [
+        "Initialize the default registry and scan existing agent skill directories",
+        "Import and update skills from observed targets",
         "Inspect and configure registry workspace state",
         "Register and inspect agent skill directories",
         "Manage skill sources, projections, and versions",
@@ -32,6 +35,44 @@ fn top_level_help_describes_command_groups() {
             "help missing command description {expected:?}: {stdout}"
         );
     }
+}
+
+#[test]
+fn top_level_init_uses_default_registry_root_and_scans_existing_dirs() {
+    let home = TestDir::new("cli-default-home");
+    let codex_skill = home.path().join(".codex/skills/demo-skill");
+    fs::create_dir_all(&codex_skill).expect("create codex skill dir");
+    fs::write(codex_skill.join("SKILL.md"), "# Demo\n").expect("write skill");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--json")
+        .arg("init")
+        .env("HOME", home.path())
+        .env_remove("CODEX_SKILLS_DIR")
+        .env_remove("CLAUDE_SKILLS_DIR")
+        .output()
+        .expect("run loom init");
+
+    assert!(
+        output.status.success(),
+        "init unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let env: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse loom init json");
+    assert_eq!(env["cmd"], serde_json::json!("init"));
+    assert_eq!(env["data"]["scanned"], serde_json::json!(true));
+    assert_eq!(
+        env["data"]["imported"].as_array().map(|items| items.len()),
+        Some(1)
+    );
+    assert!(
+        home.path()
+            .join(".loom-registry/state/registry/targets.json")
+            .is_file()
+    );
 }
 
 #[test]
@@ -104,6 +145,29 @@ fn skill_monitor_observed_command_is_available() {
         assert!(
             stdout.contains(expected),
             "monitor-observed help missing {expected:?}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn top_level_monitor_command_is_available() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["monitor", "--help"])
+        .output()
+        .expect("run loom");
+
+    assert!(
+        output.status.success(),
+        "monitor help failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in ["--once", "--interval-seconds", "--target"] {
+        assert!(
+            stdout.contains(expected),
+            "monitor help missing {expected:?}: {stdout}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- default Loom commands to ~/.loom-registry when --root is omitted
- add top-level loom init and loom monitor aliases for the common observed-skill workflow
- update README, release docs, and Homebrew tap formula generation to use the loom user-facing command

## Validation
- cargo test -q --test cli_surface
- cargo test -q
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- actionlint .github/workflows/release.yml
- target/debug/loom --help
- target/debug/loom monitor --help
- temp HOME smoke test: loom --json init && loom --json monitor --once