### PR TITLE
Fix panel matcher kind round-trip

### DIFF
--- a/panel/src/components/panel/forms/BindingAddForm.tsx
+++ b/panel/src/components/panel/forms/BindingAddForm.tsx
@@ -3,8 +3,8 @@ import { AGENT_OPTIONS } from "../../../lib/agent_options";
 import type { Target } from "../../../lib/types";
 import { api } from "../../../lib/api/client";
 
-type MatcherKind = "path-prefix" | "exact-path" | "name";
-const MATCHERS: MatcherKind[] = ["path-prefix", "exact-path", "name"];
+type MatcherKind = "path_prefix" | "exact_path" | "name";
+const MATCHERS: MatcherKind[] = ["path_prefix", "exact_path", "name"];
 
 interface BindingAddFormProps {
   targets: Target[];
@@ -20,7 +20,7 @@ interface BindingAddFormProps {
 export function BindingAddForm({ targets, onCancel, onSuccess }: BindingAddFormProps) {
   const [agent, setAgent] = useState<string>(AGENT_OPTIONS[0].slug);
   const [profile, setProfile] = useState("home");
-  const [matcherKind, setMatcherKind] = useState<MatcherKind>("path-prefix");
+  const [matcherKind, setMatcherKind] = useState<MatcherKind>("path_prefix");
   const [matcherValue, setMatcherValue] = useState("");
   const [targetId, setTargetId] = useState(targets[0]?.id ?? "");
   const [busy, setBusy] = useState(false);

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -245,7 +245,7 @@ export interface TargetAddBody {
 export interface BindingAddBody {
   agent: string;
   profile: string;
-  matcher_kind: "path-prefix" | "exact-path" | "name";
+  matcher_kind: "path_prefix" | "exact_path" | "name";
   matcher_value: string;
   target: string;
   policy_profile?: string;

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -8,6 +8,7 @@ import { HistoryPage, bucket } from "./HistoryPage";
 import { TargetsPage } from "./TargetsPage";
 import { SettingsPage } from "./SettingsPage";
 import { OverviewPage } from "./OverviewPage";
+import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
 import { api, type BindingShowPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
 import type { Binding, Skill, Target } from "../../lib/types";
 
@@ -95,7 +96,7 @@ function makeBinding(): Binding {
     id: "binding-1",
     skill: "skill.writer",
     target: "target-1",
-    matcher: "path-prefix:/repo",
+    matcher: "path_prefix:/repo",
     method: "symlink",
     policy: "auto",
   };
@@ -122,7 +123,7 @@ function bindingPayload(projectionCount: number): BindingShowPayload {
         binding_id: "binding-1",
         agent: "claude",
         profile_id: "home",
-        workspace_matcher: { kind: "path-prefix", value: "/repo" },
+        workspace_matcher: { kind: "path_prefix", value: "/repo" },
         default_target_id: "target-1",
         policy_profile: "auto",
         active: true,
@@ -254,6 +255,53 @@ test("OverviewPage disables add binding until a target exists", async () => {
   const addBinding = buttonByLabel(renderer!, "Add binding");
   expect(addBinding.props.disabled).toBe(true);
   expect(addBinding.props.title).toBe("add a target first");
+});
+
+test("BindingAddForm submits the canonical matcher kind", async () => {
+  const originalBindingAdd = api.bindingAdd;
+  const submissions: Array<Parameters<typeof api.bindingAdd>[0]> = [];
+  let successCount = 0;
+
+  api.bindingAdd = async (body) => {
+    submissions.push(body);
+    return { ok: true, cmd: "binding.add", request_id: "req-1" };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <BindingAddForm
+          targets={[makeTarget()]}
+          onCancel={() => {}}
+          onSuccess={() => {
+            successCount += 1;
+          }}
+        />,
+      );
+    });
+
+    const matcherValue = renderer!.root
+      .findAll((node: ReactTestInstance) => node.type === "input")
+      .find((node) => node.props.placeholder === "/Users/me/work");
+    if (!matcherValue) throw new Error("matcher value input not found");
+
+    await act(async () => {
+      matcherValue.props.onChange({ target: { value: "/repo" } });
+    });
+
+    await act(async () => {
+      renderer!.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+      await Promise.resolve();
+    });
+
+    expect(submissions[0]?.matcher_kind).toBe("path_prefix");
+    expect(submissions[0]?.matcher_value).toBe("/repo");
+    expect(submissions[0]?.target).toBe("target-1");
+    expect(successCount).toBe(1);
+  } finally {
+    api.bindingAdd = originalBindingAdd;
+  }
 });
 
 test("BindingsPage refetches selected binding details after a successful project", async () => {
@@ -521,7 +569,7 @@ test("BindingsPage keeps a newer selection when a previous binding delete comple
               id: "binding-2",
               skill: "skill.reader",
               target: "target-1",
-              matcher: "path-prefix:/other",
+              matcher: "path_prefix:/other",
               method: "copy",
               policy: "manual",
             },


### PR DESCRIPTION
## Summary
- use backend-canonical snake_case matcher kinds in the panel binding form
- update the panel API type to match the canonical wire shape
- add a regression test that submits the binding form and asserts matcher_kind remains path_prefix

Closes #74

## Verification
- npm ci && npm run typecheck && npm run test (Node v22.13.0)
- cargo fmt -- --check
- cargo check -q
- cargo test -q