### PR TITLE
Improve agent-native CLI experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-.PHONY: fmt fmt-check test lint panel-build panel-test e2e check ci install-hooks
+.PHONY: fmt fmt-check test lint panel-build panel-test panel-typecheck e2e check ci install-hooks
 
 fmt:
 	cargo fmt --all
@@ -24,9 +24,12 @@ panel-build:
 panel-test:
 	cd panel && bun install --frozen-lockfile && bun run test
 
+panel-typecheck:
+	cd panel && bun install --frozen-lockfile && bun run typecheck
+
 e2e:
 	./scripts/e2e-agent-flow.sh
 
-check: fmt-check lint test panel-build e2e
+check: fmt-check lint test panel-typecheck panel-test panel-build e2e
 
 ci: check

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ loom monitor --interval-seconds 30
 
 Loom defaults to `~/.loom-registry`. Pass `--root <dir>` only when you want a different registry.
 
+For agent automation, keep the mutable registry separate from the Loom source checkout and always use an explicit root:
+
+```bash
+REGISTRY_ROOT="$HOME/.loom-registry"
+
+loom --json --root "$REGISTRY_ROOT" workspace init --scan-existing
+loom --json --root "$REGISTRY_ROOT" skill monitor-observed --once
+loom --json --root "$REGISTRY_ROOT" workspace status
+loom --json --root "$REGISTRY_ROOT" sync status
+```
+
+`--root` is the Git-backed skill registry directory, not the Loom tool repository.
+
 For managed projection flows:
 
 ```bash
@@ -108,7 +121,7 @@ Prefer a guided walkthrough? Run `./scripts/demo.sh` for a scripted end-to-end t
 - **🛠️ Ops with audit** — `ops list / retry / purge` and `ops history diagnose / repair`
 - **🛡️ Hard write guard** — refuses to write when `--root` points at the Loom tool repo itself
 - **🖥️ CLI + Panel** — script anything from the CLI; diff and inspect from the React Panel
-- **📤 JSON envelope** — every command speaks compact `--json` for machine consumption (`--pretty` is available for human debugging)
+- **📤 JSON envelope** — machine-facing commands speak compact `--json` for machine consumption (`--pretty` is available for human debugging)
 
 ## How It Works
 
@@ -181,6 +194,7 @@ Quick decision: **edits from the agent side → `capture`; edits inside the regi
 
 - Multi-directory behavior is explicit via `target add`; no implicit directory inference.
 - Agent automation should use explicit `--root`, `--json`, selectors such as `binding_id` / `target_id`, and branch on `ok` + `error.code`.
+- `--json` wraps both command execution errors and argument parsing failures in the same envelope. `loom panel` is the local HTTP UI server and does not return a command envelope.
 - Read commands such as `workspace status`, `workspace doctor`, `target list`, and `sync status` do not write command audit events; write commands do.
 - Registry metadata lives under `state/registry`; Loom does not use release-style labels for internal state names.
 - State-changing registry commands commit `state/registry` to Git, and `sync push` has a safety commit before pushing.
@@ -192,6 +206,8 @@ Quick decision: **edits from the agent side → `capture`; edits inside the regi
 <details>
 <summary><strong>Full CLI reference</strong> (click to expand)</summary>
 
+Supported `--agent` values are `claude`, `codex`, `cursor`, `windsurf`, `cline`, `copilot`, `aider`, `opencode`, `gemini-cli`, and `goose`.
+
 ```bash
 loom init
 loom monitor [--target <target-id>] [--once] [--interval-seconds <seconds>]
@@ -199,14 +215,14 @@ loom monitor [--target <target-id>] [--once] [--interval-seconds <seconds>]
 loom workspace status
 loom workspace doctor
 loom workspace init [--scan-existing]
-loom workspace binding add --agent <claude|codex> --profile <id> --matcher-kind <path-prefix|exact-path|name> --matcher-value <value> --target <target-id> [--policy-profile <id>]
+loom workspace binding add --agent <agent> --profile <id> --matcher-kind <path-prefix|exact-path|name> --matcher-value <value> --target <target-id> [--policy-profile <id>]
 loom workspace binding list
 loom workspace binding show <binding-id>
 loom workspace binding remove <binding-id>
 loom workspace remote set <git-url>
 loom workspace remote status
 
-loom target add --agent <claude|codex> --path <abs-path> [--ownership <managed|observed|external>]
+loom target add --agent <agent> --path <abs-path> [--ownership <managed|observed|external>]
 loom target list
 loom target show <target-id>
 loom target remove <target-id>

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -14,7 +14,7 @@
 ## 2. Agent 基本调用契约
 
 - 固定带 `--json`，只解析 JSON envelope。
-- 固定带 `--root <absolute_path>`，避免 cwd 漂移。
+- 固定带 `--root <registry_root>`，避免 cwd 漂移；这里的 root 是可变 Git-backed skill registry，不是 Loom 源码仓库。
 - 默认 `--json` 是紧凑单行输出；人类排查时可加 `--pretty`。
 - 只把 `ok=true` 视为成功。
 - `ok=false` 时根据 `error.code` 分支处理。
@@ -32,20 +32,24 @@ JSON envelope 关键字段：
 - `meta.warnings`
 - `meta.sync_state`
 
+`meta.sync_state` 是 agent 做同步决策时应优先读取的顶层状态。部分命令也会在 `data.remote.sync_state` 中返回远端细节视图；两者同时存在时，先按 `meta.sync_state` 分支，再把 `data.remote.sync_state` 作为诊断信息记录。
+
 ## 3. 首次接管（推荐流程）
 
 Agent 首次接管本机 skills 时，执行：
 
 ```bash
-loom --json --root <repo_root> workspace init --scan-existing
-loom --json --root <repo_root> skill monitor-observed --once
+REGISTRY_ROOT="$HOME/.loom-registry"
+
+loom --json --root "$REGISTRY_ROOT" workspace init --scan-existing
+loom --json --root "$REGISTRY_ROOT" skill monitor-observed --once
 ```
 
 该命令默认顺序为：
 
-1. 初始化 `<repo_root>` 为 Git-backed Loom registry。
-2. 将默认 `~/.claude/skills` 和 `~/.codex/skills` 注册为 observed targets。
-3. 扫描 observed targets，将包含 `SKILL.md` 的 skill 导入到 `<repo_root>/skills/`。
+1. 初始化 `$REGISTRY_ROOT` 为 Git-backed Loom registry。
+2. 将已存在的默认 agent skill 目录注册为 observed targets。
+3. 扫描 observed targets，将包含 `SKILL.md` 的 skill 导入到 `$REGISTRY_ROOT/skills/`。
 
 产出中必须校验：
 
@@ -56,17 +60,17 @@ loom --json --root <repo_root> skill monitor-observed --once
 
 ## 4. 日常操作建议（Agent）
 
-1. 读取状态：`loom --json --root <repo_root> workspace status`
-2. 保存变更：`loom --json --root <repo_root> skill save <skill>`
-3. 关键节点快照：`loom --json --root <repo_root> skill snapshot <skill>`
-4. 发布版本：`loom --json --root <repo_root> skill release <skill> vX.Y.Z`
-5. 差异检查：`loom --json --root <repo_root> skill diff <skill> <from> <to>`
-6. 远端同步：`loom --json --root <repo_root> sync push` / `sync pull`
+1. 读取状态：`loom --json --root <registry_root> workspace status`
+2. 保存变更：`loom --json --root <registry_root> skill save <skill>`
+3. 关键节点快照：`loom --json --root <registry_root> skill snapshot <skill>`
+4. 发布版本：`loom --json --root <registry_root> skill release <skill> vX.Y.Z`
+5. 差异检查：`loom --json --root <registry_root> skill diff <skill> <from> <to>`
+6. 远端同步：`loom --json --root <registry_root> sync push` / `sync pull`
 
 ## 5. 安全护栏
 
 - 未经明确授权，不要默认使用 `--force` 覆盖同名 skill。
-- 优先 symlink 模式；只有环境不支持时再使用 `--copy`。
+- 优先 symlink 模式；只有环境不支持时再使用 `--method copy`。
 - `meta.warnings` 不为空时，视为“成功但有风险”，需写入运行日志。
 - `sync_state=LOCAL_ONLY` 或 `PENDING_PUSH` 时，不应宣称“远端已同步”。
 - 读命令（如 `workspace status`、`workspace doctor`、`target list`）不写 command event；不要把读命令当作审计记录来源。
@@ -80,6 +84,8 @@ loom --json --root <repo_root> skill monitor-observed --once
 - `REMOTE_DIVERGED`：先 `sync pull` 再处理冲突，再 `sync push`。
 - `PUSH_REJECTED`：按分歧流程处理，不要强推覆盖。
 - `REPLAY_CONFLICT`：进入人工或高阶冲突处理流程。
+- `QUEUE_BLOCKED`：远端不可写或依赖状态未解决，记录 pending op 并等待恢复。
+- `GIT_ERROR` / `IO_ERROR`：底层 Git 或文件系统失败，保留原始 message 供排查。
 
 ## 7. 最小自动化脚本模式
 

--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -1,6 +1,6 @@
 # Loom registry model CLI Contract
 
-Updated: 2026-04-08
+Updated: 2026-05-13
 Status: Draft
 
 ## 1. Purpose
@@ -13,7 +13,7 @@ It exists to make three things explicit:
 2. what selectors must be explicit
 3. what JSON shape agents can rely on
 
-This document turns [LOOM_STATE_MODEL.md](/Users/lifcc/Desktop/code/work/infra/loom/docs/LOOM_STATE_MODEL.md) into a concrete machine-facing interface.
+This document turns [LOOM_STATE_MODEL.md](LOOM_STATE_MODEL.md) into a concrete machine-facing interface.
 
 ## 2. Contract Principles
 
@@ -69,8 +69,11 @@ Rules:
 2. `--root` is mandatory for automation and examples in this spec.
 3. `--json` defaults to compact single-line output for token efficiency.
 4. `--json --pretty` is reserved for human debugging and documentation capture.
+5. If argument parsing fails while `--json` is present, Loom returns the same envelope shape with `cmd: "cli.parse"` and `error.code: "ARG_INVALID"`.
 
 ## 5. Selector Rules
+
+Supported `agent` values are `claude`, `codex`, `cursor`, `windsurf`, `cline`, `copilot`, `aider`, `opencode`, `gemini-cli`, and `goose`.
 
 ### 5.1 `skill_id`
 
@@ -133,6 +136,7 @@ Rules:
 4. `request_id` is echoed back if supplied, otherwise generated.
 5. `meta.op_id` is required for successful writes and omitted for pure reads.
 6. Successful envelopes keep `error: null` so agents can rely on a stable field shape.
+7. `meta.sync_state`, when present, is the authoritative top-level sync status for agent decisions. Command-specific fields such as `data.remote.sync_state` are detail views for diagnostics.
 
 ## 7. Error Object
 
@@ -162,21 +166,20 @@ Base error codes:
 
 1. `ARG_INVALID`
 2. `DEPENDENCY_CONFLICT`
-3. `BINDING_NOT_FOUND`
-4. `TARGET_NOT_FOUND`
+3. `SCHEMA_MISMATCH`
+4. `STATE_CORRUPT`
 5. `SKILL_NOT_FOUND`
-6. `INSTANCE_NOT_FOUND`
-7. `OWNERSHIP_CONFLICT`
-8. `PROJECTION_CONFLICT`
-9. `CAPTURE_CONFLICT`
-10. `LOCK_BUSY`
-11. `STATE_CORRUPT`
-12. `SCHEMA_MISMATCH`
-13. `REMOTE_UNREACHABLE`
-14. `REMOTE_DIVERGED`
-15. `PUSH_REJECTED`
-16. `REPLAY_CONFLICT`
-17. `INTERNAL_ERROR`
+6. `BINDING_NOT_FOUND`
+7. `TARGET_NOT_FOUND`
+8. `LOCK_BUSY`
+9. `REMOTE_UNREACHABLE`
+10. `REMOTE_DIVERGED`
+11. `PUSH_REJECTED`
+12. `REPLAY_CONFLICT`
+13. `QUEUE_BLOCKED`
+14. `GIT_ERROR`
+15. `IO_ERROR`
+16. `INTERNAL_ERROR`
 
 Semantics:
 
@@ -230,9 +233,9 @@ Read-only unless a future explicit repair subcommand is introduced.
 
 ```bash
 loom --json --root <root> workspace binding add \
-  --agent <claude|codex> \
+  --agent <agent> \
   --profile <profile-id> \
-  --matcher-kind <path_prefix|exact_path|name> \
+  --matcher-kind <path-prefix|exact-path|name> \
   --matcher-value <value> \
   --target <target-id>
 ```
@@ -282,7 +285,7 @@ Rules:
 
 ```bash
 loom --json --root <root> target add \
-  --agent <claude|codex> \
+  --agent <agent> \
   --path <dir> \
   --ownership <managed|observed|external>
 ```
@@ -522,18 +525,42 @@ Write command.
 ### 13.1 `ops list`
 
 ```bash
-loom --json --root <root> ops list [--status <queued|running|succeeded|failed>]
+loom --json --root <root> ops list
 ```
 
 Read-only.
 
-### 13.2 `ops show`
+### 13.2 `ops retry`
 
 ```bash
-loom --json --root <root> ops show <op-id>
+loom --json --root <root> ops retry
+```
+
+Write command.
+
+### 13.3 `ops purge`
+
+```bash
+loom --json --root <root> ops purge
+```
+
+Write command.
+
+### 13.4 `ops history diagnose`
+
+```bash
+loom --json --root <root> ops history diagnose
 ```
 
 Read-only.
+
+### 13.5 `ops history repair`
+
+```bash
+loom --json --root <root> ops history repair --strategy <local|remote>
+```
+
+Write command.
 
 ## 14. Migration Policy
 

--- a/scripts/e2e-agent-flow.sh
+++ b/scripts/e2e-agent-flow.sh
@@ -33,10 +33,44 @@ json_field() {
   printf '%s' "$body" | jq -r "$expr"
 }
 
+assert_envelope() {
+  local body="$1"
+  local label="$2"
+  local expected_ok="$3"
+  local ok request_id version
+  ok="$(json_field "$body" '.ok')"
+  request_id="$(json_field "$body" '.request_id')"
+  version="$(json_field "$body" '.version')"
+  if [[ "$ok" != "$expected_ok" ]]; then
+    echo "FAILED [$label]: expected ok=$expected_ok got ok=$ok: $body" >&2
+    exit 1
+  fi
+  if [[ "$request_id" == "null" || -z "$request_id" ]]; then
+    echo "FAILED [$label]: missing request_id: $body" >&2
+    exit 1
+  fi
+  if [[ "$version" == "null" || -z "$version" ]]; then
+    echo "FAILED [$label]: missing version: $body" >&2
+    exit 1
+  fi
+  if [[ "$expected_ok" == "true" ]]; then
+    if [[ "$(json_field "$body" '.error')" != "null" ]]; then
+      echo "FAILED [$label]: successful envelope must keep error:null: $body" >&2
+      exit 1
+    fi
+  else
+    if [[ "$(json_field "$body" '.data | type')" != "object" || "$(json_field "$body" '.data | length')" != "0" ]]; then
+      echo "FAILED [$label]: failed envelope must keep empty data object: $body" >&2
+      exit 1
+    fi
+  fi
+}
+
 assert_ok() {
   local body="$1"
   local label="$2"
   local ok
+  assert_envelope "$body" "$label" "true"
   ok="$(json_field "$body" '.ok')"
   if [[ "$ok" != "true" ]]; then
     echo "FAILED [$label]: $(printf '%s' "$body" | jq -c '.error')" >&2
@@ -63,6 +97,7 @@ run_json_expect_fail() {
     echo "FAILED [expected failure]: command unexpectedly succeeded: $*" >&2
     exit 1
   fi
+  assert_envelope "$out" "expected failure $*" "false"
   code="$(json_field "$out" '.error.code')"
   if [[ "$code" != "$expected_code" ]]; then
     echo "FAILED [expected code $expected_code got $code]: $*" >&2
@@ -241,8 +276,10 @@ EOF
 
   fail_bind_json="$(run_json_expect_fail "$repo" TARGET_NOT_FOUND workspace binding add --agent codex --profile bad --matcher-kind path-prefix --matcher-value "$workspace/bad" --target missing-target-id)"
   fail_remove_json="$(run_json_expect_fail "$repo" DEPENDENCY_CONFLICT target remove "$target_id")"
+  fail_parse_json="$(run_json_expect_fail "$repo" ARG_INVALID target add --agent bad-agent --path "$target_dir")"
   [[ "$(json_field "$fail_bind_json" '.error.code')" == "TARGET_NOT_FOUND" ]]
   [[ "$(json_field "$fail_remove_json" '.error.code')" == "DEPENDENCY_CONFLICT" ]]
+  [[ "$(json_field "$fail_parse_json" '.cmd')" == "cli.parse" ]]
 
   printf 'D PASS target=%s binding=%s instance=%s\n' "$target_id" "$bind_id" "$instance_id"
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,6 +183,7 @@ pub enum OpsHistoryCommand {
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct HistoryRepairArgs {
+    /// Which side should win when repairing operation-history divergence.
     #[arg(long, value_enum)]
     pub strategy: HistoryRepairStrategyArg,
 }
@@ -223,14 +224,18 @@ pub struct ProjectArgs {
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct CaptureArgs {
+    /// Registry skill name. Optional only when --instance uniquely identifies the projection.
     pub skill: Option<String>,
 
+    /// Binding id for selecting a projection when --instance is not provided.
     #[arg(long)]
     pub binding: Option<String>,
 
+    /// Projection instance id to capture from directly.
     #[arg(long)]
     pub instance: Option<String>,
 
+    /// Git commit message for the captured source revision.
     #[arg(long)]
     pub message: Option<String>,
 }
@@ -256,49 +261,62 @@ pub struct MonitorObservedArgs {
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct SaveArgs {
+    /// Registry skill name.
     pub skill: String,
 
+    /// Git commit message for the saved source revision.
     #[arg(long)]
     pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct SkillOnlyArgs {
+    /// Registry skill name.
     pub skill: String,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct ReleaseArgs {
+    /// Registry skill name.
     pub skill: String,
+    /// Release tag or version label to create.
     pub version: String,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct RollbackArgs {
+    /// Registry skill name.
     pub skill: String,
 
+    /// Git revision or snapshot reference to restore from.
     #[arg(long)]
     pub to: Option<String>,
 
+    /// Number of source commits to roll back when --to is not provided.
     #[arg(long)]
     pub steps: Option<u32>,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct DiffArgs {
+    /// Registry skill name.
     pub skill: String,
+    /// Older revision, snapshot, or release reference.
     pub from: String,
+    /// Newer revision, snapshot, or release reference.
     pub to: String,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct ImportObservedArgs {
+    /// Restrict import to one observed target id.
     #[arg(long)]
     pub target: Option<String>,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct PanelArgs {
+    /// Local HTTP port for the registry control panel.
     #[arg(long, default_value_t = 43117)]
     pub port: u16,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     let pretty_requested = has_flag(&raw_args, "--pretty");
     let parse_request_id =
         extract_request_id(&raw_args).unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    let cli = match Cli::try_parse_from(&raw_args) {
+    let mut cli = match Cli::try_parse_from(&raw_args) {
         Ok(cli) => cli,
         Err(err) => {
             if matches!(
@@ -50,6 +50,7 @@ async fn main() {
             err.exit();
         }
     };
+    cli.request_id = cli.request_id.and_then(valid_request_id);
 
     let app = match App::new(cli.root.clone()) {
         Ok(app) => app,
@@ -126,15 +127,25 @@ fn extract_request_id(args: &[OsString]) -> Option<String> {
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         if arg == "--request-id" {
-            return iter
-                .next()
-                .map(|value| value.to_string_lossy().into_owned());
+            return iter.next().and_then(|value| {
+                let value = value.to_string_lossy().into_owned();
+                valid_request_id(value)
+            });
         }
         if let Some(raw) = arg.to_string_lossy().strip_prefix("--request-id=") {
-            return Some(raw.to_string());
+            return valid_request_id(raw.to_string());
         }
     }
     None
+}
+
+fn valid_request_id(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.starts_with('-') {
+        None
+    } else {
+        Some(value)
+    }
 }
 
 fn pretty_json_or_empty_object(value: &serde_json::Value) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,48 @@ mod state;
 mod state_model;
 mod types;
 
-use clap::Parser;
+use std::ffi::OsString;
+
+use clap::{Parser, error::ErrorKind};
+use serde_json::json;
 
 use crate::cli::{Cli, Command};
 use crate::commands::App;
 use crate::envelope::Envelope;
+use crate::types::ErrorCode;
 
 #[tokio::main]
 async fn main() {
-    let cli = Cli::parse();
+    let raw_args: Vec<OsString> = std::env::args_os().collect();
+    let json_requested = has_flag(&raw_args, "--json");
+    let pretty_requested = has_flag(&raw_args, "--pretty");
+    let parse_request_id =
+        extract_request_id(&raw_args).unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let cli = match Cli::try_parse_from(&raw_args) {
+        Ok(cli) => cli,
+        Err(err) => {
+            if matches!(
+                err.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) {
+                let _ = err.print();
+                std::process::exit(0);
+            }
+            if json_requested {
+                let code = ErrorCode::ArgInvalid;
+                let env = Envelope::err(
+                    "cli.parse",
+                    parse_request_id,
+                    code,
+                    err.to_string(),
+                    json!({ "kind": format!("{:?}", err.kind()) }),
+                );
+                print_envelope(&env, true, pretty_requested);
+                std::process::exit(code.exit_code());
+            }
+            err.exit();
+        }
+    };
 
     let app = match App::new(cli.root.clone()) {
         Ok(app) => app,
@@ -83,6 +116,25 @@ fn print_envelope(env: &Envelope, force_json: bool, pretty: bool) {
     } else {
         eprintln!("{} failed", env.cmd);
     }
+}
+
+fn has_flag(args: &[OsString], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn extract_request_id(args: &[OsString]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--request-id" {
+            return iter
+                .next()
+                .map(|value| value.to_string_lossy().into_owned());
+        }
+        if let Some(raw) = arg.to_string_lossy().strip_prefix("--request-id=") {
+            return Some(raw.to_string());
+        }
+    }
+    None
 }
 
 fn pretty_json_or_empty_object(value: &serde_json::Value) -> String {

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -154,14 +154,59 @@ fn migrate_subcommand_is_removed() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
     assert!(
-        stderr.contains("unrecognized subcommand")
-            || stderr.contains("unexpected argument")
-            || stderr.contains("found argument"),
-        "stderr did not indicate migrate removal: {}",
-        stderr
+        output.stderr.is_empty(),
+        "--json parse failures should not write text stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
+    let env: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse migrate removal json");
+    assert_eq!(env["ok"], serde_json::json!(false));
+    assert_eq!(env["cmd"], serde_json::json!("cli.parse"));
+    assert_eq!(env["error"]["code"], serde_json::json!("ARG_INVALID"));
+    assert_eq!(env["data"], serde_json::json!({}));
+}
+
+#[test]
+fn json_mode_wraps_clap_value_errors() {
+    let root = TestDir::new("cli-json-bad-agent");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--json")
+        .arg("--request-id")
+        .arg("req-bad-agent")
+        .arg("--root")
+        .arg(root.path())
+        .args([
+            "target",
+            "add",
+            "--agent",
+            "bad-agent",
+            "--path",
+            "/tmp/skills",
+        ])
+        .output()
+        .expect("run loom");
+
+    assert!(
+        !output.status.success(),
+        "invalid agent unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "--json value errors should not write text stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let env: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse invalid agent json");
+    assert_eq!(env["ok"], serde_json::json!(false));
+    assert_eq!(env["cmd"], serde_json::json!("cli.parse"));
+    assert_eq!(env["request_id"], serde_json::json!("req-bad-agent"));
+    assert_eq!(env["error"]["code"], serde_json::json!("ARG_INVALID"));
+    assert_eq!(env["data"], serde_json::json!({}));
 }
 
 #[test]
@@ -307,5 +352,47 @@ fn top_level_monitor_command_is_available() {
             stdout.contains(expected),
             "monitor help missing {expected:?}: {stdout}"
         );
+    }
+}
+
+#[test]
+fn risky_command_help_describes_selectors_and_repair_strategy() {
+    for (args, expected) in [
+        (
+            vec!["skill", "capture", "--help"],
+            vec![
+                "Registry skill name",
+                "Binding id",
+                "Projection instance id",
+                "Git commit message",
+            ],
+        ),
+        (
+            vec!["skill", "rollback", "--help"],
+            vec![
+                "Git revision or snapshot reference",
+                "Number of source commits",
+            ],
+        ),
+        (
+            vec!["ops", "history", "repair", "--help"],
+            vec!["Which side should win"],
+        ),
+        (vec!["panel", "--help"], vec!["Local HTTP port"]),
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+            .args(args)
+            .output()
+            .expect("run loom help");
+        assert!(
+            output.status.success(),
+            "help failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for phrase in expected {
+            assert!(stdout.contains(phrase), "help missing {phrase:?}: {stdout}");
+        }
     }
 }

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -210,6 +210,76 @@ fn json_mode_wraps_clap_value_errors() {
 }
 
 #[test]
+fn json_parse_error_ignores_missing_request_id_value() {
+    let root = TestDir::new("cli-json-missing-request-id");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--json")
+        .arg("--request-id")
+        .arg("--root")
+        .arg(root.path())
+        .args(["workspace", "status"])
+        .output()
+        .expect("run loom");
+
+    assert!(
+        !output.status.success(),
+        "missing request id unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "--json parse failures should not write text stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let env: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse missing request id json");
+    assert_eq!(env["ok"], serde_json::json!(false));
+    assert_eq!(env["cmd"], serde_json::json!("cli.parse"));
+    assert_ne!(env["request_id"], serde_json::json!("--root"));
+    assert!(
+        env["request_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()),
+        "parse failure must fall back to a generated request_id: {env}"
+    );
+    assert_eq!(env["error"]["code"], serde_json::json!("ARG_INVALID"));
+}
+
+#[test]
+fn json_mode_ignores_empty_request_id_value() {
+    let root = TestDir::new("cli-json-empty-request-id");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .arg("--json")
+        .arg("--request-id=")
+        .arg("--root")
+        .arg(root.path())
+        .args(["workspace", "status"])
+        .output()
+        .expect("run loom status");
+
+    assert!(
+        output.status.success(),
+        "status unexpectedly failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let env: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse empty request id json");
+    assert_eq!(env["ok"], serde_json::json!(true));
+    assert!(
+        env["request_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()),
+        "empty request id must fall back to a generated request_id: {env}"
+    );
+}
+
+#[test]
 fn skill_orphan_clean_nested_command_is_available() {
     let output = Command::new(env!("CARGO_BIN_EXE_loom"))
         .args(["skill", "orphan", "clean", "--help"])


### PR DESCRIPTION
## Summary

- wrap `--json` argument parsing failures in the stable envelope as `cmd: "cli.parse"` with `ARG_INVALID`
- improve help text for risky/ambiguous commands like `skill capture`, `skill rollback`, `ops history repair`, and `panel --port`
- strengthen agent E2E envelope assertions and cover invalid CLI parse failures
- align README and agent docs with the current registry-root, agent enum, error-code, sync-state, and ops command surface
- add `panel-typecheck` to `make check` so local repo-level verification covers the panel type contract

## Tests

- `cargo test -q --test cli_surface`
- `cargo test -q`
- `make check`

Refs #91
