### PR TITLE
feat(cli): add --version flag and missing skill subcommand descriptions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Parser, Serialize)]
 #[command(name = "loom")]
 #[command(about = "Loom - Skill manager with Git-native backend")]
+#[command(version)]
 pub struct Cli {
     /// Print a stable machine-readable JSON envelope.
     #[arg(long, global = true)]
@@ -135,7 +136,9 @@ pub enum SkillCommand {
     Diff(DiffArgs),
     #[command(about = "Continuously import and update skills from observed targets")]
     MonitorObserved(MonitorObservedArgs),
+    #[command(about = "Import discovered skills from observed targets in one pass")]
     ImportObserved(ImportObservedArgs),
+    #[command(about = "Inspect and clean projections orphaned by binding removal")]
     Orphan {
         #[command(subcommand)]
         command: SkillOrphanCommand,
@@ -144,6 +147,7 @@ pub enum SkillCommand {
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SkillOrphanCommand {
+    #[command(about = "Remove orphaned projection records (and optionally their files)")]
     Clean(OrphanCleanArgs),
 }
 

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -231,3 +231,51 @@ fn top_level_monitor_command_is_available() {
         );
     }
 }
+
+#[test]
+fn version_flag_prints_package_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--version")
+        .output()
+        .expect("run loom --version");
+
+    assert!(
+        output.status.success(),
+        "--version unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "--version output missing package version {}: {stdout}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn skill_help_describes_every_subcommand() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["skill", "--help"])
+        .output()
+        .expect("run loom skill --help");
+
+    assert!(
+        output.status.success(),
+        "skill --help unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "Import discovered skills from observed targets in one pass",
+        "Inspect and clean projections orphaned by binding removal",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "skill --help missing description {expected:?}: {stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `#[command(version)]` to the top-level `Cli` parser so `loom --version` reports `loom 0.1.0` instead of failing with `unexpected argument`.
- Add `about = "..."` to the three `SkillCommand` variants that were rendering as blank rows in `loom skill --help`: `import-observed`, `orphan`, and the nested `orphan clean`.
- Lock both behaviors in via two new integration tests in `tests/cli_surface.rs` (`version_flag_prints_package_version`, `skill_help_describes_every_subcommand`).

Closes #70.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 188 tests pass (including the 2 new ones)
- [x] Manual: `target/debug/loom --version` → `loom 0.1.0`
- [x] Manual: `target/debug/loom skill --help` shows descriptions for `import-observed` and `orphan`

## Notes

- `Cargo.toml` version is intentionally untouched (per repo convention, feature PRs do not bump versions).
- No behavior changes outside of CLI metadata; no existing tests modified.