### PR TITLE
ci: update checkout action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -153,7 +153,7 @@ jobs:
 
       - name: Checkout
         if: env.CARGO_REGISTRY_TOKEN != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         if: env.CARGO_REGISTRY_TOKEN != ''
@@ -190,7 +190,7 @@ jobs:
 
       - name: Checkout Homebrew tap
         if: env.HOMEBREW_TAP_TOKEN != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.TAP_REPO }}
           token: ${{ env.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- update all GitHub Actions checkout steps from v4 to v6
- remove the Node.js 20 runtime deprecation warning for checkout usage in CI and release workflows

## Verification
- git diff --check origin/main...HEAD
- parsed .github/workflows/*.yml with Ruby YAML
- rg confirmed no actions/checkout@v4 references remain