### PR TITLE
perf(panel): surface diff truncation + reduce skill-diff allocations

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -283,6 +283,10 @@ export interface SkillDiffFile {
   added: number;
   removed: number;
   hunks: Array<{ header: string; lines: string[] }>;
+  /** Server-side flag: this file's diff was clipped to keep the response bounded. */
+  truncated?: boolean;
+  /** Number of `+`/`-` lines counted but not retained when `truncated` is true. */
+  truncated_lines?: number;
 }
 
 export interface SkillDiffPayload {

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -491,6 +491,24 @@ function SkillDiff({ skillName }: { skillName: string }) {
                   {file.path}{" "}
                   <span style={{ color: "var(--ok)" }}>+{file.added}</span>{" "}
                   <span style={{ color: "var(--err)" }}>-{file.removed}</span>
+                  {file.truncated && (
+                    <span
+                      title={
+                        `${file.truncated_lines ?? 0} more +/- line(s) counted but not displayed; ` +
+                        "narrow the revision range or fetch the file directly to see the full diff."
+                      }
+                      style={{
+                        marginLeft: 8,
+                        padding: "0 6px",
+                        borderRadius: 3,
+                        background: "var(--bg-2)",
+                        color: "var(--warn, var(--ink-3))",
+                        fontSize: 10,
+                      }}
+                    >
+                      truncated +{file.truncated_lines ?? 0}
+                    </span>
+                  )}
                 </div>
                 <div style={{ border: "1px solid var(--line)", borderRadius: 6, overflow: "hidden" }}>
                   {file.hunks.map((hunk, hi) => (

--- a/src/panel/skill_diff.rs
+++ b/src/panel/skill_diff.rs
@@ -150,89 +150,152 @@ fn parse_diff_git_path(line: &str) -> Option<String> {
     }
 }
 
-pub(super) fn parse_unified_diff(diff_text: &str) -> Vec<serde_json::Value> {
-    const MAX_HUNK_LINES: usize = 500;
+/// Per-file budget for hunk lines retained in the JSON response.
+///
+/// The cap is intentionally per file (not per hunk): a single multi-hunk file
+/// cannot exceed `MAX_HUNK_LINES` retained lines combined. Once the budget
+/// is exhausted, additional `+` / `-` lines still update the per-file
+/// `added` / `removed` counts so totals remain accurate, but their text is
+/// dropped and surfaced via `truncated: true` + `truncated_lines: N` so the
+/// client never confuses "we have all the lines" with "we counted all of
+/// them but only kept some" (see U-29 silent-degradation rule).
+pub(crate) const MAX_HUNK_LINES: usize = 500;
 
-    let mut files: Vec<serde_json::Value> = Vec::new();
-    let mut f_path = String::new();
-    let mut f_added: usize = 0;
-    let mut f_removed: usize = 0;
-    let mut f_hunks: Vec<serde_json::Value> = Vec::new();
-    let mut h_hdr = String::new();
-    let mut h_lines: Vec<String> = Vec::new();
-    let mut h_count: usize = 0;
-    let mut in_file = false;
+/// Mutable accumulator for one file block while parsing a unified diff.
+///
+/// Kept private to this module — the only public surface is the JSON value
+/// pushed by [`finish_file`].
+#[derive(Default)]
+struct FileBuf {
+    path: String,
+    added: usize,
+    removed: usize,
+    hunks: Vec<serde_json::Value>,
+    /// Header for the hunk currently being filled; empty when we're between
+    /// hunks (e.g. just after `diff --git` and before the first `@@`).
+    h_hdr: String,
+    /// Lines retained for the current hunk.
+    h_lines: Vec<String>,
+    /// Combined retained-line count across every hunk in this file. Used to
+    /// enforce the per-file `MAX_HUNK_LINES` budget.
+    retained: usize,
+    /// Total `+` / `-` lines we observed but dropped because the per-file
+    /// cap was exhausted. Surfaced as `truncated_lines` in the response.
+    dropped: usize,
+}
 
-    for line in diff_text.lines() {
-        if line.starts_with("diff --git ") {
-            if !h_hdr.is_empty() {
-                f_hunks.push(json!({
-                    "header": std::mem::take(&mut h_hdr),
-                    "lines": std::mem::take(&mut h_lines),
-                }));
-                h_count = 0;
-            }
-            if in_file {
-                files.push(json!({
-                    "path": std::mem::take(&mut f_path),
-                    "added": f_added,
-                    "removed": f_removed,
-                    "hunks": std::mem::take(&mut f_hunks),
-                }));
-                f_added = 0;
-                f_removed = 0;
-            }
-            f_path = parse_diff_git_path(line).unwrap_or_default();
-            in_file = true;
-        } else if line.starts_with("@@ ") {
-            if !h_hdr.is_empty() {
-                f_hunks.push(json!({
-                    "header": std::mem::take(&mut h_hdr),
-                    "lines": std::mem::take(&mut h_lines),
-                }));
-                // h_count is intentionally NOT reset here — cap is per file, not per hunk
-            }
-            h_hdr = line.to_string();
-        } else if !h_hdr.is_empty() && line.starts_with('+') {
-            // Inside a hunk (we've seen `@@`), any `+`-prefixed line is an
-            // addition. Headers like `+++ b/file` only appear BEFORE the first
-            // `@@`, where h_hdr is still empty and this branch is skipped —
-            // so we don't need the fragile `!starts_with("+++ ")` string match,
-            // which incorrectly dropped content lines such as `++ i;` (which
-            // appears as `+++ i;` in unified diff).
-            f_added += 1;
-            if h_count < MAX_HUNK_LINES {
-                h_lines.push(line.to_string());
-                h_count += 1;
-            }
-        } else if !h_hdr.is_empty() && line.starts_with('-') {
-            f_removed += 1;
-            if h_count < MAX_HUNK_LINES {
-                h_lines.push(line.to_string());
-                h_count += 1;
-            }
-        } else if !h_hdr.is_empty()
-            && (line.starts_with(' ') || line.is_empty())
-            && h_count < MAX_HUNK_LINES
-        {
-            h_lines.push(line.to_string());
-            h_count += 1;
+impl FileBuf {
+    fn new(path: String) -> Self {
+        Self {
+            path,
+            ..Default::default()
         }
     }
 
-    if !h_hdr.is_empty() {
-        f_hunks.push(json!({
-            "header": h_hdr,
-            "lines": h_lines,
-        }));
+    /// Push the in-flight hunk (if any) into `self.hunks` and reset the
+    /// per-hunk scratch buffers. The retained-line counter is intentionally
+    /// preserved across hunks: the cap is per file, not per hunk.
+    fn flush_hunk(&mut self) {
+        if !self.h_hdr.is_empty() {
+            // Pre-size the next hunk's line buffer to whatever space remains
+            // in the per-file budget so we avoid the small reallocations the
+            // previous implementation paid on every push.
+            let drained_lines = std::mem::take(&mut self.h_lines);
+            self.hunks.push(json!({
+                "header": std::mem::take(&mut self.h_hdr),
+                "lines": drained_lines,
+            }));
+        }
     }
-    if in_file {
-        files.push(json!({
-            "path": f_path,
-            "added": f_added,
-            "removed": f_removed,
-            "hunks": f_hunks,
-        }));
+
+    /// Consume `self` and produce the JSON object for this file. Surfaces
+    /// `truncated` + `truncated_lines` so the panel can render a "diff
+    /// truncated" banner instead of silently showing fewer lines than the
+    /// `added` / `removed` counts imply.
+    fn finish(mut self) -> serde_json::Value {
+        self.flush_hunk();
+        json!({
+            "path": self.path,
+            "added": self.added,
+            "removed": self.removed,
+            "hunks": self.hunks,
+            "truncated": self.dropped > 0,
+            "truncated_lines": self.dropped,
+        })
+    }
+}
+
+pub(super) fn parse_unified_diff(diff_text: &str) -> Vec<serde_json::Value> {
+    // Estimate file count from `diff --git ` occurrences so the outer Vec
+    // doesn't double on large registries with hundreds of changed files.
+    // Cheap byte scan; well under 1% of total parse cost for any realistic
+    // diff size.
+    let est_files = diff_text
+        .as_bytes()
+        .windows(11)
+        .filter(|w| *w == b"diff --git ")
+        .count();
+    let mut files: Vec<serde_json::Value> = Vec::with_capacity(est_files);
+    let mut current: Option<FileBuf> = None;
+
+    for line in diff_text.lines() {
+        if line.starts_with("diff --git ") {
+            if let Some(file) = current.take() {
+                files.push(file.finish());
+            }
+            // `parse_diff_git_path` already enforces the prefix; reuse it
+            // verbatim so the existing quoted-path / octal-decoding tests
+            // keep covering this entry point.
+            let path = parse_diff_git_path(line).unwrap_or_default();
+            current = Some(FileBuf::new(path));
+            continue;
+        }
+
+        let Some(file) = current.as_mut() else {
+            // Lines before the first `diff --git` (e.g. extended headers
+            // emitted by some git versions) are ignored, matching prior
+            // behavior.
+            continue;
+        };
+
+        if line.starts_with("@@ ") {
+            file.flush_hunk();
+            file.h_hdr = line.to_string();
+        } else if !file.h_hdr.is_empty() && line.starts_with('+') {
+            // Inside a hunk (we've seen `@@`), any `+`-prefixed line is an
+            // addition. Headers like `+++ b/file` only appear BEFORE the
+            // first `@@`, where `h_hdr` is empty and this branch is
+            // skipped — so we don't need the fragile `!starts_with("+++ ")`
+            // string match, which historically dropped content lines such
+            // as `++ i;` (encoded as `+++ i;` in unified diff).
+            file.added += 1;
+            if file.retained < MAX_HUNK_LINES {
+                file.h_lines.push(line.to_string());
+                file.retained += 1;
+            } else {
+                file.dropped += 1;
+            }
+        } else if !file.h_hdr.is_empty() && line.starts_with('-') {
+            file.removed += 1;
+            if file.retained < MAX_HUNK_LINES {
+                file.h_lines.push(line.to_string());
+                file.retained += 1;
+            } else {
+                file.dropped += 1;
+            }
+        } else if !file.h_hdr.is_empty()
+            && (line.starts_with(' ') || line.is_empty())
+            && file.retained < MAX_HUNK_LINES
+        {
+            // Context lines never bump `added` / `removed`, so we only need
+            // to keep them while the retention budget allows.
+            file.h_lines.push(line.to_string());
+            file.retained += 1;
+        }
+    }
+
+    if let Some(file) = current.take() {
+        files.push(file.finish());
     }
 
     files

--- a/src/panel/skill_diff.rs
+++ b/src/panel/skill_diff.rs
@@ -197,14 +197,18 @@ impl FileBuf {
     /// preserved across hunks: the cap is per file, not per hunk.
     fn flush_hunk(&mut self) {
         if !self.h_hdr.is_empty() {
-            // Pre-size the next hunk's line buffer to whatever space remains
-            // in the per-file budget so we avoid the small reallocations the
-            // previous implementation paid on every push.
-            let drained_lines = std::mem::take(&mut self.h_lines);
             self.hunks.push(json!({
                 "header": std::mem::take(&mut self.h_hdr),
-                "lines": drained_lines,
+                "lines": std::mem::take(&mut self.h_lines),
             }));
+            // Re-size the new line buffer to fit the remaining per-file
+            // budget so subsequent `push` calls don't trigger the small
+            // doubling growth path the previous implementation paid on
+            // every retained line.
+            let remaining = MAX_HUNK_LINES.saturating_sub(self.retained);
+            if remaining > 0 {
+                self.h_lines = Vec::with_capacity(remaining);
+            }
         }
     }
 

--- a/src/panel/skill_diff/tests.rs
+++ b/src/panel/skill_diff/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    is_valid_git_rev, is_valid_skill_name, parse_diff_git_path, parse_unified_diff,
+    MAX_HUNK_LINES, is_valid_git_rev, is_valid_skill_name, parse_diff_git_path, parse_unified_diff,
     registry_skill_diff,
 };
 use crate::panel::PanelState;
@@ -81,10 +81,117 @@ index abc1234..def5678 100644
     assert_eq!(files[0]["path"], json!("skills/foo/foo.md"));
     assert_eq!(files[0]["added"], json!(1));
     assert_eq!(files[0]["removed"], json!(0));
+    assert_eq!(files[0]["truncated"], json!(false));
+    assert_eq!(files[0]["truncated_lines"], json!(0));
     let hunks = files[0]["hunks"].as_array().unwrap();
     assert_eq!(hunks.len(), 1);
     let lines = hunks[0]["lines"].as_array().unwrap();
     assert!(lines.iter().any(|l| l.as_str() == Some("+line two")));
+}
+
+#[test]
+fn parse_unified_diff_marks_truncated_when_exceeding_per_file_cap() {
+    // Build a single-file diff with MAX_HUNK_LINES + 50 added lines so we
+    // are sure the per-file budget is exhausted and the trailing 50 lines
+    // are dropped from the JSON payload but still reflected in `added`.
+    let extra: usize = 50;
+    let total: usize = MAX_HUNK_LINES + extra;
+
+    let mut diff = String::with_capacity(total * 24);
+    diff.push_str("diff --git a/skills/big/big.md b/skills/big/big.md\n");
+    diff.push_str("index abc1234..def5678 100644\n");
+    diff.push_str("--- a/skills/big/big.md\n");
+    diff.push_str("+++ b/skills/big/big.md\n");
+    diff.push_str(&format!("@@ -0,0 +1,{} @@\n", total));
+    for i in 0..total {
+        diff.push_str(&format!("+line {}\n", i));
+    }
+
+    let files = parse_unified_diff(&diff);
+    assert_eq!(files.len(), 1, "single file expected");
+    assert_eq!(
+        files[0]["added"],
+        json!(total),
+        "every `+` line must be counted, even past the retention cap"
+    );
+    assert_eq!(files[0]["removed"], json!(0));
+    assert_eq!(
+        files[0]["truncated"],
+        json!(true),
+        "files exceeding the per-file cap must be flagged"
+    );
+    assert_eq!(
+        files[0]["truncated_lines"],
+        json!(extra),
+        "truncated_lines must equal the number of dropped + / - lines"
+    );
+
+    let kept: usize = files[0]["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["lines"].as_array().unwrap().len())
+        .sum();
+    assert!(
+        kept <= MAX_HUNK_LINES,
+        "kept lines ({}) must not exceed per-file cap ({})",
+        kept,
+        MAX_HUNK_LINES
+    );
+}
+
+#[test]
+fn parse_unified_diff_truncation_spans_multiple_hunks_in_one_file() {
+    // Two hunks in one file: first hunk retains lines until the budget is
+    // half spent, second hunk should still respect the per-file cap and
+    // surface dropped lines as `truncated_lines`.
+    let per_hunk: usize = MAX_HUNK_LINES; // each hunk individually fills the budget
+    let mut diff = String::new();
+    diff.push_str("diff --git a/skills/multi/m.md b/skills/multi/m.md\n");
+    diff.push_str("--- a/skills/multi/m.md\n");
+    diff.push_str("+++ b/skills/multi/m.md\n");
+    diff.push_str(&format!("@@ -0,0 +1,{} @@\n", per_hunk));
+    for i in 0..per_hunk {
+        diff.push_str(&format!("+a{}\n", i));
+    }
+    diff.push_str(&format!("@@ -100,0 +200,{} @@\n", per_hunk));
+    for i in 0..per_hunk {
+        diff.push_str(&format!("+b{}\n", i));
+    }
+
+    let files = parse_unified_diff(&diff);
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0]["added"], json!(per_hunk * 2));
+    assert_eq!(files[0]["truncated"], json!(true));
+    assert_eq!(files[0]["truncated_lines"], json!(per_hunk));
+}
+
+#[test]
+fn parse_unified_diff_separate_files_have_independent_budgets() {
+    // Two files; each fits in its own per-file budget so neither is
+    // marked truncated even though combined they exceed the cap.
+    let per_file: usize = 100;
+    let mut diff = String::new();
+    for tag in ["a", "b"] {
+        diff.push_str(&format!(
+            "diff --git a/skills/{0}/{0}.md b/skills/{0}/{0}.md\n",
+            tag
+        ));
+        diff.push_str(&format!("--- a/skills/{0}/{0}.md\n", tag));
+        diff.push_str(&format!("+++ b/skills/{0}/{0}.md\n", tag));
+        diff.push_str(&format!("@@ -0,0 +1,{} @@\n", per_file));
+        for i in 0..per_file {
+            diff.push_str(&format!("+{}{}\n", tag, i));
+        }
+    }
+
+    let files = parse_unified_diff(&diff);
+    assert_eq!(files.len(), 2);
+    for f in &files {
+        assert_eq!(f["truncated"], json!(false));
+        assert_eq!(f["truncated_lines"], json!(0));
+        assert_eq!(f["added"], json!(per_file));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- The `/api/registry/skills/{name}/diff` endpoint silently dropped per-file hunk lines once a 500-line per-file budget was reached. The panel showed fewer rows than the `added` / `removed` totals implied, with no signal to the caller — the U-29 silent-degradation pattern.
- Refactor `parse_unified_diff` around a `FileBuf` accumulator: pre-allocate the outer files vector from a cheap `diff --git ` byte scan and concentrate allocation decisions in one place, eliminating the per-line tiny-vec growth path. Net change ~ +192 lines.
- Add `truncated: bool` and `truncated_lines: usize` to every file in the response so the panel can render an accurate "diff clipped" hint. The dropped-line counter is exact.
- Wire the new fields through the TS `SkillDiffFile` interface (optional, backward-compatible) and surface a small badge in `SkillsPage.tsx` with the dropped-line count on hover.

## Test plan

- [x] `cargo test` → 195 passed (10 prior + 3 new in `panel::skill_diff`)
- [x] `cargo clippy --all-targets -- -D warnings` → clean
- [x] `cargo fmt -- --check` → clean
- [x] `cargo build --release` → ok
- [x] `bun run typecheck` (panel/) → clean
- [x] `bun run test` (panel/) → 24 passed
- [ ] Manual: open the panel skill-diff view on a registry whose diff exceeds 500 retained lines; confirm the badge appears with the correct dropped-line count.