### PR TITLE
fix(cli): wire --version flag and add about strings for skill subcommands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,7 +138,7 @@ pub enum SkillCommand {
     MonitorObserved(MonitorObservedArgs),
     #[command(about = "Run one import pass over observed targets and exit")]
     ImportObserved(ImportObservedArgs),
-    #[command(about = "Inspect and prune orphaned skill sources")]
+    #[command(about = "Inspect and clean projections orphaned by binding removal")]
     Orphan {
         #[command(subcommand)]
         command: SkillOrphanCommand,
@@ -147,7 +147,7 @@ pub enum SkillCommand {
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SkillOrphanCommand {
-    #[command(about = "Remove orphaned skill sources that no longer have a backing target")]
+    #[command(about = "Remove orphaned projection records (and optionally their live files)")]
     Clean(OrphanCleanArgs),
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Parser, Serialize)]
 #[command(name = "loom")]
+#[command(version)]
 #[command(about = "Loom - Skill manager with Git-native backend")]
 pub struct Cli {
     /// Print a stable machine-readable JSON envelope.
@@ -135,7 +136,9 @@ pub enum SkillCommand {
     Diff(DiffArgs),
     #[command(about = "Continuously import and update skills from observed targets")]
     MonitorObserved(MonitorObservedArgs),
+    #[command(about = "Run one import pass over observed targets and exit")]
     ImportObserved(ImportObservedArgs),
+    #[command(about = "Inspect and prune orphaned skill sources")]
     Orphan {
         #[command(subcommand)]
         command: SkillOrphanCommand,
@@ -144,6 +147,7 @@ pub enum SkillCommand {
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SkillOrphanCommand {
+    #[command(about = "Remove orphaned skill sources that no longer have a backing target")]
     Clean(OrphanCleanArgs),
 }
 

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -210,6 +210,84 @@ fn skill_monitor_observed_command_is_available() {
 }
 
 #[test]
+fn top_level_version_flag_prints_cargo_pkg_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--version")
+        .output()
+        .expect("run loom --version");
+
+    assert!(
+        output.status.success(),
+        "--version unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "--version output must contain CARGO_PKG_VERSION ({}): {stdout}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[test]
+fn skill_help_describes_every_subcommand() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["skill", "--help"])
+        .output()
+        .expect("run loom skill --help");
+
+    assert!(
+        output.status.success(),
+        "skill help unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "Import a skill source into the registry",
+        "Project a registry skill into a bound target",
+        "Capture live projection edits back to the source",
+        "Commit source changes for one skill",
+        "Create a version snapshot for one skill",
+        "Tag a skill release",
+        "Roll back a skill source to an earlier revision",
+        "Diff two revisions of a skill source",
+        "Continuously import and update skills from observed targets",
+        "Run one import pass over observed targets and exit",
+        "Inspect and prune orphaned skill sources",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "skill help missing description {expected:?}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn skill_orphan_help_describes_clean_subcommand() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["skill", "orphan", "--help"])
+        .output()
+        .expect("run loom skill orphan --help");
+
+    assert!(
+        output.status.success(),
+        "skill orphan help unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Remove orphaned skill sources that no longer have a backing target"),
+        "skill orphan help missing clean description: {stdout}"
+    );
+}
+
+#[test]
 fn top_level_monitor_command_is_available() {
     let output = Command::new(env!("CARGO_BIN_EXE_loom"))
         .args(["monitor", "--help"])

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -257,7 +257,7 @@ fn skill_help_describes_every_subcommand() {
         "Diff two revisions of a skill source",
         "Continuously import and update skills from observed targets",
         "Run one import pass over observed targets and exit",
-        "Inspect and prune orphaned skill sources",
+        "Inspect and clean projections orphaned by binding removal",
     ] {
         assert!(
             stdout.contains(expected),
@@ -282,7 +282,7 @@ fn skill_orphan_help_describes_clean_subcommand() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Remove orphaned skill sources that no longer have a backing target"),
+        stdout.contains("Remove orphaned projection records (and optionally their live files)"),
         "skill orphan help missing clean description: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary
Closes #70.

- Add `#[command(version)]` on the top-level `Cli` parser so `loom --version` prints `loom <CARGO_PKG_VERSION>` instead of failing with `error: unexpected argument '--version' found`.
- Add missing `about = "..."` strings on `SkillCommand::ImportObserved`, `SkillCommand::Orphan`, and `SkillOrphanCommand::Clean` so `loom skill --help` describes every subcommand.
- Extend `tests/cli_surface.rs` with three regression tests covering `--version`, `skill --help` descriptions, and `skill orphan --help`.

## Test plan
- [x] `cargo check --tests`
- [x] `cargo test --test cli_surface` (11 passed)
- [x] `cargo test` (full suite green)
- [x] `./target/release/loom --version` → `loom 0.1.0`
- [x] `./target/release/loom skill --help` shows descriptions for `import-observed` and `orphan`