### PR TITLE
feat(panel): tooltip explaining managed/observed/external on Targets page

### DIFF
--- a/panel/src/pages/panel/TargetsPage.test.tsx
+++ b/panel/src/pages/panel/TargetsPage.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TargetsPage } from "./TargetsPage";
+import type { Ownership, Target } from "../../lib/types";
+
+function makeTarget(id: string, ownership: Ownership): Target {
+  return {
+    id,
+    agent: "claude",
+    profile: "home",
+    path: `~/.${ownership}/skills`,
+    ownership,
+    skills: 0,
+    lastSync: "now",
+  };
+}
+
+describe("TargetsPage — ownership tier tooltip", () => {
+  it("attaches an explanatory title to each ownership chip", () => {
+    const targets: Target[] = [
+      makeTarget("target-managed", "managed"),
+      makeTarget("target-observed", "observed"),
+      makeTarget("target-external", "external"),
+    ];
+
+    const { container } = render(
+      <TargetsPage
+        targets={targets}
+        skills={[]}
+        selectedTarget={null}
+        onSelectTarget={() => {}}
+        onRemoveTarget={() => {}}
+        onMutation={() => {}}
+        readOnly={false}
+        mutationVersion={0}
+      />,
+    );
+
+    const chips = container.querySelectorAll<HTMLSpanElement>("span.chip");
+    const byOwnership = new Map<string, string>();
+    chips.forEach((chip) => {
+      for (const tier of ["managed", "observed", "external"] as const) {
+        if (chip.classList.contains(tier) && chip.title) {
+          byOwnership.set(tier, chip.title);
+        }
+      }
+    });
+
+    expect(byOwnership.get("managed")).toMatch(/Loom owns this directory/);
+    expect(byOwnership.get("observed")).toMatch(/only reads/);
+    expect(byOwnership.get("external")).toMatch(/hands-off/);
+  });
+});

--- a/panel/src/pages/panel/TargetsPage.tsx
+++ b/panel/src/pages/panel/TargetsPage.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useState } from "react";
-import type { Skill, Target } from "../../lib/types";
+import type { Ownership, Skill, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon } from "../../components/icons/nav_icons";
 import { TargetAddForm } from "../../components/panel/forms/TargetAddForm";
 import { api, ApiError, type TargetShowPayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
+
+const OWNERSHIP_TOOLTIP: Record<Ownership, string> = {
+  managed: "managed: Loom owns this directory and may write/overwrite files (projection writes go here).",
+  observed: "observed: Loom only reads from this directory; it never writes back. Use for agent dirs you edit yourself.",
+  external: "external: Loom stays hands-off. Listed for visibility only; no reads or writes.",
+};
 
 interface TargetsPageProps {
   targets: Target[];
@@ -88,7 +94,7 @@ export function TargetsPage({
                       {t.path}
                     </div>
                   </div>
-                  <span className={`chip ${t.ownership}`}>
+                  <span className={`chip ${t.ownership}`} title={OWNERSHIP_TOOLTIP[t.ownership]}>
                     <span className="dot" />
                     {t.ownership}
                   </span>
@@ -124,7 +130,7 @@ export function TargetsPage({
                   {sel.id}
                 </span>
               </h3>
-              <span className={`chip ${sel.ownership}`}>
+              <span className={`chip ${sel.ownership}`} title={OWNERSHIP_TOOLTIP[sel.ownership]}>
                 <span className="dot" />
                 {sel.ownership}
               </span>


### PR DESCRIPTION
## Summary

- Both ownership chips on `TargetsPage` (the card-grid chip and the detail-header chip) rendered just the tier name and a colored dot, with no on-page signal for what `managed` / `observed` / `external` actually controls.
- Define an `OWNERSHIP_TOOLTIP: Record<Ownership, string>` lookup at module scope and thread it through `title=` on both render sites. Native browser tooltip — same pattern already used elsewhere in this file (e.g. the disabled "target add" button hint at line 52).
- Add a dedicated `TargetsPage.test.tsx` regression that mounts one target per tier and asserts each chip's `title` mentions tier-specific behavior text.

Closes #85.

## Test plan

- [x] `bun run typecheck` (panel) — no errors
- [x] `bun run test` (panel) — 25 tests pass (1 new file, 1 new test)
- [x] `bun run build` (panel) — production bundle builds cleanly

## Notes

- Native `title=` tooltip; no new dependency or tooltip component introduced.
- `TargetAddForm`'s ownership selector is intentionally out of scope — separate UX surface.
- No `Cargo.toml` / `panel/package.json` version bump.