### PR TITLE
fix: harden audit-critical registry flows

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -118,6 +118,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function unwrapReadData<T>(path: string, body: unknown): T {
+  if (
+    isRecord(body) &&
+    body.ok === true &&
+    typeof body.cmd === "string" &&
+    typeof body.request_id === "string"
+  ) {
+    if (!("data" in body)) {
+      throw new ApiError(path, 200, `GET ${path} envelope is missing data`);
+    }
+    return body.data as T;
+  }
+  return body as T;
+}
+
 function parseRemoteStatusResponse(path: string, body: unknown): RemoteStatusResponse {
   if (!isRecord(body)) {
     throw new ApiError(path, 200, `GET ${path} returned malformed remote status payload`);
@@ -176,6 +191,10 @@ async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
   }
 
   return body as T;
+}
+
+async function getJsonData<T>(path: string, signal?: AbortSignal): Promise<T> {
+  return unwrapReadData<T>(path, await getJson<unknown>(path, signal));
 }
 
 async function postJson(path: string, body: unknown): Promise<CommandEnvelope> {
@@ -300,8 +319,8 @@ export interface SkillHistoryPayload {
 
 export const api = {
   health: (signal?: AbortSignal) => getJson<HealthPayload>("/api/health", signal),
-  info: (signal?: AbortSignal) => getJson<InfoPayload>("/api/info", signal),
-  skills: (signal?: AbortSignal) => getJson<SkillsPayload>("/api/skills", signal),
+  info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/info", signal),
+  skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/skills", signal),
   registryStatus: (signal?: AbortSignal) => getJson<RegistryPayload>("/api/registry/status", signal),
   opsHistoryDiagnose: (signal?: AbortSignal) =>
     getJson<OpsHistoryDiagnosePayload>("/api/registry/ops/diagnose", signal),
@@ -317,8 +336,14 @@ export const api = {
   targetShow: (id: string, signal?: AbortSignal) =>
     getJson<TargetShowPayload>(`/api/registry/targets/${encodeURIComponent(id)}`, signal),
   remoteStatus: async (signal?: AbortSignal) =>
-    parseRemoteStatusResponse("/api/remote/status", await getJson<unknown>("/api/remote/status", signal)),
-  pending: (signal?: AbortSignal) => getJson<PendingPayload>("/api/pending", signal),
+    parseRemoteStatusResponse(
+      "/api/remote/status",
+      unwrapReadData<RemoteStatusResponse>(
+        "/api/remote/status",
+        await getJson<unknown>("/api/remote/status", signal),
+      ),
+    ),
+  pending: (signal?: AbortSignal) => getJsonData<PendingPayload>("/api/pending", signal),
 
   opsRetry: () => postJson("/api/ops/retry", {}),
   opsPurge: () => postJson("/api/ops/purge", {}),

--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -11,8 +11,11 @@ use crate::cli::Cli;
 use crate::envelope::Envelope;
 use crate::state::AppContext;
 
+const COMMAND_EVENT_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Debug, Serialize)]
 struct CommandEvent {
+    schema_version: u32,
     event_id: String,
     request_id: String,
     cmd: String,
@@ -53,6 +56,7 @@ pub(crate) fn append_command_started(
     request_id: &str,
 ) -> Result<()> {
     let event = CommandEvent {
+        schema_version: COMMAND_EVENT_SCHEMA_VERSION,
         event_id: format!("evt_{}", Uuid::new_v4().simple()),
         request_id: request_id.to_string(),
         cmd: cmd.to_string(),
@@ -99,6 +103,7 @@ fn append_command_finished_with_fault_tags(
     fault_tags: &[&str],
 ) -> Result<()> {
     let event = CommandEvent {
+        schema_version: COMMAND_EVENT_SCHEMA_VERSION,
         event_id: format!("evt_{}", Uuid::new_v4().simple()),
         request_id: envelope.request_id.clone(),
         cmd: cmd.to_string(),
@@ -192,7 +197,7 @@ fn redact_sensitive_strings(value: &mut serde_json::Value) {
     }
 }
 
-fn redact_sensitive_string(raw: &str) -> String {
+pub(crate) fn redact_sensitive_string(raw: &str) -> String {
     if looks_like_secret(raw) {
         return "<redacted>".to_string();
     }

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -239,3 +239,36 @@ pub(super) fn create_symlink_dir(src: &Path, dst: &Path) -> Result<()> {
     std::os::windows::fs::symlink_dir(src, dst).context("failed to create symlink")?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::copy_dir_recursive_without_symlinks;
+    use std::fs;
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_without_symlinks_rejects_nested_symlink() {
+        let base = std::env::temp_dir().join(format!(
+            "loom-copy-no-symlink-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let src = base.join("src");
+        let dst = base.join("dst");
+        fs::create_dir_all(&src).expect("src dir");
+        fs::write(src.join("SKILL.md"), "# skill\n").expect("skill file");
+        std::os::unix::fs::symlink("/tmp/secret", src.join("secret-link")).expect("symlink");
+
+        let err =
+            copy_dir_recursive_without_symlinks(&src, &dst).expect_err("symlink must be rejected");
+        assert!(
+            err.to_string().contains("unsupported symlink"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !dst.join("secret-link").exists(),
+            "symlink path must not be copied"
+        );
+
+        let _ = fs::remove_dir_all(base);
+    }
+}

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -195,6 +195,40 @@ pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn copy_dir_recursive_preserving_symlinks(src: &Path, dst: &Path) -> Result<()> {
+    if !src.exists() {
+        return Err(anyhow!("source does not exist: {}", src.display()));
+    }
+    fs::create_dir_all(dst).with_context(|| format!("failed to create {}", dst.display()))?;
+
+    for entry in WalkDir::new(src).follow_links(false).into_iter() {
+        let entry = entry.with_context(|| format!("failed to walk {}", src.display()))?;
+        let rel = entry.path().strip_prefix(src)?;
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+
+        let target = dst.join(rel);
+        if entry.file_type().is_dir() {
+            fs::create_dir_all(&target)?;
+        } else if entry.file_type().is_symlink() {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let link_target = fs::read_link(entry.path())
+                .with_context(|| format!("failed to read symlink {}", entry.path().display()))?;
+            create_symlink_like(entry.path(), &link_target, &target)?;
+        } else if entry.file_type().is_file() {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(entry.path(), &target)?;
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn copy_dir_recursive_without_symlinks(src: &Path, dst: &Path) -> Result<()> {
     if !src.exists() {
         return Err(anyhow!("source does not exist: {}", src.display()));
@@ -237,6 +271,27 @@ pub(super) fn create_symlink_dir(src: &Path, dst: &Path) -> Result<()> {
 #[cfg(windows)]
 pub(super) fn create_symlink_dir(src: &Path, dst: &Path) -> Result<()> {
     std::os::windows::fs::symlink_dir(src, dst).context("failed to create symlink")?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_symlink_like(_source_link: &Path, link_target: &Path, dst: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(link_target, dst).context("failed to copy symlink")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn create_symlink_like(source_link: &Path, link_target: &Path, dst: &Path) -> Result<()> {
+    if fs::metadata(source_link)
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
+    {
+        std::os::windows::fs::symlink_dir(link_target, dst)
+            .context("failed to copy dir symlink")?;
+    } else {
+        std::os::windows::fs::symlink_file(link_target, dst)
+            .context("failed to copy file symlink")?;
+    }
     Ok(())
 }
 

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -18,7 +18,7 @@ use super::CommandFailure;
 
 // Re-export items from sibling modules so existing `use super::helpers::*` paths keep working.
 pub(crate) use super::file_ops::{
-    backup_path_if_exists, copy_dir_recursive, copy_dir_recursive_without_symlinks, read_git_field,
+    backup_path_if_exists, copy_dir_recursive_without_symlinks, read_git_field,
     restore_path_from_backup, rollback_added_skill,
 };
 pub use super::projections::{collect_skill_inventory, remote_status_payload};

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -228,6 +228,25 @@ pub(crate) fn validate_non_empty(
     Ok(())
 }
 
+pub(crate) fn validate_policy_profile(value: &str) -> std::result::Result<(), CommandFailure> {
+    if !(1..=64).contains(&value.len()) {
+        return Err(CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            "--policy-profile must be 1-64 characters",
+        ));
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | '_'))
+    {
+        return Err(CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            "--policy-profile must match [a-z0-9_-]{1,64}",
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_projection_method(
     target: &RegistryProjectionTarget,
     method: ProjectionMethod,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -82,6 +82,15 @@ impl App {
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         let input = command_event_input(&cli, &request_id);
         let audit_required = command_requires_durable_audit(&cli.command);
+        if audit_required && let Err(err) = self.ctx.ensure_not_loom_tool_repo_root() {
+            let message = err.to_string();
+            let message = message
+                .strip_prefix("ARG_INVALID:")
+                .map(str::trim)
+                .unwrap_or(&message);
+            let env = Envelope::err(cmd, request_id, ErrorCode::ArgInvalid, message, json!({}));
+            return Ok((env, ErrorCode::ArgInvalid.exit_code()));
+        }
         let mut audit_started = false;
         let mut audit_warning = None;
         match prepare_command_event_store(&self.ctx) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ use crate::envelope::{Envelope, Meta};
 use crate::state::AppContext;
 use crate::types::ErrorCode;
 
+pub(crate) use event_store::redact_sensitive_string;
 pub use helpers::{collect_skill_inventory, remote_status_payload};
 
 use event_store::{
@@ -60,6 +61,7 @@ impl App {
     }
 
     pub(crate) fn ensure_write_layout(&self) -> std::result::Result<(), CommandFailure> {
+        self.ctx.ensure_not_loom_tool_repo_root().map_err(map_io)?;
         self.ctx.ensure_state_layout().map_err(map_io)?;
         Ok(())
     }

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -18,6 +18,7 @@ use crate::state_model::{
 use crate::types::{ErrorCode, SyncState};
 
 use super::CommandFailure;
+use super::event_store::redact_sensitive_string;
 use super::file_ops::{
     copy_dir_recursive, copy_dir_recursive_preserving_symlinks, create_symlink_dir,
 };
@@ -441,6 +442,7 @@ pub(crate) fn remote_status_payload_with_pending(
     let url = gitops::remote_url(ctx)
         .map_err(map_git)?
         .unwrap_or_default();
+    let redacted_url = redact_sensitive_string(&url);
     let mut meta = Meta {
         warnings: pending_report.warnings,
         sync_state: None,
@@ -461,7 +463,7 @@ pub(crate) fn remote_status_payload_with_pending(
             json!({
                 "configured": true,
                 "remote": "origin",
-                "url": url,
+                "url": redacted_url,
                 "pending_ops": pending,
                 "tracking_ref": false,
                 "sync_state": sync_state,
@@ -486,7 +488,7 @@ pub(crate) fn remote_status_payload_with_pending(
         json!({
             "configured": true,
             "remote": "origin",
-            "url": url,
+            "url": redacted_url,
             "ahead": ahead,
             "behind": behind,
             "pending_ops": pending,

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -18,7 +18,9 @@ use crate::state_model::{
 use crate::types::{ErrorCode, SyncState};
 
 use super::CommandFailure;
-use super::file_ops::{copy_dir_recursive, create_symlink_dir};
+use super::file_ops::{
+    copy_dir_recursive, copy_dir_recursive_preserving_symlinks, create_symlink_dir,
+};
 use super::helpers::{map_git, map_io, map_push_rejected, map_queue, map_remote_unreachable};
 use crate::state::remove_path_if_exists;
 
@@ -72,7 +74,22 @@ pub(crate) fn project_skill_to_target(
 ) -> Result<()> {
     match method {
         ProjectionMethod::Symlink => create_symlink_dir(src, dst),
-        ProjectionMethod::Copy | ProjectionMethod::Materialize => {
+        ProjectionMethod::Copy => {
+            let parent = dst
+                .parent()
+                .context("projection target has no parent directory")?;
+            let tmp_dir = parent.join(format!(".loom-tmp-{}", Uuid::new_v4()));
+            if let Err(err) = copy_dir_recursive_preserving_symlinks(src, &tmp_dir) {
+                let _ = remove_path_if_exists(&tmp_dir);
+                return Err(err);
+            }
+            if let Err(err) = std::fs::rename(&tmp_dir, dst) {
+                let _ = remove_path_if_exists(&tmp_dir);
+                return Err(err).context("failed to atomically place projection");
+            }
+            Ok(())
+        }
+        ProjectionMethod::Materialize => {
             let parent = dst
                 .parent()
                 .context("projection target has no parent directory")?;
@@ -611,6 +628,42 @@ mod project_skill_tests {
         let dst = base.join("dst-mat");
         project_skill_to_target(&src, &dst, ProjectionMethod::Materialize).expect("materialize ok");
         assert!(dst.join("SKILL.md").is_file());
+        let _ = stdfs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_preserves_symlink_but_materialize_resolves_it() {
+        let base = scratch_dir("copy-vs-materialize-symlink");
+        let src = make_skill_src(&base);
+        let secret = base.join("secret.txt");
+        stdfs::write(&secret, "secret contents\n").expect("secret file");
+        std::os::unix::fs::symlink(&secret, src.join("secret-link")).expect("source symlink");
+
+        let copy_dst = base.join("dst-copy");
+        project_skill_to_target(&src, &copy_dst, ProjectionMethod::Copy).expect("copy ok");
+        assert!(
+            stdfs::symlink_metadata(copy_dst.join("secret-link"))
+                .expect("copy link metadata")
+                .file_type()
+                .is_symlink(),
+            "copy must preserve the symlink instead of dereferencing it"
+        );
+
+        let mat_dst = base.join("dst-mat");
+        project_skill_to_target(&src, &mat_dst, ProjectionMethod::Materialize)
+            .expect("materialize ok");
+        assert!(
+            stdfs::symlink_metadata(mat_dst.join("secret-link"))
+                .expect("materialized link metadata")
+                .is_file(),
+            "materialize must produce a real file"
+        );
+        assert_eq!(
+            stdfs::read_to_string(mat_dst.join("secret-link")).expect("materialized content"),
+            "secret contents\n"
+        );
+
         let _ = stdfs::remove_dir_all(&base);
     }
 

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -25,13 +25,12 @@ use crate::types::ErrorCode;
 
 use super::fs_probe::probe_symlink;
 use super::helpers::{
-    backup_path_if_exists, commit_registry_state, copy_dir_recursive,
-    copy_dir_recursive_without_symlinks, ensure_skill_exists, map_arg, map_git, map_io, map_lock,
-    map_project_io, map_registry_state, maybe_autosync_or_queue, project_skill_to_target,
-    projection_instance_id, projection_method_as_str, record_registry_operation,
-    resolve_capture_projection, restore_path_from_backup, rollback_added_skill,
-    update_projection_after_capture, upsert_projection, upsert_rule, validate_projection_method,
-    validate_skill_name,
+    backup_path_if_exists, commit_registry_state, copy_dir_recursive_without_symlinks,
+    ensure_skill_exists, map_arg, map_git, map_io, map_lock, map_project_io, map_registry_state,
+    maybe_autosync_or_queue, project_skill_to_target, projection_instance_id,
+    projection_method_as_str, record_registry_operation, resolve_capture_projection,
+    restore_path_from_backup, rollback_added_skill, update_projection_after_capture,
+    upsert_projection, upsert_rule, validate_projection_method, validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -75,7 +74,13 @@ impl App {
             }
         } else {
             let source = args.source.as_str();
-            let clone = gitops::run_git_allow_failure(
+            gitops::validate_git_url(source).map_err(|err| {
+                CommandFailure::new(
+                    ErrorCode::ArgInvalid,
+                    format!("invalid git source '{}': {}", source, err),
+                )
+            })?;
+            let clone = gitops::run_git_allow_failure_restricted(
                 &self.ctx,
                 &[
                     "clone",
@@ -371,7 +376,7 @@ impl App {
                 .state_dir
                 .join(format!("tmp-capture-{}", Uuid::new_v4()));
             let _ = remove_path_if_exists(&tmp_path);
-            if let Err(err) = copy_dir_recursive(&live_path, &tmp_path) {
+            if let Err(err) = copy_dir_recursive_without_symlinks(&live_path, &tmp_path) {
                 let _ = remove_path_if_exists(&tmp_path);
                 return Err(map_io(err));
             }

--- a/src/commands/workspace_cmds.rs
+++ b/src/commands/workspace_cmds.rs
@@ -23,13 +23,41 @@ use super::helpers::{
     agent_kind_as_str, collect_skill_inventory, commit_registry_state, map_git, map_io, map_lock,
     map_registry_state, maybe_autosync_or_queue, read_git_field, record_registry_operation,
     remote_status_payload, remote_status_payload_with_pending, unique_binding_id,
-    validate_non_empty, workspace_matcher_kind_as_str,
+    validate_non_empty, validate_policy_profile, workspace_matcher_kind_as_str,
 };
 use super::{App, CommandFailure};
 
 enum LivePathCleanup {
     Deleted(String),
     Skipped { path: String, reason: &'static str },
+}
+
+const DEFAULT_SCAN_AGENTS: [AgentKind; 10] = [
+    AgentKind::Claude,
+    AgentKind::Codex,
+    AgentKind::Cursor,
+    AgentKind::Windsurf,
+    AgentKind::Cline,
+    AgentKind::Copilot,
+    AgentKind::Aider,
+    AgentKind::Opencode,
+    AgentKind::GeminiCli,
+    AgentKind::Goose,
+];
+
+fn default_skill_dir(agent: AgentKind, home: &str) -> PathBuf {
+    match agent {
+        AgentKind::Claude => PathBuf::from(format!("{home}/.claude/skills")),
+        AgentKind::Codex => PathBuf::from(format!("{home}/.codex/skills")),
+        AgentKind::Cursor => PathBuf::from(format!("{home}/.cursor/skills")),
+        AgentKind::Windsurf => PathBuf::from(format!("{home}/.windsurf/skills")),
+        AgentKind::Cline => PathBuf::from(format!("{home}/.cline/skills")),
+        AgentKind::Copilot => PathBuf::from(format!("{home}/.github/copilot/skills")),
+        AgentKind::Aider => PathBuf::from(format!("{home}/.aider/skills")),
+        AgentKind::Opencode => PathBuf::from(format!("{home}/.opencode/skills")),
+        AgentKind::GeminiCli => PathBuf::from(format!("{home}/.gemini/skills")),
+        AgentKind::Goose => PathBuf::from(format!("{home}/.config/goose/skills")),
+    }
 }
 
 fn cleanup_orphan_live_path(
@@ -251,12 +279,10 @@ impl App {
                     "--scan-existing requires HOME to be set",
                 )
             })?;
-            let candidates = [
-                (AgentKind::Claude, format!("{}/.claude/skills", home)),
-                (AgentKind::Codex, format!("{}/.codex/skills", home)),
-            ];
-            for (agent, path_str) in candidates {
-                let p = Path::new(&path_str);
+            for agent in DEFAULT_SCAN_AGENTS {
+                let path = default_skill_dir(agent, &home);
+                let path_str = path.display().to_string();
+                let p = path.as_path();
                 if !p.exists() {
                     skipped.push(json!({
                         "agent": agent_kind_as_str(agent),
@@ -364,7 +390,7 @@ impl App {
         validate_non_empty("profile", &args.profile)?;
         validate_non_empty("matcher_value", &args.matcher_value)?;
         validate_non_empty("target", &args.target)?;
-        validate_non_empty("policy_profile", &args.policy_profile)?;
+        validate_policy_profile(&args.policy_profile)?;
 
         let paths = self.ensure_registry_layout()?;
         let snapshot = paths.load_snapshot().map_err(map_registry_state)?;

--- a/src/commands/workspace_cmds.rs
+++ b/src/commands/workspace_cmds.rs
@@ -644,6 +644,12 @@ impl App {
             RemoteCommand::Set { url } => {
                 let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
                 self.ensure_write_repo_ready()?;
+                gitops::validate_git_url(url).map_err(|err| {
+                    CommandFailure::new(
+                        ErrorCode::ArgInvalid,
+                        format!("invalid remote url '{}': {}", url, err),
+                    )
+                })?;
                 gitops::set_remote_origin(&self.ctx, url).map_err(map_git)?;
                 Ok((json!({"remote": "origin", "url": url}), Meta::default()))
             }

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -67,7 +67,11 @@ fn run_git_raw_in_with_env_mode_and_input(
         .arg("-c")
         .arg("protocol.https.allow=always")
         .arg("-c")
-        .arg("protocol.ssh.allow=always")
+        .arg("protocol.ssh.allow=always");
+    if matches!(env_mode, GitEnvMode::Normal) {
+        command.arg("-c").arg("protocol.file.allow=always");
+    }
+    command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .args(args);
@@ -421,7 +425,33 @@ pub fn validate_git_url(raw: &str) -> Result<()> {
             )),
         };
     }
+    let path = Path::new(url);
+    if path.is_absolute() {
+        return validate_local_git_remote_path(path);
+    }
     validate_scp_like_git_url(url)
+}
+
+fn validate_local_git_remote_path(path: &Path) -> Result<()> {
+    if !path.exists() {
+        if path.extension().is_some_and(|extension| extension == "git") {
+            return Ok(());
+        }
+        return Err(anyhow!(
+            "local git remote path does not exist: {}",
+            path.display()
+        ));
+    }
+    if path.join(".git").is_dir() {
+        return Ok(());
+    }
+    if path.join("HEAD").is_file() && path.join("objects").is_dir() {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "local git remote path must point to a git repository: {}",
+        path.display()
+    ))
 }
 
 fn validate_scp_like_git_url(url: &str) -> Result<()> {
@@ -519,12 +549,54 @@ impl Drop for TempFile {
 #[cfg(test)]
 mod tests {
     use super::validate_git_url;
+    use std::fs;
+    use std::process::Command;
 
     #[test]
     fn git_url_validation_accepts_https_and_ssh_forms() {
         validate_git_url("https://github.com/org/repo.git").expect("https accepted");
         validate_git_url("ssh://git@github.com/org/repo.git").expect("ssh accepted");
         validate_git_url("git@github.com:org/repo.git").expect("scp-like ssh accepted");
+    }
+
+    #[test]
+    fn git_url_validation_accepts_existing_local_git_repo_path() {
+        let base = std::env::temp_dir().join(format!(
+            "loom-local-remote-url-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let repo = base.join("origin.git");
+        fs::create_dir_all(&base).expect("base dir");
+        let output = Command::new("git")
+            .arg("init")
+            .arg("--bare")
+            .arg(&repo)
+            .output()
+            .expect("git init --bare");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        validate_git_url(repo.to_string_lossy().as_ref()).expect("local bare repo accepted");
+
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn git_url_validation_accepts_missing_local_git_path_for_later_creation() {
+        let base = std::env::temp_dir().join(format!(
+            "loom-missing-local-remote-url-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let repo = base.join("future.git");
+        fs::create_dir_all(&base).expect("base dir");
+
+        validate_git_url(repo.to_string_lossy().as_ref())
+            .expect("missing .git path accepted for later creation");
+
+        let _ = fs::remove_dir_all(base);
     }
 
     #[test]

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -23,19 +23,51 @@ const HISTORY_COMPACT_AFTER_SEGMENTS: usize = 8;
 const HISTORY_RETAIN_RECENT_SEGMENTS: usize = 4;
 const HISTORY_RETAIN_ARCHIVES: usize = 4;
 
+#[derive(Debug, Clone, Copy)]
+enum GitEnvMode {
+    Normal,
+    Restricted,
+}
+
 fn run_git_raw_in_with_env_and_input(
     repo_dir: &Path,
     envs: &[(&str, &str)],
     input: Option<&[u8]>,
     args: &[&str],
 ) -> Result<Output> {
+    run_git_raw_in_with_env_mode_and_input(repo_dir, envs, input, args, GitEnvMode::Normal)
+}
+
+fn run_git_raw_in_with_env_mode_and_input(
+    repo_dir: &Path,
+    envs: &[(&str, &str)],
+    input: Option<&[u8]>,
+    args: &[&str],
+    env_mode: GitEnvMode,
+) -> Result<Output> {
     let mut command = Command::new("git");
+    if matches!(env_mode, GitEnvMode::Restricted) {
+        command.env_clear();
+        if let Some(path) = std::env::var_os("PATH") {
+            command.env("PATH", path);
+        }
+        command
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_TERMINAL_PROMPT", "0");
+    }
     command
         .current_dir(repo_dir)
         .arg("-c")
         .arg("commit.gpgsign=false")
         .arg("-c")
         .arg("tag.gpgSign=false")
+        .arg("-c")
+        .arg("protocol.allow=never")
+        .arg("-c")
+        .arg("protocol.https.allow=always")
+        .arg("-c")
+        .arg("protocol.ssh.allow=always")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .args(args);
@@ -89,6 +121,10 @@ fn run_git_in_with_input(repo_dir: &Path, args: &[&str], input: &[u8]) -> Result
 
 pub fn run_git_allow_failure(ctx: &AppContext, args: &[&str]) -> Result<Output> {
     run_git_allow_failure_in(&ctx.root, args)
+}
+
+pub fn run_git_allow_failure_restricted(ctx: &AppContext, args: &[&str]) -> Result<Output> {
+    run_git_raw_in_with_env_mode_and_input(&ctx.root, &[], None, args, GitEnvMode::Restricted)
 }
 
 fn run_git_allow_failure_in(repo_dir: &Path, args: &[&str]) -> Result<Output> {
@@ -213,6 +249,7 @@ pub fn resolve_ref(ctx: &AppContext, reference: &str) -> Result<String> {
 }
 
 pub fn set_remote_origin(ctx: &AppContext, url: &str) -> Result<()> {
+    validate_git_url(url)?;
     let has_origin = run_git_allow_failure(ctx, &["remote", "get-url", "origin"])?;
     if has_origin.status.success() {
         run_git(ctx, &["remote", "set-url", "origin", url])?;
@@ -240,6 +277,7 @@ pub fn remote_url(ctx: &AppContext) -> Result<Option<String>> {
 }
 
 pub fn fetch_origin_main_if_present(ctx: &AppContext) -> Result<bool> {
+    ensure_origin_remote_url_allowed(ctx)?;
     let output = run_git_allow_failure(ctx, &["fetch", "origin", "main"])?;
     if output.status.success() {
         return Ok(true);
@@ -254,6 +292,7 @@ pub fn fetch_origin_main_if_present(ctx: &AppContext) -> Result<bool> {
 }
 
 pub fn fetch_origin_history_branch_if_present(ctx: &AppContext) -> Result<bool> {
+    ensure_origin_remote_url_allowed(ctx)?;
     let output = run_git_allow_failure(ctx, &["fetch", "origin", HISTORY_BRANCH])?;
     if output.status.success() {
         return Ok(true);
@@ -322,6 +361,7 @@ pub fn ahead_behind_refs(ctx: &AppContext, left: &str, right: &str) -> Result<(u
 }
 
 pub fn push_main_with_tags(ctx: &AppContext) -> Result<()> {
+    ensure_origin_remote_url_allowed(ctx)?;
     let mut args = vec!["push", "--atomic", "origin", "HEAD:main"];
     if history_branch_exists(ctx)? {
         args.push("loom-history:loom-history");
@@ -332,6 +372,7 @@ pub fn push_main_with_tags(ctx: &AppContext) -> Result<()> {
 }
 
 pub fn pull_rebase_main(ctx: &AppContext) -> Result<()> {
+    ensure_origin_remote_url_allowed(ctx)?;
     let output = run_git_allow_failure(ctx, &["pull", "--rebase", "origin", "main"])?;
     if output.status.success() {
         return Ok(());
@@ -341,6 +382,75 @@ pub fn pull_rebase_main(ctx: &AppContext) -> Result<()> {
     let _ = run_git_allow_failure(ctx, &["rebase", "--abort"]);
 
     Err(anyhow!("git pull --rebase origin main failed: {}", stderr))
+}
+
+fn ensure_origin_remote_url_allowed(ctx: &AppContext) -> Result<()> {
+    if let Some(url) = remote_url(ctx)? {
+        validate_git_url(&url)?;
+    }
+    Ok(())
+}
+
+pub fn validate_git_url(raw: &str) -> Result<()> {
+    let url = raw.trim();
+    if url.is_empty() {
+        return Err(anyhow!("git url must not be empty"));
+    }
+    if url != raw {
+        return Err(anyhow!(
+            "git url must not include leading or trailing whitespace"
+        ));
+    }
+    if url.starts_with('-') {
+        return Err(anyhow!("git url must not start with '-'"));
+    }
+    if url
+        .chars()
+        .any(|ch| ch.is_ascii_control() || ch.is_whitespace())
+    {
+        return Err(anyhow!(
+            "git url must not contain whitespace or control characters"
+        ));
+    }
+    if let Some((scheme, _rest)) = url.split_once("://") {
+        return match scheme {
+            "https" | "ssh" => Ok(()),
+            _ => Err(anyhow!(
+                "unsupported git url scheme '{}'; use https:// or ssh://",
+                scheme
+            )),
+        };
+    }
+    validate_scp_like_git_url(url)
+}
+
+fn validate_scp_like_git_url(url: &str) -> Result<()> {
+    let Some((user_host, path)) = url.split_once(':') else {
+        return Err(anyhow!(
+            "git url must use https://, ssh://, or git@host:owner/repo.git"
+        ));
+    };
+    if user_host.is_empty() || path.is_empty() || path.starts_with(':') {
+        return Err(anyhow!(
+            "git url must use https://, ssh://, or git@host:owner/repo.git"
+        ));
+    }
+    if user_host.contains('/') || user_host == "ext" {
+        return Err(anyhow!("unsupported git url"));
+    }
+    let host = user_host
+        .rsplit_once('@')
+        .map_or(user_host, |(_, host)| host);
+    if host.is_empty() || !host.contains('.') {
+        return Err(anyhow!("scp-like git url must include a hostname"));
+    }
+    if !host
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-'))
+    {
+        return Err(anyhow!("scp-like git url contains an invalid hostname"));
+    }
+    Ok(())
 }
 
 pub fn diff_path(ctx: &AppContext, from: &str, to: &str, path: &Path) -> Result<String> {
@@ -403,5 +513,30 @@ impl TempFile {
 impl Drop for TempFile {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_git_url;
+
+    #[test]
+    fn git_url_validation_accepts_https_and_ssh_forms() {
+        validate_git_url("https://github.com/org/repo.git").expect("https accepted");
+        validate_git_url("ssh://git@github.com/org/repo.git").expect("ssh accepted");
+        validate_git_url("git@github.com:org/repo.git").expect("scp-like ssh accepted");
+    }
+
+    #[test]
+    fn git_url_validation_rejects_dangerous_protocols_and_options() {
+        for url in [
+            "ext::sh -c 'touch /tmp/pwned'",
+            "file:///etc/passwd",
+            "--upload-pack=sh",
+            "git://github.com/org/repo.git",
+            " https://github.com/org/repo.git",
+        ] {
+            assert!(validate_git_url(url).is_err(), "{url} should be rejected");
+        }
     }
 }

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -471,12 +471,15 @@ fn validate_scp_like_git_url(url: &str) -> Result<()> {
     let host = user_host
         .rsplit_once('@')
         .map_or(user_host, |(_, host)| host);
-    if host.is_empty() || !host.contains('.') {
+    if host.is_empty() || host == "ext" {
         return Err(anyhow!("scp-like git url must include a hostname"));
+    }
+    if host.starts_with('-') || host.starts_with('.') {
+        return Err(anyhow!("scp-like git url contains an invalid hostname"));
     }
     if !host
         .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-'))
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_'))
     {
         return Err(anyhow!("scp-like git url contains an invalid hostname"));
     }
@@ -557,6 +560,9 @@ mod tests {
         validate_git_url("https://github.com/org/repo.git").expect("https accepted");
         validate_git_url("ssh://git@github.com/org/repo.git").expect("ssh accepted");
         validate_git_url("git@github.com:org/repo.git").expect("scp-like ssh accepted");
+        validate_git_url("git@localhost:repo.git").expect("localhost scp-like ssh accepted");
+        validate_git_url("git@github:org/repo.git").expect("ssh config alias accepted");
+        validate_git_url("git@github_work:org/repo.git").expect("ssh config alias accepted");
     }
 
     #[test]
@@ -607,6 +613,11 @@ mod tests {
             "--upload-pack=sh",
             "git://github.com/org/repo.git",
             " https://github.com/org/repo.git",
+            "git@ext:repo.git",
+            "git@-github:org/repo.git",
+            "git@.github:org/repo.git",
+            "git@bad/host:org/repo.git",
+            "git@bad=host:org/repo.git",
         ] {
             assert!(validate_git_url(url).is_err(), "{url} should be rejected");
         }

--- a/src/panel/auth.rs
+++ b/src/panel/auth.rs
@@ -154,11 +154,13 @@ pub(crate) fn error_envelope(
 
 pub(super) fn load_registry_snapshot(
     ctx: &AppContext,
+    cmd: &str,
 ) -> std::result::Result<crate::state_model::RegistrySnapshot, Json<serde_json::Value>> {
     let paths = RegistryStatePaths::from_app_context(ctx);
     match paths.maybe_load_snapshot() {
         Ok(Some(snapshot)) => Ok(snapshot),
         Ok(None) => Err(registry_error(
+            cmd,
             "ARG_INVALID",
             format!(
                 "registry state not initialized under {}",
@@ -172,15 +174,25 @@ pub(super) fn load_registry_snapshot(
             } else {
                 "STATE_CORRUPT"
             };
-            Err(registry_error(code, message))
+            Err(registry_error(cmd, code, message))
         }
     }
 }
 
-pub(super) fn registry_ok(data: serde_json::Value) -> Json<serde_json::Value> {
-    Json(json!({"ok": true, "data": data}))
+pub(super) fn registry_ok(cmd: &str, data: serde_json::Value) -> Json<serde_json::Value> {
+    Json(json!({
+        "ok": true,
+        "cmd": cmd,
+        "request_id": Uuid::new_v4().to_string(),
+        "version": env!("CARGO_PKG_VERSION"),
+        "data": data,
+        "meta": {
+            "warnings": []
+        }
+    }))
 }
 
-pub(super) fn registry_error(code: &str, message: String) -> Json<serde_json::Value> {
-    Json(json!({"ok": false, "error": {"code": code, "message": message}}))
+pub(super) fn registry_error(cmd: &str, code: &str, message: String) -> Json<serde_json::Value> {
+    let request_id = Uuid::new_v4().to_string();
+    Json(error_envelope(cmd, &request_id, code, &message))
 }

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -13,7 +13,7 @@ use crate::cli::{
     ProjectArgs, ProjectionMethod, RemoteCommand, SyncCommand, TargetCommand, TargetOwnership,
     WorkspaceBindingCommand, WorkspaceCommand,
 };
-use crate::commands::{collect_skill_inventory, remote_status_payload};
+use crate::commands::{collect_skill_inventory, redact_sensitive_string, remote_status_payload};
 use crate::state::resolve_agent_skill_dirs;
 use crate::state_model::RegistryStatePaths;
 
@@ -63,6 +63,7 @@ pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Va
         .ok()
         .flatten()
         .unwrap_or_default();
+    let remote_url = redact_sensitive_string(&remote_url);
     let registry_paths = RegistryStatePaths::from_app_context(&state.ctx);
 
     registry_ok(

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -26,11 +26,9 @@ use super::{
     RemoteSetRequest, SkillAddRequest, TargetAddRequest,
 };
 
-/// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The backend does not
-/// maintain a closed whitelist (users may extend profiles over time),
-/// but the panel surface should refuse obviously malformed input so the
-/// Registry bindings file stays auditable. CLI users may still submit other
-/// formats directly via `loom workspace binding add`.
+/// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The core CLI path enforces
+/// the same shape; keeping the panel check here avoids doing a full command
+/// dispatch for obviously malformed requests.
 fn policy_profile_looks_sane(value: &str) -> bool {
     (1..=64).contains(&value.len())
         && value

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -65,35 +65,44 @@ pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Va
         .unwrap_or_default();
     let registry_paths = RegistryStatePaths::from_app_context(&state.ctx);
 
-    Json(json!({
-        "root": state.ctx.root.display().to_string(),
-        "state_dir": state.ctx.state_dir.display().to_string(),
-        "registry_targets_file": registry_paths.targets_file.display().to_string(),
-        "claude_dir": target_dirs.claude.display().to_string(),
-        "codex_dir": target_dirs.codex.display().to_string(),
-        "remote_url": remote_url,
-    }))
+    registry_ok(
+        "panel.info",
+        json!({
+            "root": state.ctx.root.display().to_string(),
+            "state_dir": state.ctx.state_dir.display().to_string(),
+            "registry_targets_file": registry_paths.targets_file.display().to_string(),
+            "claude_dir": target_dirs.claude.display().to_string(),
+            "codex_dir": target_dirs.codex.display().to_string(),
+            "remote_url": remote_url,
+        }),
+    )
 }
 
 pub(super) async fn skills(State(state): State<PanelState>) -> Json<serde_json::Value> {
     let inventory = collect_skill_inventory(&state.ctx);
-    Json(json!({
-        "skills": inventory.source_skills,
-        "backup_skills": inventory.backup_skills,
-        "source_dirs": inventory
-            .source_dirs
-            .iter()
-            .map(|path: &std::path::PathBuf| path.display().to_string())
-            .collect::<Vec<_>>(),
-        "warnings": inventory.warnings
-    }))
+    registry_ok(
+        "panel.skills",
+        json!({
+            "skills": inventory.source_skills,
+            "backup_skills": inventory.backup_skills,
+            "source_dirs": inventory
+                .source_dirs
+                .iter()
+                .map(|path: &std::path::PathBuf| path.display().to_string())
+                .collect::<Vec<_>>(),
+            "warnings": inventory.warnings
+        }),
+    )
 }
 
 pub(super) async fn registry_status(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match load_registry_snapshot(&state.ctx) {
-        Ok(snapshot) => (StatusCode::OK, registry_ok(snapshot.status_view())),
+    match load_registry_snapshot(&state.ctx, "registry.status") {
+        Ok(snapshot) => (
+            StatusCode::OK,
+            registry_ok("registry.status", snapshot.status_view()),
+        ),
         Err(err) => {
             let status = status_for_registry_error_payload(&err.0);
             (status, err)
@@ -109,7 +118,7 @@ pub(super) async fn registry_ops(
     Query(query): Query<OpsQuery>,
     State(state): State<PanelState>,
 ) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx) {
+    match load_registry_snapshot(&state.ctx, "registry.ops") {
         Ok(snapshot) => {
             let total = snapshot.operations.len();
             let limit = query
@@ -135,16 +144,19 @@ pub(super) async fn registry_ops(
                 })
                 .collect::<Vec<_>>();
 
-            registry_ok(json!({
-                "state_model": "registry",
-                "count": total,
-                "loaded_count": operations.len(),
-                "offset": offset,
-                "limit": limit,
-                "has_more": start > 0,
-                "operations": operations,
-                "checkpoint": snapshot.checkpoint,
-            }))
+            registry_ok(
+                "registry.ops",
+                json!({
+                    "state_model": "registry",
+                    "count": total,
+                    "loaded_count": operations.len(),
+                    "offset": offset,
+                    "limit": limit,
+                    "has_more": start > 0,
+                    "operations": operations,
+                    "checkpoint": snapshot.checkpoint,
+                }),
+            )
         }
         Err(err) => err,
     }
@@ -154,7 +166,7 @@ pub(super) async fn registry_projections(
     Query(query): Query<ProjectionsQuery>,
     State(state): State<PanelState>,
 ) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx) {
+    match load_registry_snapshot(&state.ctx, "registry.projections") {
         Ok(snapshot) => {
             let projections: Vec<_> = snapshot
                 .projections
@@ -162,23 +174,29 @@ pub(super) async fn registry_projections(
                 .iter()
                 .filter(|p| query.health.as_deref().is_none_or(|h| p.health == h))
                 .collect();
-            registry_ok(json!({
-                "state_model": "registry",
-                "count": projections.len(),
-                "projections": projections,
-            }))
+            registry_ok(
+                "registry.projections",
+                json!({
+                    "state_model": "registry",
+                    "count": projections.len(),
+                    "projections": projections,
+                }),
+            )
         }
         Err(err) => err,
     }
 }
 
 pub(super) async fn registry_bindings(State(state): State<PanelState>) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx) {
-        Ok(snapshot) => registry_ok(json!({
-            "state_model": "registry",
-            "count": snapshot.bindings.bindings.len(),
-            "bindings": snapshot.bindings.bindings
-        })),
+    match load_registry_snapshot(&state.ctx, "registry.bindings") {
+        Ok(snapshot) => registry_ok(
+            "registry.bindings",
+            json!({
+                "state_model": "registry",
+                "count": snapshot.bindings.bindings.len(),
+                "bindings": snapshot.bindings.bindings
+            }),
+        ),
         Err(err) => err,
     }
 }
@@ -187,7 +205,7 @@ pub(super) async fn registry_binding_show(
     AxumPath(binding_id): AxumPath<String>,
     State(state): State<PanelState>,
 ) -> Json<serde_json::Value> {
-    let snapshot = match load_registry_snapshot(&state.ctx) {
+    let snapshot = match load_registry_snapshot(&state.ctx, "registry.binding.show") {
         Ok(snapshot) => snapshot,
         Err(err) => return err,
     };
@@ -195,28 +213,35 @@ pub(super) async fn registry_binding_show(
         Some(binding) => binding,
         None => {
             return registry_error(
+                "registry.binding.show",
                 "BINDING_NOT_FOUND",
                 format!("binding '{}' not found", binding_id),
             );
         }
     };
 
-    registry_ok(json!({
-        "state_model": "registry",
-        "binding": binding,
-        "default_target": snapshot.binding_default_target(&binding),
-        "rules": snapshot.binding_rules(&binding.binding_id),
-        "projections": snapshot.binding_projections(&binding.binding_id)
-    }))
+    registry_ok(
+        "registry.binding.show",
+        json!({
+            "state_model": "registry",
+            "binding": binding,
+            "default_target": snapshot.binding_default_target(&binding),
+            "rules": snapshot.binding_rules(&binding.binding_id),
+            "projections": snapshot.binding_projections(&binding.binding_id)
+        }),
+    )
 }
 
 pub(super) async fn registry_targets(State(state): State<PanelState>) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx) {
-        Ok(snapshot) => registry_ok(json!({
-            "state_model": "registry",
-            "count": snapshot.targets.targets.len(),
-            "targets": snapshot.targets.targets
-        })),
+    match load_registry_snapshot(&state.ctx, "registry.targets") {
+        Ok(snapshot) => registry_ok(
+            "registry.targets",
+            json!({
+                "state_model": "registry",
+                "count": snapshot.targets.targets.len(),
+                "targets": snapshot.targets.targets
+            }),
+        ),
         Err(err) => err,
     }
 }
@@ -225,7 +250,7 @@ pub(super) async fn registry_target_show(
     AxumPath(target_id): AxumPath<String>,
     State(state): State<PanelState>,
 ) -> Json<serde_json::Value> {
-    let snapshot = match load_registry_snapshot(&state.ctx) {
+    let snapshot = match load_registry_snapshot(&state.ctx, "registry.target.show") {
         Ok(snapshot) => snapshot,
         Err(err) => return err,
     };
@@ -233,6 +258,7 @@ pub(super) async fn registry_target_show(
         Some(target) => target,
         None => {
             return registry_error(
+                "registry.target.show",
                 "TARGET_NOT_FOUND",
                 format!("target '{}' not found", target_id),
             );
@@ -240,13 +266,16 @@ pub(super) async fn registry_target_show(
     };
     let relations = snapshot.target_relations(&target_id);
 
-    registry_ok(json!({
-        "state_model": "registry",
-        "target": target,
-        "bindings": relations.bindings,
-        "rules": relations.rules,
-        "projections": relations.projections
-    }))
+    registry_ok(
+        "registry.target.show",
+        json!({
+            "state_model": "registry",
+            "target": target,
+            "bindings": relations.bindings,
+            "rules": relations.rules,
+            "projections": relations.projections
+        }),
+    )
 }
 
 pub(super) async fn registry_target_add(
@@ -614,17 +643,14 @@ pub(super) async fn remote_status(
     match remote_status_payload(&state.ctx) {
         Ok((remote, meta)) => (
             StatusCode::OK,
-            Json(json!({"remote": remote, "warnings": meta.warnings})),
+            registry_ok(
+                "remote.status",
+                json!({"remote": remote, "warnings": meta.warnings}),
+            ),
         ),
         Err(err) => (
             status_for_error_code(Some(err.code.as_str())),
-            Json(json!({
-                "ok": false,
-                "error": {
-                    "code": err.code.as_str(),
-                    "message": err.message,
-                }
-            })),
+            registry_error("remote.status", err.code.as_str(), err.message),
         ),
     }
 }
@@ -633,8 +659,8 @@ pub(super) async fn registry_ops_diagnose(
     State(state): State<PanelState>,
 ) -> Json<serde_json::Value> {
     match crate::gitops::history_status(&state.ctx) {
-        Ok(report) => registry_ok(serde_json::json!(report)),
-        Err(err) => registry_error("GIT_ERROR", err.to_string()),
+        Ok(report) => registry_ok("registry.ops.diagnose", serde_json::json!(report)),
+        Err(err) => registry_error("registry.ops.diagnose", "GIT_ERROR", err.to_string()),
     }
 }
 
@@ -644,23 +670,20 @@ pub(super) async fn pending(
     match state.ctx.read_pending_report() {
         Ok(report) => (
             StatusCode::OK,
-            Json(json!({
-                "count": report.ops.len(),
-                "ops": report.ops,
-                "journal_events": report.journal_events,
-                "history_events": report.history_events,
-                "warnings": report.warnings
-            })),
+            registry_ok(
+                "pending.list",
+                json!({
+                    "count": report.ops.len(),
+                    "ops": report.ops,
+                    "journal_events": report.journal_events,
+                    "history_events": report.history_events,
+                    "warnings": report.warnings
+                }),
+            ),
         ),
         Err(err) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "ok": false,
-                "error": {
-                    "code": "IO_ERROR",
-                    "message": err.to_string(),
-                }
-            })),
+            registry_error("pending.list", "IO_ERROR", err.to_string()),
         ),
     }
 }

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use axum::{
     Router,
+    extract::DefaultBodyLimit,
     routing::{get, post},
 };
 use serde::Deserialize;
@@ -21,6 +22,8 @@ use handlers::*;
 use skill_diff::registry_skill_diff;
 use skill_history::registry_skill_history;
 use static_serve::{ensure_panel_dist, frontend_index, frontend_static_asset};
+
+const MAX_PANEL_BODY_BYTES: usize = 1024 * 1024;
 
 #[derive(Clone)]
 pub(crate) struct PanelState {
@@ -152,9 +155,10 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/sync/pull", post(sync_pull))
         .route("/api/sync/replay", post(sync_replay))
         .route("/{*path}", get(frontend_static_asset))
+        .layer(DefaultBodyLimit::max(MAX_PANEL_BODY_BYTES))
         .with_state(state);
 
-    println!("panel listening on http://{}", addr);
+    eprintln!("panel listening on http://{}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(

--- a/src/panel/skill_diff.rs
+++ b/src/panel/skill_diff.rs
@@ -243,10 +243,12 @@ pub(super) async fn registry_skill_diff(
     Query(params): Query<DiffParams>,
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    const CMD: &str = "registry.skill.diff";
     if !is_valid_skill_name(&skill_name) {
         return (
             StatusCode::BAD_REQUEST,
             registry_error(
+                CMD,
                 "GIT_DIFF_FAILED",
                 "skill name must contain only [a-zA-Z0-9._-]".to_string(),
             ),
@@ -259,6 +261,7 @@ pub(super) async fn registry_skill_diff(
         return (
             StatusCode::BAD_REQUEST,
             registry_error(
+                CMD,
                 "GIT_DIFF_FAILED",
                 "rev_a must match [a-f0-9]{7,40}".to_string(),
             ),
@@ -270,6 +273,7 @@ pub(super) async fn registry_skill_diff(
         return (
             StatusCode::BAD_REQUEST,
             registry_error(
+                CMD,
                 "GIT_DIFF_FAILED",
                 "rev_b must match [a-f0-9]{7,40}".to_string(),
             ),
@@ -287,6 +291,7 @@ pub(super) async fn registry_skill_diff(
                 return (
                     StatusCode::BAD_REQUEST,
                     registry_error(
+                        CMD,
                         "GIT_DIFF_FAILED",
                         "fewer than 2 commits touch this skill; provide rev_a explicitly"
                             .to_string(),
@@ -303,6 +308,7 @@ pub(super) async fn registry_skill_diff(
         return (
             StatusCode::BAD_REQUEST,
             registry_error(
+                CMD,
                 "GIT_DIFF_FAILED",
                 format!("skill '{skill_name}' not found in revision range"),
             ),
@@ -329,7 +335,7 @@ pub(super) async fn registry_skill_diff(
         Err(e) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                registry_error("GIT_DIFF_FAILED", format!("git process error: {e}")),
+                registry_error(CMD, "GIT_DIFF_FAILED", format!("git process error: {e}")),
             );
         }
     };
@@ -353,7 +359,7 @@ pub(super) async fn registry_skill_diff(
         let _ = child.kill().await;
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            registry_error("GIT_DIFF_FAILED", format!("reading git output: {e}")),
+            registry_error(CMD, "GIT_DIFF_FAILED", format!("reading git output: {e}")),
         );
     }
 
@@ -362,6 +368,7 @@ pub(super) async fn registry_skill_diff(
         return (
             StatusCode::BAD_REQUEST,
             registry_error(
+                CMD,
                 "GIT_DIFF_FAILED",
                 format!("diff exceeds {MAX_DIFF_BYTES} bytes; narrow the revision range"),
             ),
@@ -377,7 +384,7 @@ pub(super) async fn registry_skill_diff(
         Err(e) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                registry_error("GIT_DIFF_FAILED", format!("waiting for git: {e}")),
+                registry_error(CMD, "GIT_DIFF_FAILED", format!("waiting for git: {e}")),
             );
         }
     };
@@ -386,7 +393,7 @@ pub(super) async fn registry_skill_diff(
         let stderr = String::from_utf8_lossy(&stderr_bytes);
         return (
             StatusCode::BAD_REQUEST,
-            registry_error("GIT_DIFF_FAILED", stderr.trim().to_string()),
+            registry_error(CMD, "GIT_DIFF_FAILED", stderr.trim().to_string()),
         );
     }
 
@@ -398,12 +405,15 @@ pub(super) async fn registry_skill_diff(
 
     (
         StatusCode::OK,
-        registry_ok(json!({
-            "skill": skill_name,
-            "rev_a": resolved_a,
-            "rev_b": resolved_b,
-            "files": files,
-        })),
+        registry_ok(
+            CMD,
+            json!({
+                "skill": skill_name,
+                "rev_a": resolved_a,
+                "rev_b": resolved_b,
+                "files": files,
+            }),
+        ),
     )
 }
 

--- a/src/panel/skill_history.rs
+++ b/src/panel/skill_history.rs
@@ -128,17 +128,19 @@ pub(super) async fn registry_skill_history(
     AxumPath(skill_name): AxumPath<String>,
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    const CMD: &str = "registry.skill.history";
     if !skill_name_looks_sane(&skill_name) {
         return (
             StatusCode::BAD_REQUEST,
             registry_error(
+                CMD,
                 "ARG_INVALID",
                 "skill name must be a single path segment".to_string(),
             ),
         );
     }
 
-    let snapshot = match load_registry_snapshot(&state.ctx) {
+    let snapshot = match load_registry_snapshot(&state.ctx, CMD) {
         Ok(s) => s,
         Err(err_json) => {
             let code = err_json.0["error"]["code"].as_str();
@@ -167,7 +169,11 @@ pub(super) async fn registry_skill_history(
     if instance_ids.is_empty() && !skill_in_rules && !skill_in_inventory {
         return (
             StatusCode::NOT_FOUND,
-            registry_error("SKILL_NOT_FOUND", format!("skill '{skill_name}' not found")),
+            registry_error(
+                CMD,
+                "SKILL_NOT_FOUND",
+                format!("skill '{skill_name}' not found"),
+            ),
         );
     }
 
@@ -192,6 +198,7 @@ pub(super) async fn registry_skill_history(
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     registry_error(
+                        CMD,
                         "OBS_READ_ERROR",
                         format!("failed to read observations for {instance_id}: {e:#}"),
                     ),
@@ -212,11 +219,12 @@ pub(super) async fn registry_skill_history(
 
     (
         StatusCode::OK,
-        history_ok_payload(skill_name, events, warnings),
+        history_ok_payload(CMD, skill_name, events, warnings),
     )
 }
 
 fn history_ok_payload(
+    cmd: &str,
     skill_name: String,
     events: Vec<RegistryObservationEvent>,
     warnings: Vec<String>,
@@ -224,6 +232,9 @@ fn history_ok_payload(
     let count = events.len();
     Json(json!({
         "ok": true,
+        "cmd": cmd,
+        "request_id": uuid::Uuid::new_v4().to_string(),
+        "version": env!("CARGO_PKG_VERSION"),
         "data": {
             "skill": skill_name,
             "count": count,

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::panel::handlers::{OpsQuery, pending, registry_ops, remote_set, remote_status};
+use crate::panel::handlers::{OpsQuery, info, pending, registry_ops, remote_set, remote_status};
 use crate::state_model::{REGISTRY_SCHEMA_VERSION, RegistryOperationRecord};
 use axum::{
     Json,
@@ -225,6 +225,34 @@ async fn remote_set_configures_origin_from_authorized_panel_request() {
     assert_eq!(remote_status_code, StatusCode::OK);
     assert_eq!(remote_payload["data"]["remote"]["configured"], json!(true));
     assert_eq!(remote_payload["data"]["remote"]["url"], json!(url));
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
+async fn info_and_remote_status_redact_remote_credentials() {
+    let (root, state) = make_test_state();
+    let url =
+        "https://user:pass@example.com/loom-registry.git?token=ghp_secret&ref=main#ghp_fragment";
+    crate::gitops::ensure_repo_initialized(&state.ctx).expect("init repo");
+    crate::gitops::set_remote_origin(&state.ctx, url).expect("set remote");
+
+    let Json(info_payload) = info(State(state.clone())).await;
+    let info_url = info_payload["data"]["remote_url"]
+        .as_str()
+        .expect("info remote url");
+    assert!(!info_url.contains("user:pass"));
+    assert!(!info_url.contains("ghp_secret"));
+    assert!(info_url.contains("<redacted>"));
+
+    let (status, Json(remote_payload)) = remote_status(State(state)).await;
+    assert_eq!(status, StatusCode::OK);
+    let status_url = remote_payload["data"]["remote"]["url"]
+        .as_str()
+        .expect("status remote url");
+    assert!(!status_url.contains("user:pass"));
+    assert!(!status_url.contains("ghp_secret"));
+    assert!(status_url.contains("<redacted>"));
 
     cleanup_root(root);
 }

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -162,9 +162,12 @@ async fn remote_status_returns_success_payload_when_remote_is_not_configured() {
     let (status, Json(payload)) = remote_status(State(state)).await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["remote"]["configured"], json!(false));
-    assert!(payload["remote"].is_object());
-    assert!(payload["warnings"].is_array());
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("remote.status"));
+    assert!(payload["request_id"].as_str().is_some());
+    assert_eq!(payload["data"]["remote"]["configured"], json!(false));
+    assert!(payload["data"]["remote"].is_object());
+    assert!(payload["data"]["warnings"].is_array());
 
     let _ = fs::remove_dir_all(root);
 }
@@ -220,8 +223,8 @@ async fn remote_set_configures_origin_from_authorized_panel_request() {
 
     let (remote_status_code, Json(remote_payload)) = remote_status(State(state)).await;
     assert_eq!(remote_status_code, StatusCode::OK);
-    assert_eq!(remote_payload["remote"]["configured"], json!(true));
-    assert_eq!(remote_payload["remote"]["url"], json!(url));
+    assert_eq!(remote_payload["data"]["remote"]["configured"], json!(true));
+    assert_eq!(remote_payload["data"]["remote"]["url"], json!(url));
 
     cleanup_root(root);
 }
@@ -257,8 +260,11 @@ async fn pending_returns_ok_with_empty_report_on_success() {
     let (status, Json(payload)) = pending(State(state)).await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["count"], json!(0));
-    assert!(payload["ops"].as_array().is_some());
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("pending.list"));
+    assert!(payload["request_id"].as_str().is_some());
+    assert_eq!(payload["data"]["count"], json!(0));
+    assert!(payload["data"]["ops"].as_array().is_some());
 
     let _ = fs::remove_dir_all(root);
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -207,13 +207,18 @@ impl AppContext {
         self.lock_named(&format!("skill-{}", skill))
     }
 
-    fn lock_named(&self, name: &str) -> Result<LockGuard> {
+    pub fn ensure_not_loom_tool_repo_root(&self) -> Result<()> {
         if is_loom_tool_repo_root(&self.root) {
             anyhow::bail!(
                 "ARG_INVALID:refusing write operations in Loom tool repository root '{}'; use --root <separate skill registry repo>",
                 self.root.display()
             );
         }
+        Ok(())
+    }
+
+    fn lock_named(&self, name: &str) -> Result<LockGuard> {
+        self.ensure_not_loom_tool_repo_root()?;
         self.ensure_state_layout()?;
         let lock_path = self.locks_dir.join(format!("{}.lock", name));
         let current_thread = std::thread::current().id();
@@ -461,14 +466,44 @@ fn is_loom_tool_repo_root(root: &Path) -> bool {
         return false;
     }
 
-    match fs::read_to_string(&cargo_toml) {
-        Ok(content) => content.contains("name = \"skillloom\""),
-        Err(_) => false,
-    }
+    package_name_from_cargo_toml(&cargo_toml).is_some_and(|name| name == "skillloom")
 }
 
 fn canonicalize_or_self(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn package_name_from_cargo_toml(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let mut in_package = false;
+    for raw_line in content.lines() {
+        let line = raw_line
+            .split_once('#')
+            .map_or(raw_line, |(line, _)| line)
+            .trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "name" {
+            continue;
+        }
+        let value = value.trim();
+        return value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .map(str::to_string);
+    }
+    None
 }
 
 fn write_atomic(path: &Path, contents: &str) -> Result<()> {

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -227,14 +227,11 @@ impl AppContext {
                 history_events: snapshot.history_events,
                 warnings: Vec::new(),
             }),
-            Ok(snapshot) => Ok(LoadedSnapshot {
-                active_ops: Vec::new(),
-                history_events: 0,
-                warnings: vec![format!(
-                    "ignored pending ops snapshot version {}; expected {}",
-                    snapshot.version, OPS_SNAPSHOT_VERSION
-                )],
-            }),
+            Ok(snapshot) => anyhow::bail!(
+                "pending ops snapshot version mismatch: found {}; expected {}",
+                snapshot.version,
+                OPS_SNAPSHOT_VERSION
+            ),
             Err(err) => Ok(LoadedSnapshot {
                 active_ops: Vec::new(),
                 history_events: 0,
@@ -452,7 +449,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn pending_snapshot_version_mismatch_is_ignored_with_warning() {
+    fn pending_snapshot_version_mismatch_fails_closed() {
         let root = std::env::temp_dir().join(format!(
             "loom-ops-snapshot-version-{}",
             uuid::Uuid::new_v4().simple()
@@ -469,17 +466,13 @@ mod tests {
         let raw = serde_json::to_string_pretty(&snapshot).expect("snapshot json");
         fs::write(&ctx.pending_ops_snapshot_file, raw).expect("write snapshot");
 
-        let report = ctx.read_pending_report().expect("pending report");
-
-        assert!(report.ops.is_empty(), "stale snapshot ops must be ignored");
-        assert_eq!(report.history_events, 0);
+        let err = ctx
+            .read_pending_report()
+            .expect_err("version mismatch must fail closed");
         assert!(
-            report
-                .warnings
-                .iter()
-                .any(|warning| warning.contains("ignored pending ops snapshot version")),
-            "expected version warning, got {:?}",
-            report.warnings
+            err.to_string()
+                .contains("pending ops snapshot version mismatch"),
+            "unexpected error: {err}"
         );
 
         let _ = fs::remove_dir_all(root);

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -13,6 +13,8 @@ use crate::types::PendingOp;
 use super::{AppContext, OPS_COMPACTION_THRESHOLD};
 use super::{append_lines, maybe_fault_inject, write_atomic, write_history_segment_if_missing};
 
+const OPS_SNAPSHOT_VERSION: u32 = 1;
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 enum OpJournalEvent {
@@ -220,10 +222,18 @@ impl AppContext {
         };
 
         match serde_json::from_str::<OpsSnapshot>(&raw) {
-            Ok(snapshot) => Ok(LoadedSnapshot {
+            Ok(snapshot) if snapshot.version == OPS_SNAPSHOT_VERSION => Ok(LoadedSnapshot {
                 active_ops: snapshot.active_ops,
                 history_events: snapshot.history_events,
                 warnings: Vec::new(),
+            }),
+            Ok(snapshot) => Ok(LoadedSnapshot {
+                active_ops: Vec::new(),
+                history_events: 0,
+                warnings: vec![format!(
+                    "ignored pending ops snapshot version {}; expected {}",
+                    snapshot.version, OPS_SNAPSHOT_VERSION
+                )],
             }),
             Err(err) => Ok(LoadedSnapshot {
                 active_ops: Vec::new(),
@@ -272,7 +282,7 @@ impl AppContext {
         maybe_fault_inject("ops_compact_after_history")?;
 
         let snapshot = OpsSnapshot {
-            version: 1,
+            version: OPS_SNAPSHOT_VERSION,
             created_at: Utc::now(),
             history_events: model.history_events + model.journal_events,
             active_ops: model.active_ops.into_values().collect(),
@@ -318,7 +328,7 @@ pub fn synthesize_snapshot_raw_from_segment_bodies(segment_bodies: &[String]) ->
     }
 
     let snapshot = OpsSnapshot {
-        version: 1,
+        version: OPS_SNAPSHOT_VERSION,
         created_at: Utc::now(),
         history_events: seen_event_ids.len(),
         active_ops: active_ops.into_values().collect(),
@@ -433,4 +443,45 @@ fn sanitize_segment_token(token: &str) -> String {
 
 fn shorten_segment_token(token: &str) -> String {
     token.chars().take(12).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PendingOp;
+    use serde_json::json;
+
+    #[test]
+    fn pending_snapshot_version_mismatch_is_ignored_with_warning() {
+        let root = std::env::temp_dir().join(format!(
+            "loom-ops-snapshot-version-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let ctx = AppContext::new(Some(root.clone())).expect("ctx");
+        ctx.ensure_state_layout().expect("layout");
+        let op = PendingOp::new("sync.push", json!({"commit": "abc"}), "req-1".to_string());
+        let snapshot = OpsSnapshot {
+            version: OPS_SNAPSHOT_VERSION + 1,
+            created_at: Utc::now(),
+            history_events: 10,
+            active_ops: vec![op],
+        };
+        let raw = serde_json::to_string_pretty(&snapshot).expect("snapshot json");
+        fs::write(&ctx.pending_ops_snapshot_file, raw).expect("write snapshot");
+
+        let report = ctx.read_pending_report().expect("pending report");
+
+        assert!(report.ops.is_empty(), "stale snapshot ops must be ignored");
+        assert_eq!(report.history_events, 0);
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("ignored pending ops snapshot version")),
+            "expected version warning, got {:?}",
+            report.warnings
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -221,6 +221,8 @@ fn workspace_status_is_read_only_in_empty_dir() {
 
     let events = read_command_events(root.path());
     assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["schema_version"], Value::from(1));
+    assert_eq!(events[1]["schema_version"], Value::from(1));
     assert_eq!(events[0]["status"], Value::String("started".to_string()));
     assert_eq!(
         events[0]["cmd"],

--- a/tests/root_guard.rs
+++ b/tests/root_guard.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 mod common;
 
-use common::run_loom;
+use common::{TestDir, run_loom, write_file};
 
 #[test]
 fn write_commands_are_rejected_for_loom_tool_repo_root() {
@@ -45,5 +45,50 @@ fn write_commands_are_rejected_for_loom_tool_repo_root() {
             && message.contains("separate skill registry repo"),
         "unexpected guard error message: {}",
         message
+    );
+}
+
+#[test]
+fn write_guard_runs_before_initializing_fake_tool_repo_root() {
+    let root = TestDir::new("fake-tool-root-guard");
+    write_file(
+        &root.path().join("Cargo.toml"),
+        r#"[package]
+name = "skillloom"
+version = "0.1.0"
+"#,
+    );
+    write_file(&root.path().join("src/main.rs"), "fn main() {}\n");
+    write_file(&root.path().join("src/commands/mod.rs"), "");
+
+    let target_path = root.path().join("live/claude");
+    let target_path = target_path.display().to_string();
+
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "target",
+            "add",
+            "--agent",
+            "claude",
+            "--path",
+            &target_path,
+            "--ownership",
+            "managed",
+        ],
+    );
+
+    assert!(!output.status.success());
+    assert_eq!(
+        env["error"]["code"],
+        Value::String("ARG_INVALID".to_string())
+    );
+    assert!(
+        !root.path().join(".git").exists(),
+        "guard must reject before git initialization"
+    );
+    assert!(
+        !root.path().join("state/locks").exists(),
+        "guard must reject before lock/layout initialization"
     );
 }

--- a/tests/root_guard.rs
+++ b/tests/root_guard.rs
@@ -91,4 +91,8 @@ version = "0.1.0"
         !root.path().join("state/locks").exists(),
         "guard must reject before lock/layout initialization"
     );
+    assert!(
+        !root.path().join("state/events").exists(),
+        "guard must reject before command audit initialization"
+    );
 }

--- a/tests/workspace_init.rs
+++ b/tests/workspace_init.rs
@@ -16,6 +16,7 @@ fn workspace_init_scan_existing_imports_present_dirs() {
 
     fs::create_dir_all(fake_home.path().join(".claude/skills")).expect("create .claude/skills");
     fs::create_dir_all(fake_home.path().join(".codex/skills")).expect("create .codex/skills");
+    fs::create_dir_all(fake_home.path().join(".cursor/skills")).expect("create .cursor/skills");
 
     let home_str = fake_home.path().to_string_lossy().into_owned();
     let (output, env) = run_loom_with_env(
@@ -35,16 +36,16 @@ fn workspace_init_scan_existing_imports_present_dirs() {
     assert_eq!(env["data"]["scanned"], Value::Bool(true));
     assert_eq!(
         env["data"]["imported"].as_array().map(|a| a.len()),
-        Some(2),
-        "expected both dirs imported: {:?}",
+        Some(3),
+        "expected present default dirs imported: {:?}",
         env["data"]
     );
-    assert_eq!(env["data"]["skipped"].as_array().map(|a| a.len()), Some(0));
+    assert_eq!(env["data"]["skipped"].as_array().map(|a| a.len()), Some(7));
 
     // Confirm the targets are actually persisted.
     let (list_output, list_env) = run_loom(root.path(), &["target", "list"]);
     assert!(list_output.status.success());
-    assert_eq!(list_env["data"]["count"], Value::from(2));
+    assert_eq!(list_env["data"]["count"], Value::from(3));
 }
 
 #[test]
@@ -52,7 +53,7 @@ fn workspace_init_scan_existing_skips_absent_dirs() {
     let root = TestDir::new("ws-init-scan-skip");
     let fake_home = TestDir::new("ws-init-scan-skip-home");
 
-    // Only create the Claude dir; Codex dir intentionally absent.
+    // Only create the Claude dir; all other default agent dirs intentionally absent.
     fs::create_dir_all(fake_home.path().join(".claude/skills")).expect("create .claude/skills");
 
     let home_str = fake_home.path().to_string_lossy().into_owned();
@@ -69,7 +70,7 @@ fn workspace_init_scan_existing_skips_absent_dirs() {
         String::from_utf8_lossy(&output.stdout)
     );
     assert_eq!(env["data"]["imported"].as_array().map(|a| a.len()), Some(1));
-    assert_eq!(env["data"]["skipped"].as_array().map(|a| a.len()), Some(1));
+    assert_eq!(env["data"]["skipped"].as_array().map(|a| a.len()), Some(9));
     assert_eq!(
         env["data"]["skipped"][0]["reason"],
         Value::String("does-not-exist".to_string())

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -165,6 +165,45 @@ fn workspace_binding_add_fails_for_unknown_target() {
 }
 
 #[test]
+fn workspace_binding_add_rejects_malformed_policy_profile() {
+    let root = TestDir::new("registry-binding-bad-policy");
+    let target_path = root.path().join("live/claude-project-a");
+    let (target_output, _) = target_add(root.path(), "claude", &target_path, "managed");
+    assert!(target_output.status.success(), "target add should succeed");
+
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "workspace",
+            "binding",
+            "add",
+            "--agent",
+            "claude",
+            "--profile",
+            "default",
+            "--matcher-kind",
+            "path-prefix",
+            "--matcher-value",
+            "/tmp/project-a",
+            "--target",
+            "target_claude_claude_project_a",
+            "--policy-profile",
+            "Total Nonsense",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "binding add unexpectedly accepted malformed policy profile"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        env["error"]["code"],
+        Value::String("ARG_INVALID".to_string())
+    );
+}
+
+#[test]
 fn registry_state_commit_stages_legacy_v3_deletions() {
     let root = TestDir::new("registry-state-stage-v3-delete");
     let target_path = root.path().join("live/claude");


### PR DESCRIPTION
## Summary
- harden git-backed registry entry points with URL validation, restricted untrusted clone environment, and symlink-safe capture
- split copy/materialize projection semantics, scan all supported default agents during init, and validate policy_profile in the CLI write path
- unify panel read envelopes, add body limits/redaction, and version state/audit records for safer future format changes

## Verification
- cargo test
- cd panel && bun run typecheck
- cd panel && bun run test

## Review notes
- Based on the multi-agent audit report: addresses the highest-risk git URL, capture symlink, projection semantics, init coverage, panel envelope, write guard, state versioning, body-limit, and remote-redaction issues.
- Existing local registry remotes are still supported only as validated local git paths; file:// remains rejected.