### PR TITLE
feat(panel): point the Skills empty state at the add button and CLI

### DIFF
--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -168,3 +168,25 @@ describe("SkillsPage — history tab", () => {
     });
   });
 });
+
+describe("SkillsPage — empty registry", () => {
+  it("guides first-run users to the add button and the loom skill add CLI", () => {
+    render(
+      <SkillsPage
+        skills={[]}
+        targets={[]}
+        selectedSkill={null}
+        onSelectSkill={() => {}}
+        onMutation={() => {}}
+        readOnly={false}
+      />,
+    );
+
+    // The CTA references the in-panel button by its label so users notice it.
+    expect(screen.getAllByText(/\+ skill add/).length).toBeGreaterThan(0);
+    // And it surfaces the equivalent CLI invocation for terminal-first users.
+    expect(
+      screen.getAllByText(/loom skill add <source> --name <name>/).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -22,11 +22,16 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
   const sel = skills.find((s) => s.id === selectedSkill) ?? skills[0];
   const capture = useMutation();
   const captureDisabled = capture.busy || readOnly || !sel;
-  const emptyMessage = readOnly
+  const emptyMessage: React.ReactNode = readOnly
     ? "Live registry API is offline. Start the panel backend to load real skills."
     : q
     ? "No skills match the current filter."
-    : "No skills in this registry yet.";
+    : (
+        <>
+          No skills in this registry yet — use the <strong>+ skill add</strong> button above, or run{" "}
+          <code className="mono">loom skill add &lt;source&gt; --name &lt;name&gt;</code>.
+        </>
+      );
 
   const runCapture = () => {
     if (!sel) return;


### PR DESCRIPTION
## Summary

- `SkillsPage` already has a `+ skill add` button in the header but the empty cell shown when the registry has no skills only said `No skills in this registry yet.`, so neither in-panel users nor terminal-first users got any onward signal.
- Replace the empty message with JSX that names both the in-panel button and the equivalent `loom skill add <source> --name <name>` CLI invocation. Read-only and filter-no-match branches are unchanged.
- Add a `SkillsPage.test.tsx` regression that renders an empty registry and asserts both signals are present.

Closes #78.

## Test plan

- [x] `bun run typecheck` (panel) — no errors
- [x] `bun run test` (panel) — 24 tests pass (including the new one)
- [x] `bun run build` (panel) — production bundle builds cleanly
- [x] Manual code review: only `SkillsPage.tsx:25-32` and the new test block in `SkillsPage.test.tsx` change

## Notes

- `Cargo.toml` and `panel/package.json` versions are intentionally untouched.
- No behavior change for non-empty registries, the offline-API branch, or the active-filter branch.