### PR TITLE
Remove unused PageId in panel/src/types.ts

### DIFF
--- a/panel/src/types.ts
+++ b/panel/src/types.ts
@@ -14,15 +14,6 @@ import type { RegistryRule } from "./generated/RegistryRule";
 import type { RegistryProjection } from "./generated/RegistryProjection";
 import type { RegistryCheckpoint } from "./generated/RegistryCheckpoint";
 
-export type PageId =
-  | "overview"
-  | "skills"
-  | "bindings"
-  | "targets"
-  | "projections"
-  | "ops"
-  | "settings";
-
 export type HealthPayload = {
   ok?: boolean;
   service?: string;


### PR DESCRIPTION
## Summary
- `PageId` in `panel/src/types.ts` and `PanelPageKey` in `panel/src/lib/types.ts` had drifted (issue #76): `PageId` still listed `projections` while omitting the current `history` and `sync` pages.
- `PanelPageKey` is the canonical type used by the active routing surface (`PanelApp`, `Sidebar`, `Topbar`); `PageId` had no consumers.
- Drop `PageId` so future page additions only need to update one type.

## Test plan
- [x] `bun run typecheck` (panel) — passes
- [x] `bun run test` (panel) — 4 files / 23 tests passed

Closes #76