### PR TITLE
fix(registry): roll back state on operation log failure

### DIFF
--- a/src/commands/target_cmds.rs
+++ b/src/commands/target_cmds.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use anyhow::Context;
 use chrono::Utc;
 use serde_json::json;
 
@@ -93,6 +94,7 @@ impl App {
 
         let paths = self.ensure_registry_layout()?;
         let mut targets = paths.load_targets().map_err(map_registry_state)?;
+        let original_targets = targets.clone();
 
         if let Some(existing) = targets
             .targets
@@ -130,7 +132,7 @@ impl App {
             .sort_by(|left, right| left.target_id.cmp(&right.target_id));
         paths.save_targets(&targets).map_err(map_registry_state)?;
 
-        let op_id = record_registry_operation(
+        let op_id = match record_registry_operation(
             &paths,
             "target.add",
             json!({
@@ -143,8 +145,21 @@ impl App {
             json!({
                 "target_id": target.target_id
             }),
-        )
-        .map_err(map_registry_state)?;
+        ) {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                paths
+                    .save_targets(&original_targets)
+                    .with_context(|| {
+                        format!(
+                            "failed to rollback targets after operation-log failure: {}",
+                            err
+                        )
+                    })
+                    .map_err(map_registry_state)?;
+                return Err(map_registry_state(err));
+            }
+        };
         let commit = commit_registry_state(&self.ctx, &format!("target({}): add", target_id))?;
         let mut meta = Meta {
             op_id: Some(op_id),
@@ -175,6 +190,7 @@ impl App {
         self.ensure_write_repo_ready()?;
         let paths = self.ensure_registry_layout()?;
         let mut snapshot = paths.load_snapshot().map_err(map_registry_state)?;
+        let original_targets = snapshot.targets.clone();
         let target = snapshot.target(&args.target_id).cloned().ok_or_else(|| {
             CommandFailure::new(
                 ErrorCode::TargetNotFound,
@@ -215,7 +231,7 @@ impl App {
             .save_targets(&snapshot.targets)
             .map_err(map_registry_state)?;
 
-        let op_id = record_registry_operation(
+        let op_id = match record_registry_operation(
             &paths,
             "target.remove",
             json!({
@@ -225,8 +241,21 @@ impl App {
             json!({
                 "target_id": target.target_id
             }),
-        )
-        .map_err(map_registry_state)?;
+        ) {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                paths
+                    .save_targets(&original_targets)
+                    .with_context(|| {
+                        format!(
+                            "failed to rollback targets after operation-log failure: {}",
+                            err
+                        )
+                    })
+                    .map_err(map_registry_state)?;
+                return Err(map_registry_state(err));
+            }
+        };
         let commit =
             commit_registry_state(&self.ctx, &format!("target({}): remove", args.target_id))?;
         let mut meta = Meta {

--- a/src/commands/workspace_cmds.rs
+++ b/src/commands/workspace_cmds.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use chrono::Utc;
 use serde_json::json;
 
@@ -394,6 +395,7 @@ impl App {
 
         let paths = self.ensure_registry_layout()?;
         let snapshot = paths.load_snapshot().map_err(map_registry_state)?;
+        let original_bindings = snapshot.bindings.clone();
         if snapshot.target(&args.target).is_none() {
             return Err(CommandFailure::new(
                 ErrorCode::TargetNotFound,
@@ -441,7 +443,7 @@ impl App {
             .sort_by(|left, right| left.binding_id.cmp(&right.binding_id));
         paths.save_bindings(&bindings).map_err(map_registry_state)?;
 
-        let op_id = record_registry_operation(
+        let op_id = match record_registry_operation(
             &paths,
             "workspace.binding.add",
             json!({
@@ -456,8 +458,21 @@ impl App {
             json!({
                 "binding_id": binding.binding_id
             }),
-        )
-        .map_err(map_registry_state)?;
+        ) {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                paths
+                    .save_bindings(&original_bindings)
+                    .with_context(|| {
+                        format!(
+                            "failed to rollback bindings after operation-log failure: {}",
+                            err
+                        )
+                    })
+                    .map_err(map_registry_state)?;
+                return Err(map_registry_state(err));
+            }
+        };
         let commit = commit_registry_state(&self.ctx, &format!("binding({}): add", binding_id))?;
         let mut meta = Meta {
             op_id: Some(op_id),
@@ -488,6 +503,9 @@ impl App {
         self.ensure_write_repo_ready()?;
         let paths = self.ensure_registry_layout()?;
         let mut snapshot = paths.load_snapshot().map_err(map_registry_state)?;
+        let original_bindings = snapshot.bindings.clone();
+        let original_rules = snapshot.rules.clone();
+        let original_projections = snapshot.projections.clone();
         let binding = snapshot.binding(&args.binding_id).cloned().ok_or_else(|| {
             CommandFailure::new(
                 ErrorCode::BindingNotFound,
@@ -528,7 +546,7 @@ impl App {
             )
             .map_err(map_registry_state)?;
 
-        let op_id = record_registry_operation(
+        let op_id = match record_registry_operation(
             &paths,
             "workspace.binding.remove",
             json!({
@@ -540,8 +558,25 @@ impl App {
                 "removed_rules": removed_rules.iter().map(|rule| rule.skill_id.clone()).collect::<Vec<_>>(),
                 "orphaned_projection_ids": orphaned_projection_ids,
             }),
-        )
-        .map_err(map_registry_state)?;
+        ) {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                paths
+                    .save_bindings_rules_projections(
+                        &original_bindings,
+                        &original_rules,
+                        &original_projections,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "failed to rollback bindings after operation-log failure: {}",
+                            err
+                        )
+                    })
+                    .map_err(map_registry_state)?;
+                return Err(map_registry_state(err));
+            }
+        };
 
         let mut meta = Meta {
             op_id: Some(op_id),
@@ -589,6 +624,7 @@ impl App {
         self.ensure_write_layout()?;
         let paths = self.ensure_registry_layout()?;
         let mut snapshot = paths.load_snapshot().map_err(map_registry_state)?;
+        let original_projections = snapshot.projections.clone();
         let target_paths = snapshot
             .targets
             .targets
@@ -632,7 +668,7 @@ impl App {
             .save_projections(&snapshot.projections)
             .map_err(map_registry_state)?;
 
-        let op_id = record_registry_operation(
+        let op_id = match record_registry_operation(
             &paths,
             "skill.orphan.clean",
             json!({ "request_id": request_id }),
@@ -643,8 +679,21 @@ impl App {
                 "skipped_paths": skipped_paths,
                 "delete_live_paths": args.delete_live_paths,
             }),
-        )
-        .map_err(map_registry_state)?;
+        ) {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                paths
+                    .save_projections(&original_projections)
+                    .with_context(|| {
+                        format!(
+                            "failed to rollback projections after operation-log failure: {}",
+                            err
+                        )
+                    })
+                    .map_err(map_registry_state)?;
+                return Err(map_registry_state(err));
+            }
+        };
 
         Ok((
             json!({

--- a/src/state_model/json_io.rs
+++ b/src/state_model/json_io.rs
@@ -10,7 +10,7 @@ use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -19,6 +19,7 @@ where
     T: Serialize,
 {
     if path.exists() {
+        ensure_existing_file(path)?;
         return Ok(());
     }
     write_json_file(path, value)
@@ -26,9 +27,20 @@ where
 
 pub(super) fn ensure_text_file(path: &Path, contents: &str) -> Result<()> {
     if path.exists() {
+        ensure_existing_file(path)?;
         return Ok(());
     }
     write_atomic(path, contents)
+}
+
+fn ensure_existing_file(path: &Path) -> Result<()> {
+    if path.is_file() {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "registry path exists but is not a file: {}",
+        path.display()
+    ))
 }
 
 pub(super) fn write_json_file<T>(path: &Path, value: &T) -> Result<()>

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use common::actions::{binding_add, target_add};
 use serde_json::Value;
 
-use common::{TestDir, run_loom, write_minimal_registry_state};
+use common::{TestDir, run_loom, run_loom_with_env, write_minimal_registry_state};
 
 fn git_ok(root: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
@@ -40,6 +40,20 @@ fn git_status(root: &Path, args: &[&str]) -> bool {
         .success()
 }
 
+fn registry_array_len(root: &Path, file_name: &str, key: &str) -> usize {
+    let path = root.join("state/registry").join(file_name);
+    if !path.exists() {
+        return 0;
+    }
+    let raw = fs::read_to_string(&path).expect("read registry json");
+    let value: Value = serde_json::from_str(&raw).expect("parse registry json");
+    value[key].as_array().map(Vec::len).unwrap_or(0)
+}
+
+fn operations_log(root: &Path) -> String {
+    fs::read_to_string(root.join("state/registry/ops/operations.jsonl")).unwrap_or_default()
+}
+
 #[test]
 fn target_add_bootstraps_registry_state_and_records_op() {
     let root = TestDir::new("registry-target-add");
@@ -70,6 +84,68 @@ fn target_add_bootstraps_registry_state_and_records_op() {
 }
 
 #[test]
+fn target_add_rejects_directory_operations_log_before_mutating_targets() {
+    let root = TestDir::new("registry-target-add-directory-oplog");
+    fs::create_dir_all(root.path().join("state/registry/ops/operations.jsonl"))
+        .expect("create directory at operations log path");
+    let target_path = root.path().join("live/claude-project-a");
+
+    let (output, env) = target_add(root.path(), "claude", &target_path, "managed");
+
+    assert!(
+        !output.status.success(),
+        "target add unexpectedly succeeded with directory operations log"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        env["error"]["code"],
+        Value::String("STATE_CORRUPT".to_string())
+    );
+    assert_eq!(
+        registry_array_len(root.path(), "targets.json", "targets"),
+        0,
+        "failed command must not leave the target in registry state"
+    );
+}
+
+#[test]
+fn target_add_rolls_back_targets_after_operation_log_failure() {
+    let root = TestDir::new("registry-target-add-oplog-rollback");
+    let target_path = root.path().join("live/claude-project-a");
+    let target_path_arg = target_path.to_string_lossy().into_owned();
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "record_v3_operation_after_append")],
+        &[
+            "target",
+            "add",
+            "--agent",
+            "claude",
+            "--path",
+            &target_path_arg,
+            "--ownership",
+            "managed",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "target add unexpectedly succeeded with injected operation-log failure"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        registry_array_len(root.path(), "targets.json", "targets"),
+        0,
+        "target state must roll back when the operation record cannot be persisted"
+    );
+    assert!(
+        operations_log(root.path()).is_empty(),
+        "operation log append must also be rolled back"
+    );
+}
+
+#[test]
 fn target_add_is_idempotent_for_same_agent_and_path() {
     let root = TestDir::new("registry-target-add-idempotent");
     let target_path = root.path().join("live/codex-workbench");
@@ -83,6 +159,51 @@ fn target_add_is_idempotent_for_same_agent_and_path() {
     let (list_output, list_env) = run_loom(root.path(), &["target", "list"]);
     assert!(list_output.status.success(), "target list should succeed");
     assert_eq!(list_env["data"]["count"], Value::from(1));
+}
+
+#[test]
+fn workspace_binding_add_rolls_back_bindings_after_operation_log_failure() {
+    let root = TestDir::new("registry-binding-add-oplog-rollback");
+    let target_path = root.path().join("live/claude-project-a");
+    let (target_output, _) = target_add(root.path(), "claude", &target_path, "managed");
+    assert!(target_output.status.success(), "target add should succeed");
+    let operations_before = operations_log(root.path());
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "record_v3_operation_after_append")],
+        &[
+            "workspace",
+            "binding",
+            "add",
+            "--agent",
+            "claude",
+            "--profile",
+            "default",
+            "--matcher-kind",
+            "path-prefix",
+            "--matcher-value",
+            "/tmp/project-a",
+            "--target",
+            "target_claude_claude_project_a",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "binding add unexpectedly succeeded with injected operation-log failure"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        registry_array_len(root.path(), "bindings.json", "bindings"),
+        0,
+        "binding state must roll back when the operation record cannot be persisted"
+    );
+    assert_eq!(
+        operations_log(root.path()),
+        operations_before,
+        "operation log should be restored to the pre-command contents"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reject registry JSON/JSONL paths that already exist as directories during layout initialization
- restore target, binding, and orphan projection state if operation-log persistence fails after the state file was saved
- add regressions for the #89 target.add directory-oplog reproduction and operation-log rollback paths for target.add and binding.add

Fixes #89

## Verification

- cargo test -q --test write operation
- cargo test -q --test write
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- manual repro: directory at state/registry/ops/operations.jsonl now returns STATE_CORRUPT with targets length 0
