### PR TITLE
Harden skill diff tests against git signing config

### DIFF
--- a/src/panel/skill_diff/tests.rs
+++ b/src/panel/skill_diff/tests.rs
@@ -21,6 +21,27 @@ fn make_state(root: &std::path::Path) -> PanelState {
     }
 }
 
+fn git_ok(root: &std::path::Path, args: &[&str]) -> std::process::Output {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .arg("-c")
+        .arg("tag.gpgSign=false")
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
 #[test]
 fn is_valid_skill_name_accepts_dotted_names() {
     assert!(
@@ -144,14 +165,7 @@ async fn registry_skill_diff_returns_error_for_nonexistent_skill() {
     let root = std::env::temp_dir().join(format!("loom-diff-nopath-{}", Uuid::new_v4()));
     fs::create_dir_all(root.join("skills/other")).unwrap();
 
-    let git = |args: &[&str]| {
-        std::process::Command::new("git")
-            .arg("-C")
-            .arg(&root)
-            .args(args)
-            .output()
-            .expect("git")
-    };
+    let git = |args: &[&str]| git_ok(&root, args);
 
     git(&["init"]);
     git(&["config", "user.email", "test@example.com"]);
@@ -217,14 +231,7 @@ async fn registry_skill_diff_returns_diff_for_two_commits() {
     let root = std::env::temp_dir().join(format!("loom-diff-integ-{}", Uuid::new_v4()));
     fs::create_dir_all(root.join("skills/foo")).unwrap();
 
-    let git = |args: &[&str]| {
-        std::process::Command::new("git")
-            .arg("-C")
-            .arg(&root)
-            .args(args)
-            .output()
-            .expect("git")
-    };
+    let git = |args: &[&str]| git_ok(&root, args);
 
     git(&["init"]);
     git(&["config", "user.email", "test@example.com"]);


### PR DESCRIPTION
## Summary
- Disable inherited commit/tag signing for temporary Git repos used by skill diff tests
- Assert each test setup git command succeeds so fixture failures fail at the source

## Root cause
The baseline failure was caused by the test fixture inheriting global Git signing config. When `commit.gpgsign=true` and GPG is unavailable in a sandbox, fixture commits fail; the test then passes empty/invalid revs into the diff route and gets a 400 response.

## Verification
- Hostile HOME with `commit.gpgsign=true` and broken GPG: targeted test passes
- `cargo fmt --all -- --check`
- `cargo test -q --bin loom panel::skill_diff::tests`
- `cargo check`
- `cargo test -q`