### PR TITLE
[codex] Make Loom CLI more agent-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Prefer a guided walkthrough? Run `./scripts/demo.sh` for a scripted end-to-end t
 - **🛠️ Ops with audit** — `ops list / retry / purge` and `ops history diagnose / repair`
 - **🛡️ Hard write guard** — refuses to write when `--root` points at the Loom tool repo itself
 - **🖥️ CLI + Panel** — script anything from the CLI; diff and inspect from the React Panel
-- **📤 JSON envelope** — every command speaks `--json` for machine consumption
+- **📤 JSON envelope** — every command speaks compact `--json` for machine consumption (`--pretty` is available for human debugging)
 
 ## How It Works
 
@@ -163,6 +163,8 @@ Four core concepts:
 ## Notes
 
 - Multi-directory behavior is explicit via `target add`; no implicit directory inference.
+- Agent automation should use explicit `--root`, `--json`, selectors such as `binding_id` / `target_id`, and branch on `ok` + `error.code`.
+- Read commands such as `workspace status`, `workspace doctor`, `target list`, and `sync status` do not write command audit events; write commands do.
 - Registry metadata lives under `state/registry`; Loom does not use release-style labels for internal state names.
 - State-changing registry commands commit `state/registry` to Git, and `sync push` has a safety commit before pushing.
 - Hard write guard: if `--root` points to the Loom tool repo itself, write operations are rejected. Use an independent skill registry repo for mutable operations.
@@ -217,7 +219,7 @@ loom ops history repair --strategy <local|remote>
 loom panel [--port 43117]
 ```
 
-Most commands support `--json` for machine-readable output. Commands default to `~/.loom-registry`; use `--root <dir>` to override that registry.
+Most commands support compact `--json` for machine-readable output; add `--pretty` when you want formatted JSON for inspection. Commands default to `~/.loom-registry`; use `--root <dir>` to override that registry.
 
 </details>
 

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -4,17 +4,18 @@
 
 推荐先触发 `loom` 技能（`SKILL.md`），再执行本文档中的非交互命令。
 
-> 当前命令面是 breaking change：旧顶层命令（`loom init/save/status/...`）已移除，Agent 必须使用 `workspace/skill/sync/ops` 命令组。
+`loom init` 和 `loom monitor` 是保留给快速启动的顶层别名。Agent 自动化应优先使用显式的 `workspace/target/skill/sync/ops` 命令组，避免隐藏默认路径。
 
 ## 1. 双模式约定
 
-- 人类操作者：优先 `loom workspace init --wizard`（交互式选择）。
+- 人类操作者：可以使用 `loom init` 和 `loom monitor --once` 快速启动。
 - Agent：优先非交互模式，固定使用 `--json` + 明确参数。
 
 ## 2. Agent 基本调用契约
 
 - 固定带 `--json`，只解析 JSON envelope。
 - 固定带 `--root <absolute_path>`，避免 cwd 漂移。
+- 默认 `--json` 是紧凑单行输出；人类排查时可加 `--pretty`。
 - 只把 `ok=true` 视为成功。
 - `ok=false` 时根据 `error.code` 分支处理。
 - 记录 `request_id` 到日志，保证可追踪。
@@ -36,21 +37,22 @@ JSON envelope 关键字段：
 Agent 首次接管本机 skills 时，执行：
 
 ```bash
-loom --json --root <repo_root> workspace init --from-agent both --target both
+loom --json --root <repo_root> workspace init --scan-existing
+loom --json --root <repo_root> skill monitor-observed --once
 ```
 
 该命令默认顺序为：
 
-1. 备份 agent 原 skills 目录到 `<repo_root>/state/backups/<timestamp>/`
-2. 导入到 `<repo_root>/skills/`
-3. 建立 symlink（或 `--copy`）
+1. 初始化 `<repo_root>` 为 Git-backed Loom registry。
+2. 将默认 `~/.claude/skills` 和 `~/.codex/skills` 注册为 observed targets。
+3. 扫描 observed targets，将包含 `SKILL.md` 的 skill 导入到 `<repo_root>/skills/`。
 
 产出中必须校验：
 
-- `data.backup.destination` 存在
-- `data.backup.manifest` 存在
-- `data.summary.imported >= 0`
-- `data.summary.linked >= 0`
+- `workspace init` 返回 `data.initialized=true`
+- `workspace init` 返回 `data.scanned=true`
+- `skill monitor-observed --once` 返回 `ok=true`
+- `meta.warnings` 为空，或被明确记录为“成功但有风险”
 
 ## 4. 日常操作建议（Agent）
 
@@ -63,11 +65,11 @@ loom --json --root <repo_root> workspace init --from-agent both --target both
 
 ## 5. 安全护栏
 
-- 未经明确授权，不要默认使用 `--skip-backup`。
 - 未经明确授权，不要默认使用 `--force` 覆盖同名 skill。
 - 优先 symlink 模式；只有环境不支持时再使用 `--copy`。
 - `meta.warnings` 不为空时，视为“成功但有风险”，需写入运行日志。
 - `sync_state=LOCAL_ONLY` 或 `PENDING_PUSH` 时，不应宣称“远端已同步”。
+- 读命令（如 `workspace status`、`workspace doctor`、`target list`）不写 command event；不要把读命令当作审计记录来源。
 
 ## 6. 常见失败码处理
 
@@ -83,7 +85,8 @@ loom --json --root <repo_root> workspace init --from-agent both --target both
 
 ```bash
 # 1) 初始化（首次）
-loom --json --root "$ROOT" workspace init --from-agent both --target both
+loom --json --root "$ROOT" workspace init --scan-existing
+loom --json --root "$ROOT" skill monitor-observed --once
 
 # 2) 日常保存
 loom --json --root "$ROOT" skill save "$SKILL"
@@ -95,7 +98,8 @@ loom --json --root "$ROOT" sync push
 ## 8. 人类快速入口
 
 ```bash
-loom workspace init --wizard
+loom init
+loom monitor --once
 ```
 
 该入口用于“安装后首跑”或“不想记参数”的场景；Agent 不应依赖交互式输入。

--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -59,16 +59,16 @@ Optional global flags:
 
 ```bash
 --json
+--pretty
 --request-id <id>
---strict
---dry-run
 ```
 
 Rules:
 
 1. Agents should always use `--json`.
 2. `--root` is mandatory for automation and examples in this spec.
-3. `--dry-run` must not mutate source, targets, bindings, or ops journal.
+3. `--json` defaults to compact single-line output for token efficiency.
+4. `--json --pretty` is reserved for human debugging and documentation capture.
 
 ## 5. Selector Rules
 
@@ -132,6 +132,7 @@ Rules:
 3. `cmd` is the canonical command name, not raw argv text.
 4. `request_id` is echoed back if supplied, otherwise generated.
 5. `meta.op_id` is required for successful writes and omitted for pure reads.
+6. Successful envelopes keep `error: null` so agents can rely on a stable field shape.
 
 ## 7. Error Object
 
@@ -561,6 +562,7 @@ Requirements:
 
 1. no `op_id`
 2. no write side effects
+3. no command-event audit write
 
 ### 15.2 Writes
 

--- a/docs/LOOM_TEST_PLAN.md
+++ b/docs/LOOM_TEST_PLAN.md
@@ -116,7 +116,7 @@ Required checks:
 4. Any target-scoped command requires `target_id` or an equivalent explicit selector.
 5. Every write response can return `op_id`.
 6. Every projection or capture response can return `binding_id`, `target_id`, and `instance_id`.
-7. Read commands are side-effect free by design.
+7. Read commands are side-effect free by design and do not append command audit events.
 
 Pass condition:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Pretty-print the JSON envelope. Ignored unless --json is set.
+    #[arg(long, global = true)]
+    pub pretty: bool,
+
     /// Correlate this command with an external automation request.
     #[arg(long, global = true)]
     pub request_id: Option<String>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,7 +80,6 @@ impl App {
             .request_id
             .clone()
             .unwrap_or_else(|| Uuid::new_v4().to_string());
-        let input = command_event_input(&cli, &request_id);
         let audit_required = command_requires_durable_audit(&cli.command);
         if audit_required && let Err(err) = self.ctx.ensure_not_loom_tool_repo_root() {
             let message = err.to_string();
@@ -92,36 +91,32 @@ impl App {
             return Ok((env, ErrorCode::ArgInvalid.exit_code()));
         }
         let mut audit_started = false;
-        let mut audit_warning = None;
-        match prepare_command_event_store(&self.ctx) {
-            Ok(()) => match append_command_started(&self.ctx, cmd, input, &request_id) {
-                Ok(()) => audit_started = true,
-                Err(err) if audit_required => {
+        if audit_required {
+            let input = command_event_input(&cli, &request_id);
+            match prepare_command_event_store(&self.ctx) {
+                Ok(()) => match append_command_started(&self.ctx, cmd, input, &request_id) {
+                    Ok(()) => audit_started = true,
+                    Err(err) => {
+                        let env = Envelope::err(
+                            cmd,
+                            request_id,
+                            ErrorCode::InternalError,
+                            format!("failed to append command event: {}", err),
+                            json!({}),
+                        );
+                        return Ok((env, ErrorCode::InternalError.exit_code()));
+                    }
+                },
+                Err(err) => {
                     let env = Envelope::err(
                         cmd,
                         request_id,
                         ErrorCode::InternalError,
-                        format!("failed to append command event: {}", err),
+                        format!("failed to prepare command event log: {}", err),
                         json!({}),
                     );
                     return Ok((env, ErrorCode::InternalError.exit_code()));
                 }
-                Err(err) => {
-                    audit_warning = Some(format!("failed to append command event: {}", err));
-                }
-            },
-            Err(err) if audit_required => {
-                let env = Envelope::err(
-                    cmd,
-                    request_id,
-                    ErrorCode::InternalError,
-                    format!("failed to prepare command event log: {}", err),
-                    json!({}),
-                );
-                return Ok((env, ErrorCode::InternalError.exit_code()));
-            }
-            Err(err) => {
-                audit_warning = Some(format!("failed to prepare command event log: {}", err));
             }
         }
 
@@ -165,18 +160,12 @@ impl App {
 
         match result {
             Ok((data, meta)) => {
-                let mut env = Envelope::ok(cmd, request_id, data, meta);
-                if let Some(warning) = audit_warning.take() {
-                    env.meta.warnings.push(warning);
-                }
+                let env = Envelope::ok(cmd, request_id, data, meta);
                 Ok(self.finish_command_audit(cmd, env, 0, audit_started, audit_required))
             }
             Err(f) => {
                 let exit_code = f.code.exit_code();
-                let mut env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
-                if let Some(warning) = audit_warning.take() {
-                    env.meta.warnings.push(warning);
-                }
+                let env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
                 Ok(self.finish_command_audit(cmd, env, exit_code, audit_started, audit_required))
             }
         }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -25,7 +25,6 @@ pub struct Envelope {
     pub request_id: String,
     pub version: String,
     pub data: serde_json::Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ErrorBody>,
     pub meta: Meta,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
 
     match app.execute(cli.clone()) {
         Ok((env, code)) => {
-            print_envelope(&env, cli.json);
+            print_envelope(&env, cli.json, cli.pretty);
             if code != 0 {
                 std::process::exit(code);
             }
@@ -48,9 +48,14 @@ async fn main() {
     }
 }
 
-fn print_envelope(env: &Envelope, force_json: bool) {
+fn print_envelope(env: &Envelope, force_json: bool, pretty: bool) {
     if force_json {
-        match serde_json::to_string_pretty(env) {
+        let rendered = if pretty {
+            serde_json::to_string_pretty(env)
+        } else {
+            serde_json::to_string(env)
+        };
+        match rendered {
             Ok(s) => println!("{}", s),
             Err(e) => {
                 eprintln!("failed to serialize output: {}", e);

--- a/src/panel/auth.rs
+++ b/src/panel/auth.rs
@@ -71,6 +71,7 @@ pub(crate) fn run_panel_command(
     let request_id = Uuid::new_v4().to_string();
     let cli = Cli {
         json: true,
+        pretty: false,
         request_id: Some(request_id.clone()),
         root: Some(state.ctx.root.clone()),
         command,

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -76,6 +76,66 @@ fn top_level_init_uses_default_registry_root_and_scans_existing_dirs() {
 }
 
 #[test]
+fn json_output_defaults_to_compact_envelope() {
+    let root = TestDir::new("cli-compact-json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--json")
+        .arg("--root")
+        .arg(root.path())
+        .args(["workspace", "status"])
+        .output()
+        .expect("run loom status");
+
+    assert!(
+        output.status.success(),
+        "status unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.lines().count(),
+        1,
+        "--json should be compact by default: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"error\":null"),
+        "successful envelopes must keep a stable error:null field: {stdout}"
+    );
+    serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("parse compact json");
+}
+
+#[test]
+fn pretty_json_output_is_opt_in() {
+    let root = TestDir::new("cli-pretty-json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--json")
+        .arg("--pretty")
+        .arg("--root")
+        .arg(root.path())
+        .args(["workspace", "status"])
+        .output()
+        .expect("run loom status");
+
+    assert!(
+        output.status.success(),
+        "status unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.lines().count() > 1,
+        "--json --pretty should keep human-readable formatting: {stdout}"
+    );
+    serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("parse pretty json");
+}
+
+#[test]
 fn migrate_subcommand_is_removed() {
     let root = TestDir::new("cli-no-migrate");
 

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -217,28 +217,12 @@ fn workspace_status_is_read_only_in_empty_dir() {
     assert_eq!(env["ok"], true);
     assert!(!root.path().join(".git").exists());
     assert!(!root.path().join("state/registry").exists());
+    assert!(!root.path().join("state/events").exists());
     assert!(!root.path().join("skills").exists());
-
-    let events = read_command_events(root.path());
-    assert_eq!(events.len(), 2);
-    assert_eq!(events[0]["schema_version"], Value::from(1));
-    assert_eq!(events[1]["schema_version"], Value::from(1));
-    assert_eq!(events[0]["status"], Value::String("started".to_string()));
-    assert_eq!(
-        events[0]["cmd"],
-        Value::String("workspace.status".to_string())
-    );
-    assert!(events[0]["input"]["request_id"].as_str().is_some());
-    assert_eq!(events[1]["status"], Value::String("succeeded".to_string()));
-    assert_eq!(events[1]["exit_code"], Value::from(0));
-    assert_eq!(
-        events[1]["output"]["state_model"],
-        Value::String("registry".to_string())
-    );
 }
 
 #[test]
-fn workspace_status_warns_when_command_audit_preflight_is_unavailable() {
+fn workspace_status_ignores_unavailable_command_audit_path() {
     let root = TestDir::new("status-audit-warning");
     let events_dir = root.path().join("state/events");
     if let Some(parent) = events_dir.parent() {
@@ -254,12 +238,12 @@ fn workspace_status_warns_when_command_audit_preflight_is_unavailable() {
     );
     assert_eq!(env["ok"], Value::Bool(true));
     assert!(
-        env["meta"]["warnings"]
+        !env["meta"]["warnings"]
             .as_array()
             .expect("warnings array")
             .iter()
             .filter_map(serde_json::Value::as_str)
-            .any(|warning| warning.contains("failed to prepare command event log"))
+            .any(|warning| warning.contains("command event"))
     );
     assert!(!root.path().join("state/registry").exists());
 }
@@ -291,7 +275,7 @@ fn failed_command_emits_durable_command_event() {
 }
 
 #[test]
-fn finish_append_failure_still_leaves_started_audit_record() {
+fn workspace_status_does_not_enter_command_audit_finish_path() {
     let root = TestDir::new("finish-append-failure");
 
     let (output, env) = run_loom_with_env(
@@ -303,22 +287,14 @@ fn finish_append_failure_still_leaves_started_audit_record() {
     assert!(output.status.success(), "status should still succeed");
     assert_eq!(env["ok"], Value::Bool(true));
     assert!(
-        env["meta"]["warnings"]
+        !env["meta"]["warnings"]
             .as_array()
             .expect("warnings array")
             .iter()
             .filter_map(serde_json::Value::as_str)
-            .any(|warning| warning.contains("failed to append command event"))
+            .any(|warning| warning.contains("command event"))
     );
-
-    let events = read_command_events(root.path());
-    assert_eq!(events.len(), 1);
-    assert_eq!(
-        events[0]["cmd"],
-        Value::String("workspace.status".to_string())
-    );
-    assert_eq!(events[0]["status"], Value::String("started".to_string()));
-    assert!(events[0]["input"]["request_id"].as_str().is_some());
+    assert!(!root.path().join("state/events/commands.jsonl").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make `--json` compact by default and add `--pretty` for human-readable output
- keep successful JSON envelopes schema-stable with `error: null`
- stop read commands from appending command audit events while preserving durable audit for writes
- align agent-facing docs with the real `workspace init --scan-existing` and `skill monitor-observed --once` flow

## Why
The agent-facing contract had drifted from the real CLI surface and read commands were still creating command-event state. That made simple status checks both noisier for agents and inconsistent with the documented zero-side-effect read contract.

## Validation
- cargo check
- cargo test -q --test cli_surface
- cargo test -q --test reliability workspace_status
- cargo test -q --test reliability failed_command_emits_durable_command_event
- make check
