### PR TITLE
fix(panel): surface git remote-url failures in /api/info via meta.warnings

### DIFF
--- a/src/panel/auth.rs
+++ b/src/panel/auth.rs
@@ -181,6 +181,14 @@ pub(super) fn load_registry_snapshot(
 }
 
 pub(super) fn registry_ok(cmd: &str, data: serde_json::Value) -> Json<serde_json::Value> {
+    registry_ok_with_warnings(cmd, data, Vec::new())
+}
+
+pub(super) fn registry_ok_with_warnings(
+    cmd: &str,
+    data: serde_json::Value,
+    warnings: Vec<String>,
+) -> Json<serde_json::Value> {
     Json(json!({
         "ok": true,
         "cmd": cmd,
@@ -188,7 +196,7 @@ pub(super) fn registry_ok(cmd: &str, data: serde_json::Value) -> Json<serde_json
         "version": env!("CARGO_PKG_VERSION"),
         "data": data,
         "meta": {
-            "warnings": []
+            "warnings": warnings,
         }
     }))
 }

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -19,7 +19,8 @@ use crate::state_model::RegistryStatePaths;
 
 use super::auth::{
     ensure_mutation_authorized, error_envelope, load_registry_snapshot, registry_error,
-    registry_ok, run_panel_command, status_for_error_code, status_for_registry_error_payload,
+    registry_ok, registry_ok_with_warnings, run_panel_command, status_for_error_code,
+    status_for_registry_error_payload,
 };
 use super::{
     BindingAddRequest, CaptureRequest, HistoryRepairRequest, PanelState, ProjectRequest,
@@ -59,14 +60,19 @@ pub(super) async fn health() -> Json<serde_json::Value> {
 
 pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Value> {
     let target_dirs = resolve_agent_skill_dirs(&state.ctx.root);
-    let remote_url = crate::gitops::remote_url(&state.ctx)
-        .ok()
-        .flatten()
-        .unwrap_or_default();
-    let remote_url = redact_sensitive_string(&remote_url);
     let registry_paths = RegistryStatePaths::from_app_context(&state.ctx);
 
-    registry_ok(
+    let mut warnings: Vec<String> = Vec::new();
+    let remote_url = match crate::gitops::remote_url(&state.ctx) {
+        Ok(Some(url)) => redact_sensitive_string(&url),
+        Ok(None) => String::new(),
+        Err(err) => {
+            warnings.push(format!("failed to read git remote url: {err}"));
+            String::new()
+        }
+    };
+
+    registry_ok_with_warnings(
         "panel.info",
         json!({
             "root": state.ctx.root.display().to_string(),
@@ -76,6 +82,7 @@ pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Va
             "codex_dir": target_dirs.codex.display().to_string(),
             "remote_url": remote_url,
         }),
+        warnings,
     )
 }
 

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -65,7 +65,27 @@ pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Va
     let mut warnings: Vec<String> = Vec::new();
     let remote_url = match crate::gitops::remote_url(&state.ctx) {
         Ok(Some(url)) => redact_sensitive_string(&url),
-        Ok(None) => String::new(),
+        Ok(None) => {
+            // `gitops::remote_url` returns `Ok(None)` for both "no remote
+            // configured" (exit 2 "No such remote 'origin'") and "not a git
+            // repository" (exit 128). Probe with `rev-parse --git-dir` to
+            // distinguish the two so a missing or corrupt repository is
+            // surfaced as a warning instead of being indistinguishable from
+            // an unconfigured remote.
+            match crate::gitops::run_git_allow_failure(&state.ctx, &["rev-parse", "--git-dir"]) {
+                Ok(probe) if !probe.status.success() => {
+                    warnings.push(format!(
+                        "git repository not initialized at {}",
+                        state.ctx.root.display()
+                    ));
+                }
+                Err(err) => {
+                    warnings.push(format!("failed to probe git repository: {err}"));
+                }
+                Ok(_) => {}
+            }
+            String::new()
+        }
         Err(err) => {
             warnings.push(format!("failed to read git remote url: {err}"));
             String::new()

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -244,6 +244,12 @@ async fn info_and_remote_status_redact_remote_credentials() {
     assert!(!info_url.contains("user:pass"));
     assert!(!info_url.contains("ghp_secret"));
     assert!(info_url.contains("<redacted>"));
+    assert_eq!(
+        info_payload["meta"]["warnings"]
+            .as_array()
+            .expect("warnings array"),
+        &Vec::<serde_json::Value>::new()
+    );
 
     let (status, Json(remote_payload)) = remote_status(State(state)).await;
     assert_eq!(status, StatusCode::OK);
@@ -255,6 +261,28 @@ async fn info_and_remote_status_redact_remote_credentials() {
     assert!(status_url.contains("<redacted>"));
 
     cleanup_root(root);
+}
+
+#[tokio::test]
+async fn info_surfaces_warning_when_git_remote_lookup_fails() {
+    let (root, state) = make_test_state();
+    // Remove the worktree out from under the panel to make `git remote get-url`
+    // fail at spawn time (current_dir does not exist).
+    fs::remove_dir_all(&root).expect("remove root");
+
+    let Json(payload) = info(State(state)).await;
+
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["data"]["remote_url"], json!(""));
+    let warnings = payload["meta"]["warnings"]
+        .as_array()
+        .expect("warnings array");
+    assert_eq!(warnings.len(), 1);
+    let message = warnings[0].as_str().expect("warning string");
+    assert!(
+        message.starts_with("failed to read git remote url"),
+        "unexpected warning: {message}"
+    );
 }
 
 #[tokio::test]

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -264,6 +264,50 @@ async fn info_and_remote_status_redact_remote_credentials() {
 }
 
 #[tokio::test]
+async fn info_surfaces_warning_when_root_is_not_a_git_repository() {
+    let (root, state) = make_test_state();
+    // make_test_state creates the directory but never runs `git init`, so
+    // `git remote get-url origin` exits 128 with "fatal: not a git
+    // repository" — currently mapped to Ok(None) inside gitops::remote_url.
+    // The handler should probe the repo and surface the misconfiguration.
+
+    let Json(payload) = info(State(state)).await;
+
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["data"]["remote_url"], json!(""));
+    let warnings = payload["meta"]["warnings"]
+        .as_array()
+        .expect("warnings array");
+    assert_eq!(warnings.len(), 1);
+    let message = warnings[0].as_str().expect("warning string");
+    assert!(
+        message.starts_with("git repository not initialized"),
+        "unexpected warning: {message}"
+    );
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
+async fn info_omits_warning_when_repo_initialized_but_no_remote_configured() {
+    let (root, state) = make_test_state();
+    crate::gitops::ensure_repo_initialized(&state.ctx).expect("init repo");
+
+    let Json(payload) = info(State(state)).await;
+
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["data"]["remote_url"], json!(""));
+    assert_eq!(
+        payload["meta"]["warnings"]
+            .as_array()
+            .expect("warnings array"),
+        &Vec::<serde_json::Value>::new()
+    );
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
 async fn info_surfaces_warning_when_git_remote_lookup_fails() {
     let (root, state) = make_test_state();
     // Remove the worktree out from under the panel to make `git remote get-url`


### PR DESCRIPTION
Closes #75.

## Summary

- `panel/info` no longer collapses git failures into a silent empty `remote_url`.
- Errors from `gitops::remote_url` now surface as a `meta.warnings` entry, matching the pattern already used by `pending.list` and `skill.history`.
- New `registry_ok_with_warnings` helper in `auth.rs`; existing `registry_ok` routes through it so every other call site keeps an identical wire shape.

## Why

`info` was the only `info`-class handler that hid backend errors. With the previous `.ok().flatten().unwrap_or_default()` pattern, three distinct states (`Ok(Some(url))`, `Ok(None)`, `Err(_)`) all rendered as `""`, so a missing or unreadable `git` binary looked exactly like "no remote configured" — a U-29 (no silent degradation) violation.

## Test plan

- [x] `cargo test` — all 187 tests pass across 12 binaries.
- [x] Existing test `info_and_remote_status_redact_remote_credentials` extended to assert `meta.warnings == []` on the happy path.
- [x] New test `info_surfaces_warning_when_git_remote_lookup_fails` removes the worktree out from under the panel so `git remote get-url` fails at spawn time, then asserts `data.remote_url == ""` and that the warning array contains the expected message.

## Out of scope

This PR fixes only `info`. Other audit findings filed alongside this one (#72, #73, #74, #76) are tracked separately.