### PR TITLE
Fix registry audit history for skill lifecycle events

### DIFF
--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -209,7 +209,7 @@ function summarizePolicy(skillBindings: Binding[]): string {
 type DetailTab = "history" | "diff" | "targets";
 
 interface LifecycleEvent {
-  kind: "release" | "capture" | "save" | "snapshot" | "project";
+  kind: "release" | "capture" | "save" | "snapshot" | "project" | "rollback";
   v: string;
   time: string;
   who: string;
@@ -222,11 +222,14 @@ const KIND_COLOR: Record<LifecycleEvent["kind"], string> = {
   save: "var(--ink-2)",
   snapshot: "var(--warn)",
   project: "var(--ok)",
+  rollback: "var(--err)",
 };
 
 const KIND_MAP: Record<string, LifecycleEvent["kind"]> = {
   captured: "capture",
   projected: "project",
+  rollback: "rollback",
+  monitor: "save",
   snapshot: "snapshot",
   released: "release",
   saved: "save",

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -21,13 +21,14 @@ pub(crate) use super::file_ops::{
     backup_path_if_exists, copy_dir_recursive_without_symlinks, read_git_field,
     restore_path_from_backup, rollback_added_skill,
 };
-pub use super::projections::{collect_skill_inventory, remote_status_payload};
 pub(crate) use super::projections::{
-    maybe_autosync_or_queue, project_skill_to_target, record_registry_observation,
-    record_registry_operation, remote_status_payload_with_pending, resolve_capture_projection,
+    RegistryAuditStateBackup, maybe_autosync_or_queue, project_skill_to_target,
+    record_registry_observation, record_registry_operation, remote_status_payload_with_pending,
+    resolve_capture_projection, restore_registry_audit_state, snapshot_registry_audit_state,
     sync_push_internal, sync_replay_internal, update_projection_after_capture, upsert_projection,
     upsert_rule,
 };
+pub use super::projections::{collect_skill_inventory, remote_status_payload};
 
 // ---------------------------------------------------------------------------
 // Git bootstrap

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -23,9 +23,10 @@ pub(crate) use super::file_ops::{
 };
 pub use super::projections::{collect_skill_inventory, remote_status_payload};
 pub(crate) use super::projections::{
-    maybe_autosync_or_queue, project_skill_to_target, record_registry_operation,
-    remote_status_payload_with_pending, resolve_capture_projection, sync_push_internal,
-    sync_replay_internal, update_projection_after_capture, upsert_projection, upsert_rule,
+    maybe_autosync_or_queue, project_skill_to_target, record_registry_observation,
+    record_registry_operation, remote_status_payload_with_pending, resolve_capture_projection,
+    sync_push_internal, sync_replay_internal, update_projection_after_capture, upsert_projection,
+    upsert_rule,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -12,8 +12,9 @@ use crate::envelope::Meta;
 use crate::gitops;
 use crate::state::{AppContext, PendingOpsReport, resolve_agent_skill_source_dirs};
 use crate::state_model::{
-    RegistryBindingRule, RegistryOperationRecord, RegistryProjectionInstance,
-    RegistryProjectionsFile, RegistryRulesFile, RegistrySnapshot, RegistryStatePaths,
+    RegistryBindingRule, RegistryObservationEvent, RegistryOperationRecord,
+    RegistryProjectionInstance, RegistryProjectionsFile, RegistryRulesFile, RegistrySnapshot,
+    RegistryStatePaths,
 };
 use crate::types::{ErrorCode, SyncState};
 
@@ -278,6 +279,28 @@ pub(crate) fn record_registry_operation(
     }
 
     Ok(op_id)
+}
+
+pub(crate) fn record_registry_observation(
+    paths: &RegistryStatePaths,
+    instance_id: &str,
+    kind: &str,
+    path: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+) -> Result<String> {
+    let event_id = Uuid::new_v4().to_string();
+    let event = RegistryObservationEvent {
+        event_id: event_id.clone(),
+        instance_id: instance_id.to_string(),
+        kind: kind.to_string(),
+        path,
+        from,
+        to,
+        observed_at: Utc::now(),
+    };
+    paths.append_observation(&event)?;
+    Ok(event_id)
 }
 
 fn maybe_projection_fault(tag: &str) -> Result<()> {

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -303,6 +303,103 @@ pub(crate) fn record_registry_observation(
     Ok(event_id)
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct RegistryAuditStateBackup {
+    operations: Vec<u8>,
+    checkpoint: Vec<u8>,
+    observations: Vec<(String, Vec<u8>)>,
+}
+
+pub(crate) fn snapshot_registry_audit_state(
+    paths: &RegistryStatePaths,
+) -> Result<RegistryAuditStateBackup> {
+    let mut observations = Vec::new();
+    if paths.observations_dir.exists() {
+        for entry in fs::read_dir(&paths.observations_dir).with_context(|| {
+            format!(
+                "failed to read observations dir {}",
+                paths.observations_dir.display()
+            )
+        })? {
+            let entry = entry.with_context(|| {
+                format!(
+                    "failed to read observations entry under {}",
+                    paths.observations_dir.display()
+                )
+            })?;
+            let file_type = entry.file_type().with_context(|| {
+                format!(
+                    "failed to inspect observation entry {}",
+                    entry.path().display()
+                )
+            })?;
+            if !file_type.is_file() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let contents = fs::read(entry.path()).with_context(|| {
+                format!("failed to snapshot observation {}", entry.path().display())
+            })?;
+            observations.push((name, contents));
+        }
+    }
+
+    Ok(RegistryAuditStateBackup {
+        operations: fs::read(&paths.operations_file)
+            .with_context(|| format!("failed to snapshot {}", paths.operations_file.display()))?,
+        checkpoint: fs::read(&paths.checkpoint_file)
+            .with_context(|| format!("failed to snapshot {}", paths.checkpoint_file.display()))?,
+        observations,
+    })
+}
+
+pub(crate) fn restore_registry_audit_state(
+    paths: &RegistryStatePaths,
+    backup: &RegistryAuditStateBackup,
+) -> Result<()> {
+    fs::write(&paths.operations_file, &backup.operations)
+        .with_context(|| format!("failed to restore {}", paths.operations_file.display()))?;
+    fs::write(&paths.checkpoint_file, &backup.checkpoint)
+        .with_context(|| format!("failed to restore {}", paths.checkpoint_file.display()))?;
+
+    fs::create_dir_all(&paths.observations_dir).with_context(|| {
+        format!(
+            "failed to create observations dir {}",
+            paths.observations_dir.display()
+        )
+    })?;
+    for entry in fs::read_dir(&paths.observations_dir).with_context(|| {
+        format!(
+            "failed to read observations dir {}",
+            paths.observations_dir.display()
+        )
+    })? {
+        let entry = entry.with_context(|| {
+            format!(
+                "failed to read observations entry under {}",
+                paths.observations_dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to inspect observation entry {}", path.display()))?;
+        if file_type.is_dir() {
+            fs::remove_dir_all(&path)
+                .with_context(|| format!("failed to remove observation dir {}", path.display()))?;
+        } else {
+            fs::remove_file(&path)
+                .with_context(|| format!("failed to remove observation file {}", path.display()))?;
+        }
+    }
+    for (name, contents) in &backup.observations {
+        let path = paths.observations_dir.join(name);
+        fs::write(&path, contents)
+            .with_context(|| format!("failed to restore observation {}", path.display()))?;
+    }
+    Ok(())
+}
+
 fn maybe_projection_fault(tag: &str) -> Result<()> {
     if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
         return Err(anyhow::anyhow!("fault injected at {}", tag));

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -28,9 +28,10 @@ use super::helpers::{
     backup_path_if_exists, commit_registry_state, copy_dir_recursive_without_symlinks,
     ensure_skill_exists, map_arg, map_git, map_io, map_lock, map_project_io, map_registry_state,
     maybe_autosync_or_queue, project_skill_to_target, projection_instance_id,
-    projection_method_as_str, record_registry_operation, resolve_capture_projection,
-    restore_path_from_backup, rollback_added_skill, update_projection_after_capture,
-    upsert_projection, upsert_rule, validate_projection_method, validate_skill_name,
+    projection_method_as_str, record_registry_observation, record_registry_operation,
+    resolve_capture_projection, restore_path_from_backup, rollback_added_skill,
+    update_projection_after_capture, upsert_projection, upsert_rule, validate_projection_method,
+    validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -296,6 +297,15 @@ impl App {
                     }),
                 )
                 .map_err(map_registry_state)?;
+                record_registry_observation(
+                    &paths,
+                    &instance_id,
+                    "projected",
+                    Some(projection.materialized_path.clone()),
+                    None,
+                    Some(projection.last_applied_rev.clone()),
+                )
+                .map_err(map_registry_state)?;
                 let commit = commit_registry_state(
                     &self.ctx,
                     &format!("project({}): record projection", args.skill),
@@ -476,6 +486,15 @@ impl App {
                     "instance_id": projection.instance_id,
                     "commit": commit
                 }),
+            )
+            .map_err(map_registry_state)?;
+            record_registry_observation(
+                &paths,
+                &projection.instance_id,
+                "captured",
+                Some(live_path.display().to_string()),
+                Some(projection.last_applied_rev.clone()),
+                Some(current_rev),
             )
             .map_err(map_registry_state)?;
             Ok((commit, op_id, changed))
@@ -1231,6 +1250,13 @@ impl App {
                     }),
                 )
                 .map_err(map_registry_state)?;
+                record_observed_skill_events(
+                    &paths,
+                    &snapshot.projections.projections,
+                    imported.iter().chain(updated.iter()),
+                    &commit,
+                )
+                .map_err(map_registry_state)?;
                 let state_commit =
                     commit_registry_state(&self.ctx, "monitor-observed: record registry state")?;
                 let mut meta = Meta {
@@ -1432,6 +1458,34 @@ fn merge_monitor_meta(meta: &mut Meta, cycle_meta: Meta) {
         meta.sync_state = cycle_meta.sync_state;
     }
     meta.warnings.extend(cycle_meta.warnings);
+}
+
+fn record_observed_skill_events<'a>(
+    paths: &RegistryStatePaths,
+    projections: &[RegistryProjectionInstance],
+    changes: impl Iterator<Item = &'a serde_json::Value>,
+    commit: &str,
+) -> anyhow::Result<()> {
+    for item in changes {
+        let Some(skill_id) = item["skill"].as_str() else {
+            continue;
+        };
+        let path = item["source"]
+            .as_str()
+            .or_else(|| item["path"].as_str())
+            .map(str::to_string);
+        for projection in projections.iter().filter(|p| p.skill_id == skill_id) {
+            record_registry_observation(
+                paths,
+                &projection.instance_id,
+                "monitor",
+                path.clone(),
+                None,
+                Some(commit.to_string()),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn observed_import_targets(

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -25,11 +25,12 @@ use crate::types::ErrorCode;
 
 use super::fs_probe::probe_symlink;
 use super::helpers::{
-    backup_path_if_exists, commit_registry_state, copy_dir_recursive_without_symlinks,
-    ensure_skill_exists, map_arg, map_git, map_io, map_lock, map_project_io, map_registry_state,
-    maybe_autosync_or_queue, project_skill_to_target, projection_instance_id,
-    projection_method_as_str, record_registry_observation, record_registry_operation,
-    resolve_capture_projection, restore_path_from_backup, rollback_added_skill,
+    RegistryAuditStateBackup, backup_path_if_exists, commit_registry_state,
+    copy_dir_recursive_without_symlinks, ensure_skill_exists, map_arg, map_git, map_io, map_lock,
+    map_project_io, map_registry_state, maybe_autosync_or_queue, project_skill_to_target,
+    projection_instance_id, projection_method_as_str, record_registry_observation,
+    record_registry_operation, resolve_capture_projection, restore_path_from_backup,
+    restore_registry_audit_state, rollback_added_skill, snapshot_registry_audit_state,
     update_projection_after_capture, upsert_projection, upsert_rule, validate_projection_method,
     validate_skill_name,
 };
@@ -275,6 +276,8 @@ impl App {
         };
         upsert_projection(&mut projections, projection.clone());
 
+        let registry_audit_backup =
+            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
         let post_materialize: std::result::Result<(Option<String>, Meta), CommandFailure> =
             (|| {
                 maybe_skill_fault("skill_project_after_materialize")?;
@@ -306,6 +309,7 @@ impl App {
                     Some(projection.last_applied_rev.clone()),
                 )
                 .map_err(map_registry_state)?;
+                maybe_skill_fault("skill_project_after_observation")?;
                 let commit = commit_registry_state(
                     &self.ctx,
                     &format!("project({}): record projection", args.skill),
@@ -334,6 +338,7 @@ impl App {
         let (commit, meta) = match post_materialize {
             Ok(result) => result,
             Err(err) => {
+                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
                 rollback_project_mutation(
                     &paths,
                     &materialized_path,
@@ -441,6 +446,8 @@ impl App {
         }
 
         let mut commit_created = false;
+        let registry_audit_backup =
+            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
         let post_replace = (|| {
             maybe_skill_fault("skill_capture_after_source_replace")?;
             gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
@@ -497,12 +504,14 @@ impl App {
                 Some(current_rev),
             )
             .map_err(map_registry_state)?;
+            maybe_skill_fault("skill_capture_after_observation")?;
             Ok((commit, op_id, changed))
         })();
 
         let (commit, op_id, changed) = match post_replace {
             Ok(result) => result,
             Err(err) => {
+                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
                 rollback_capture_mutation(
                     &self.ctx,
                     &skill_path,
@@ -556,6 +565,7 @@ impl App {
         let (state_commit, meta) = match post_state_commit {
             Ok(result) => result,
             Err(err) => {
+                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
                 rollback_capture_mutation(
                     &self.ctx,
                     &skill_path,
@@ -819,8 +829,7 @@ impl App {
 
         let mut meta = Meta::default();
         let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
-        let registry_backup =
-            snapshot_registry_operation_state(&paths).map_err(map_registry_state)?;
+        let registry_backup = snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
         let mut changed = false;
         for skill_rel in &imported_rels {
             match gitops::has_staged_changes_for_path(&self.ctx, Path::new(skill_rel)) {
@@ -1211,8 +1220,7 @@ impl App {
 
         let mut meta = Meta::default();
         let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
-        let registry_backup =
-            snapshot_registry_operation_state(&paths).map_err(map_registry_state)?;
+        let registry_backup = snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
         let commit = if has_changes {
             let change_count = imported.len() + updated.len();
             let message = if change_count == 1 {
@@ -1257,6 +1265,7 @@ impl App {
                     &commit,
                 )
                 .map_err(map_registry_state)?;
+                maybe_skill_fault("skill_monitor_after_observation")?;
                 let state_commit =
                     commit_registry_state(&self.ctx, "monitor-observed: record registry state")?;
                 let mut meta = Meta {
@@ -1620,33 +1629,6 @@ fn collect_materialized_files(root: &Path) -> anyhow::Result<BTreeMap<PathBuf, V
     Ok(files)
 }
 
-struct RegistryOperationStateBackup {
-    operations: Vec<u8>,
-    checkpoint: Vec<u8>,
-}
-
-fn snapshot_registry_operation_state(
-    paths: &RegistryStatePaths,
-) -> anyhow::Result<RegistryOperationStateBackup> {
-    Ok(RegistryOperationStateBackup {
-        operations: fs::read(&paths.operations_file)
-            .with_context(|| format!("failed to snapshot {}", paths.operations_file.display()))?,
-        checkpoint: fs::read(&paths.checkpoint_file)
-            .with_context(|| format!("failed to snapshot {}", paths.checkpoint_file.display()))?,
-    })
-}
-
-fn restore_registry_operation_state(
-    paths: &RegistryStatePaths,
-    backup: &RegistryOperationStateBackup,
-) -> anyhow::Result<()> {
-    fs::write(&paths.operations_file, &backup.operations)
-        .with_context(|| format!("failed to restore {}", paths.operations_file.display()))?;
-    fs::write(&paths.checkpoint_file, &backup.checkpoint)
-        .with_context(|| format!("failed to restore {}", paths.checkpoint_file.display()))?;
-    Ok(())
-}
-
 fn reset_command_created_commits(ctx: &crate::state::AppContext, previous_head: &str) {
     let _ = gitops::run_git_allow_failure(ctx, &["reset", "--soft", previous_head]);
 }
@@ -1659,27 +1641,27 @@ fn unstage_registry_state(ctx: &crate::state::AppContext) {
 fn rollback_import_after_commit(
     ctx: &crate::state::AppContext,
     paths: &RegistryStatePaths,
-    registry_backup: &RegistryOperationStateBackup,
+    registry_backup: &RegistryAuditStateBackup,
     previous_head: &str,
     imported_rels: &[String],
 ) {
     reset_command_created_commits(ctx, previous_head);
     rollback_imported_skills(ctx, imported_rels);
-    let _ = restore_registry_operation_state(paths, registry_backup);
+    let _ = restore_registry_audit_state(paths, registry_backup);
     unstage_registry_state(ctx);
 }
 
 fn rollback_monitor_after_commit(
     ctx: &crate::state::AppContext,
     paths: &RegistryStatePaths,
-    registry_backup: &RegistryOperationStateBackup,
+    registry_backup: &RegistryAuditStateBackup,
     previous_head: &str,
     imported_rels: &[String],
     update_rollbacks: &[MonitorUpdateRollback],
 ) {
     reset_command_created_commits(ctx, previous_head);
     rollback_monitor_changes(ctx, imported_rels, update_rollbacks);
-    let _ = restore_registry_operation_state(paths, registry_backup);
+    let _ = restore_registry_audit_state(paths, registry_backup);
     unstage_registry_state(ctx);
 }
 

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -38,7 +38,7 @@ impl App {
         let paths = self.ensure_registry_layout()?;
         let registry_audit_backup =
             snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
-        let post_audit: std::result::Result<(String, Option<String>), CommandFailure> = (|| {
+        let post_audit: std::result::Result<(Option<String>, Meta), CommandFailure> = (|| {
             let op_id = record_registry_operation(
                 &paths,
                 "skill.release",
@@ -66,28 +66,26 @@ impl App {
                 &self.ctx,
                 &format!("release({}): record registry operation", args.skill),
             )?;
-            Ok((op_id, state_commit))
-        })(
-        );
-        let (op_id, state_commit) = match post_audit {
+            let mut meta = Meta {
+                op_id: Some(op_id),
+                ..Meta::default()
+            };
+            maybe_autosync_or_queue(
+                &self.ctx,
+                "release",
+                request_id,
+                json!({"skill": args.skill, "tag": tag, "state_commit": state_commit}),
+                &mut meta,
+            )?;
+            Ok((state_commit, meta))
+        })();
+        let (state_commit, meta) = match post_audit {
             Ok(result) => result,
             Err(err) => {
                 let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
                 return Err(err);
             }
         };
-
-        let mut meta = Meta {
-            op_id: Some(op_id),
-            ..Meta::default()
-        };
-        maybe_autosync_or_queue(
-            &self.ctx,
-            "release",
-            request_id,
-            json!({"skill": args.skill, "tag": tag, "state_commit": state_commit}),
-            &mut meta,
-        )?;
 
         Ok((
             json!({"skill": args.skill, "version": args.version, "tag": tag, "state_commit": state_commit}),
@@ -141,7 +139,7 @@ impl App {
         let paths = self.ensure_registry_layout()?;
         let registry_audit_backup =
             snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
-        let post_audit: std::result::Result<(String, Option<String>), CommandFailure> = (|| {
+        let post_audit: std::result::Result<(Option<String>, Meta), CommandFailure> = (|| {
             let op_id = record_registry_operation(
                 &paths,
                 "skill.rollback",
@@ -169,33 +167,31 @@ impl App {
                 &self.ctx,
                 &format!("rollback({}): record registry operation", args.skill),
             )?;
-            Ok((op_id, state_commit))
-        })(
-        );
-        let (op_id, state_commit) = match post_audit {
+            let mut meta = Meta {
+                op_id: Some(op_id),
+                ..Meta::default()
+            };
+            maybe_autosync_or_queue(
+                &self.ctx,
+                "rollback",
+                request_id,
+                json!({
+                    "skill": args.skill,
+                    "commit": commit,
+                    "reference": reference,
+                    "state_commit": state_commit
+                }),
+                &mut meta,
+            )?;
+            Ok((state_commit, meta))
+        })();
+        let (state_commit, mut meta) = match post_audit {
             Ok(result) => result,
             Err(err) => {
                 let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
                 return Err(err);
             }
         };
-
-        let mut meta = Meta {
-            op_id: Some(op_id),
-            ..Meta::default()
-        };
-        maybe_autosync_or_queue(
-            &self.ctx,
-            "rollback",
-            request_id,
-            json!({
-                "skill": args.skill,
-                "commit": commit,
-                "reference": reference,
-                "state_commit": state_commit
-            }),
-            &mut meta,
-        )?;
 
         if let Ok(Some(snapshot)) = paths.maybe_load_snapshot() {
             let stale: Vec<_> = snapshot

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -28,6 +28,10 @@ impl App {
         let _lock = self.ctx.lock_skill(&args.skill).map_err(map_lock)?;
 
         let tag = format!("release/{}/{}", args.skill, args.version);
+        let paths = self.ensure_registry_layout()?;
+        let registry_audit_backup =
+            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
+
         gitops::create_annotated_tag(
             &self.ctx,
             &tag,
@@ -35,9 +39,6 @@ impl App {
         )
         .map_err(map_git)?;
 
-        let paths = self.ensure_registry_layout()?;
-        let registry_audit_backup =
-            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
         let post_audit: std::result::Result<(Option<String>, Meta), CommandFailure> = (|| {
             let op_id = record_registry_operation(
                 &paths,
@@ -83,6 +84,7 @@ impl App {
             Ok(result) => result,
             Err(err) => {
                 let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                delete_tag_best_effort(self, &tag);
                 return Err(err);
             }
         };
@@ -133,12 +135,13 @@ impl App {
             ));
         }
 
-        let message = format!("rollback({}): restore from {}", args.skill, reference);
-        let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
-
         let paths = self.ensure_registry_layout()?;
         let registry_audit_backup =
             snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
+
+        let message = format!("rollback({}): restore from {}", args.skill, reference);
+        let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
+
         let post_audit: std::result::Result<(Option<String>, Meta), CommandFailure> = (|| {
             let op_id = record_registry_operation(
                 &paths,
@@ -189,6 +192,7 @@ impl App {
             Ok(result) => result,
             Err(err) => {
                 let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                reset_rollback_commit_best_effort(self, &previous_head);
                 return Err(err);
             }
         };
@@ -235,6 +239,14 @@ impl App {
             Meta::default(),
         ))
     }
+}
+
+fn delete_tag_best_effort(app: &App, tag: &str) {
+    let _ = gitops::run_git_allow_failure(&app.ctx, &["tag", "-d", tag]);
+}
+
+fn reset_rollback_commit_best_effort(app: &App, previous_head: &str) {
+    let _ = gitops::run_git_allow_failure(&app.ctx, &["reset", "--soft", previous_head]);
 }
 
 fn record_skill_projection_observations(

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -33,11 +33,10 @@ impl App {
         let tag = format!("release/{}/{}", args.skill, args.version);
         let paths = RegistryStatePaths::from_app_context(&self.ctx);
         let registry_layout_backup =
-            backup_path_if_exists(&self.ctx, &paths.registry_dir, "registry-layout")
-                .map_err(map_registry_state)?;
+            backup_registry_layout(&self.ctx, &paths).map_err(map_registry_state)?;
         if let Err(err) = paths.ensure_layout() {
-            restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
-            remove_backup_path_best_effort(registry_layout_backup.as_ref());
+            restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+            remove_registry_layout_backups_best_effort(&registry_layout_backup);
             let _ = gitops::restore_index(&self.ctx, &previous_index);
             return Err(map_registry_state(err));
         }
@@ -47,8 +46,8 @@ impl App {
             &tag,
             &format!("release {} {}", args.skill, args.version),
         ) {
-            restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
-            remove_backup_path_best_effort(registry_layout_backup.as_ref());
+            restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+            remove_registry_layout_backups_best_effort(&registry_layout_backup);
             let _ = gitops::restore_index(&self.ctx, &previous_index);
             return Err(map_git(err));
         }
@@ -97,13 +96,13 @@ impl App {
         })();
         let (state_commit, meta) = match post_audit {
             Ok(result) => {
-                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                remove_registry_layout_backups_best_effort(&registry_layout_backup);
                 result
             }
             Err(err) => {
                 reset_command_created_commit_best_effort(self, &previous_head);
-                restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
-                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+                remove_registry_layout_backups_best_effort(&registry_layout_backup);
                 let _ = gitops::restore_index(&self.ctx, &previous_index);
                 delete_tag_best_effort(self, &tag);
                 return Err(err);
@@ -182,13 +181,12 @@ impl App {
 
         let paths = RegistryStatePaths::from_app_context(&self.ctx);
         let registry_layout_backup =
-            backup_path_if_exists(&self.ctx, &paths.registry_dir, "registry-layout")
-                .map_err(map_registry_state)?;
+            backup_registry_layout(&self.ctx, &paths).map_err(map_registry_state)?;
         if let Err(err) = paths.ensure_layout() {
             restore_path_best_effort(&skill_path, skill_backup.as_ref());
             remove_backup_path_best_effort(skill_backup.as_ref());
-            restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
-            remove_backup_path_best_effort(registry_layout_backup.as_ref());
+            restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+            remove_registry_layout_backups_best_effort(&registry_layout_backup);
             let _ = gitops::restore_index(&self.ctx, &previous_index);
             return Err(map_registry_state(err));
         }
@@ -199,8 +197,8 @@ impl App {
             Err(err) => {
                 restore_path_best_effort(&skill_path, skill_backup.as_ref());
                 remove_backup_path_best_effort(skill_backup.as_ref());
-                restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
-                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+                remove_registry_layout_backups_best_effort(&registry_layout_backup);
                 let _ = gitops::restore_index(&self.ctx, &previous_index);
                 return Err(map_git(err));
             }
@@ -256,15 +254,15 @@ impl App {
         let (state_commit, mut meta) = match post_audit {
             Ok(result) => {
                 remove_backup_path_best_effort(skill_backup.as_ref());
-                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                remove_registry_layout_backups_best_effort(&registry_layout_backup);
                 result
             }
             Err(err) => {
                 reset_command_created_commit_best_effort(self, &previous_head);
                 restore_path_best_effort(&skill_path, skill_backup.as_ref());
                 remove_backup_path_best_effort(skill_backup.as_ref());
-                restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
-                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+                remove_registry_layout_backups_best_effort(&registry_layout_backup);
                 let _ = gitops::restore_index(&self.ctx, &previous_index);
                 return Err(err);
             }
@@ -328,6 +326,42 @@ fn restore_path_best_effort(path: &Path, backup: Option<&serde_json::Value>) {
     } else {
         let _ = crate::state::remove_path_if_exists(path);
     }
+}
+
+struct RegistryLayoutBackup {
+    registry: Option<serde_json::Value>,
+    legacy_v3: Option<serde_json::Value>,
+}
+
+fn backup_registry_layout(
+    ctx: &crate::state::AppContext,
+    paths: &RegistryStatePaths,
+) -> anyhow::Result<RegistryLayoutBackup> {
+    Ok(RegistryLayoutBackup {
+        registry: backup_path_if_exists(ctx, &paths.registry_dir, "registry-layout")?,
+        legacy_v3: backup_path_if_exists(
+            ctx,
+            &paths.state_dir.join("v3"),
+            "legacy-registry-layout",
+        )?,
+    })
+}
+
+fn restore_registry_layout_best_effort(paths: &RegistryStatePaths, backup: &RegistryLayoutBackup) {
+    if backup.registry.is_some() {
+        restore_path_best_effort(&paths.registry_dir, backup.registry.as_ref());
+    } else {
+        let _ = crate::state::remove_path_if_exists(&paths.registry_dir);
+    }
+
+    if backup.legacy_v3.is_some() {
+        restore_path_best_effort(&paths.state_dir.join("v3"), backup.legacy_v3.as_ref());
+    }
+}
+
+fn remove_registry_layout_backups_best_effort(backup: &RegistryLayoutBackup) {
+    remove_backup_path_best_effort(backup.registry.as_ref());
+    remove_backup_path_best_effort(backup.legacy_v3.as_ref());
 }
 
 fn remove_backup_path_best_effort(backup: Option<&serde_json::Value>) {

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -11,7 +11,7 @@ use crate::types::ErrorCode;
 use super::helpers::{
     commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock, map_registry_state,
     maybe_autosync_or_queue, record_registry_observation, record_registry_operation,
-    validate_skill_name,
+    restore_registry_audit_state, snapshot_registry_audit_state, validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -36,33 +36,46 @@ impl App {
         .map_err(map_git)?;
 
         let paths = self.ensure_registry_layout()?;
-        let op_id = record_registry_operation(
-            &paths,
-            "skill.release",
-            json!({
-                "skill": args.skill,
-                "version": args.version,
-                "tag": tag,
-                "request_id": request_id
-            }),
-            json!({
-                "tag": tag
-            }),
-        )
-        .map_err(map_registry_state)?;
-        record_skill_projection_observations(
-            &paths,
-            &args.skill,
-            "released",
-            None,
-            None,
-            Some(tag.clone()),
-        )
-        .map_err(map_registry_state)?;
-        let state_commit = commit_registry_state(
-            &self.ctx,
-            &format!("release({}): record registry operation", args.skill),
-        )?;
+        let registry_audit_backup =
+            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
+        let post_audit: std::result::Result<(String, Option<String>), CommandFailure> = (|| {
+            let op_id = record_registry_operation(
+                &paths,
+                "skill.release",
+                json!({
+                    "skill": args.skill,
+                    "version": args.version,
+                    "tag": tag,
+                    "request_id": request_id
+                }),
+                json!({
+                    "tag": tag
+                }),
+            )
+            .map_err(map_registry_state)?;
+            record_skill_projection_observations(
+                &paths,
+                &args.skill,
+                "released",
+                None,
+                None,
+                Some(tag.clone()),
+            )
+            .map_err(map_registry_state)?;
+            let state_commit = commit_registry_state(
+                &self.ctx,
+                &format!("release({}): record registry operation", args.skill),
+            )?;
+            Ok((op_id, state_commit))
+        })(
+        );
+        let (op_id, state_commit) = match post_audit {
+            Ok(result) => result,
+            Err(err) => {
+                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                return Err(err);
+            }
+        };
 
         let mut meta = Meta {
             op_id: Some(op_id),
@@ -126,33 +139,46 @@ impl App {
         let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
 
         let paths = self.ensure_registry_layout()?;
-        let op_id = record_registry_operation(
-            &paths,
-            "skill.rollback",
-            json!({
-                "skill": args.skill,
-                "reference": reference,
-                "request_id": request_id
-            }),
-            json!({
-                "commit": commit,
-                "noop": false
-            }),
-        )
-        .map_err(map_registry_state)?;
-        record_skill_projection_observations(
-            &paths,
-            &args.skill,
-            "rollback",
-            Some(skill_rel.clone()),
-            Some(previous_head),
-            Some(reference.clone()),
-        )
-        .map_err(map_registry_state)?;
-        let state_commit = commit_registry_state(
-            &self.ctx,
-            &format!("rollback({}): record registry operation", args.skill),
-        )?;
+        let registry_audit_backup =
+            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
+        let post_audit: std::result::Result<(String, Option<String>), CommandFailure> = (|| {
+            let op_id = record_registry_operation(
+                &paths,
+                "skill.rollback",
+                json!({
+                    "skill": args.skill,
+                    "reference": reference,
+                    "request_id": request_id
+                }),
+                json!({
+                    "commit": commit,
+                    "noop": false
+                }),
+            )
+            .map_err(map_registry_state)?;
+            record_skill_projection_observations(
+                &paths,
+                &args.skill,
+                "rollback",
+                Some(skill_rel.clone()),
+                Some(previous_head.clone()),
+                Some(reference.clone()),
+            )
+            .map_err(map_registry_state)?;
+            let state_commit = commit_registry_state(
+                &self.ctx,
+                &format!("rollback({}): record registry operation", args.skill),
+            )?;
+            Ok((op_id, state_commit))
+        })(
+        );
+        let (op_id, state_commit) = match post_audit {
+            Ok(result) => result,
+            Err(err) => {
+                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                return Err(err);
+            }
+        };
 
         let mut meta = Meta {
             op_id: Some(op_id),

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -91,7 +91,6 @@ impl App {
         let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
         self.ensure_write_repo_ready()?;
         ensure_skill_exists(&self.ctx, &args.skill)?;
-        let paths = self.ensure_registry_layout()?;
         if args.to.is_some() && args.steps.is_some() {
             return Err(CommandFailure::new(
                 ErrorCode::ArgInvalid,
@@ -126,6 +125,7 @@ impl App {
         let message = format!("rollback({}): restore from {}", args.skill, reference);
         let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
 
+        let paths = self.ensure_registry_layout()?;
         let op_id = record_registry_operation(
             &paths,
             "skill.rollback",

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 
 use serde_json::json;
@@ -9,9 +10,10 @@ use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
 use super::helpers::{
-    commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock, map_registry_state,
-    maybe_autosync_or_queue, record_registry_observation, record_registry_operation,
-    restore_registry_audit_state, snapshot_registry_audit_state, validate_skill_name,
+    backup_path_if_exists, commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock,
+    map_registry_state, maybe_autosync_or_queue, record_registry_observation,
+    record_registry_operation, restore_path_from_backup, restore_registry_audit_state,
+    snapshot_registry_audit_state, validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -27,6 +29,8 @@ impl App {
         ensure_skill_exists(&self.ctx, &args.skill)?;
         let _lock = self.ctx.lock_skill(&args.skill).map_err(map_lock)?;
 
+        let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
+        let previous_index = gitops::snapshot_index(&self.ctx).map_err(map_git)?;
         let tag = format!("release/{}/{}", args.skill, args.version);
         let paths = self.ensure_registry_layout()?;
         let registry_audit_backup =
@@ -67,6 +71,7 @@ impl App {
                 &self.ctx,
                 &format!("release({}): record registry operation", args.skill),
             )?;
+            maybe_version_fault("skill_release_after_state_commit")?;
             let mut meta = Meta {
                 op_id: Some(op_id),
                 ..Meta::default()
@@ -83,7 +88,9 @@ impl App {
         let (state_commit, meta) = match post_audit {
             Ok(result) => result,
             Err(err) => {
+                reset_command_created_commit_best_effort(self, &previous_head);
                 let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                let _ = gitops::restore_index(&self.ctx, &previous_index);
                 delete_tag_best_effort(self, &tag);
                 return Err(err);
             }
@@ -119,9 +126,13 @@ impl App {
 
         let _lock = self.ctx.lock_skill(&args.skill).map_err(map_lock)?;
         let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
+        let previous_index = gitops::snapshot_index(&self.ctx).map_err(map_git)?;
         gitops::resolve_ref(&self.ctx, &reference).map_err(map_git)?;
 
         let skill_rel = format!("skills/{}", args.skill);
+        let skill_path = self.ctx.root.join(&skill_rel);
+        let skill_backup = backup_path_if_exists(&self.ctx, &skill_path, "skill-rollback")
+            .map_err(map_registry_state)?;
         gitops::checkout_path_from_ref(&self.ctx, &reference, Path::new(&skill_rel))
             .map_err(map_git)?;
         gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
@@ -170,6 +181,7 @@ impl App {
                 &self.ctx,
                 &format!("rollback({}): record registry operation", args.skill),
             )?;
+            maybe_version_fault("skill_rollback_after_state_commit")?;
             let mut meta = Meta {
                 op_id: Some(op_id),
                 ..Meta::default()
@@ -189,10 +201,16 @@ impl App {
             Ok((state_commit, meta))
         })();
         let (state_commit, mut meta) = match post_audit {
-            Ok(result) => result,
+            Ok(result) => {
+                remove_backup_path_best_effort(skill_backup.as_ref());
+                result
+            }
             Err(err) => {
+                reset_command_created_commit_best_effort(self, &previous_head);
+                restore_skill_path_best_effort(&skill_path, skill_backup.as_ref());
+                remove_backup_path_best_effort(skill_backup.as_ref());
                 let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
-                reset_rollback_commit_best_effort(self, &previous_head);
+                let _ = gitops::restore_index(&self.ctx, &previous_index);
                 return Err(err);
             }
         };
@@ -245,8 +263,43 @@ fn delete_tag_best_effort(app: &App, tag: &str) {
     let _ = gitops::run_git_allow_failure(&app.ctx, &["tag", "-d", tag]);
 }
 
-fn reset_rollback_commit_best_effort(app: &App, previous_head: &str) {
+fn reset_command_created_commit_best_effort(app: &App, previous_head: &str) {
     let _ = gitops::run_git_allow_failure(&app.ctx, &["reset", "--soft", previous_head]);
+}
+
+fn restore_skill_path_best_effort(path: &Path, backup: Option<&serde_json::Value>) {
+    if let Some(backup) = backup {
+        let _ = restore_path_from_backup(path, backup);
+    } else {
+        let _ = crate::state::remove_path_if_exists(path);
+    }
+}
+
+fn remove_backup_path_best_effort(backup: Option<&serde_json::Value>) {
+    let Some(path) = backup
+        .and_then(|backup| backup.get("backup_path"))
+        .and_then(serde_json::Value::as_str)
+        .map(Path::new)
+    else {
+        return;
+    };
+    let _ = crate::state::remove_path_if_exists(path);
+    if let Some(parent) = path.parent() {
+        let _ = fs::remove_dir(parent);
+        if let Some(grandparent) = parent.parent() {
+            let _ = fs::remove_dir(grandparent);
+        }
+    }
+}
+
+fn maybe_version_fault(tag: &str) -> std::result::Result<(), CommandFailure> {
+    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
+        return Err(CommandFailure::new(
+            ErrorCode::InternalError,
+            format!("fault injected at {}", tag),
+        ));
+    }
+    Ok(())
 }
 
 fn record_skill_projection_observations(

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -9,7 +9,9 @@ use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
 use super::helpers::{
-    ensure_skill_exists, map_arg, map_git, map_lock, maybe_autosync_or_queue, validate_skill_name,
+    commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock, map_registry_state,
+    maybe_autosync_or_queue, record_registry_observation, record_registry_operation,
+    validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -33,17 +35,49 @@ impl App {
         )
         .map_err(map_git)?;
 
-        let mut meta = Meta::default();
+        let paths = self.ensure_registry_layout()?;
+        let op_id = record_registry_operation(
+            &paths,
+            "skill.release",
+            json!({
+                "skill": args.skill,
+                "version": args.version,
+                "tag": tag,
+                "request_id": request_id
+            }),
+            json!({
+                "tag": tag
+            }),
+        )
+        .map_err(map_registry_state)?;
+        record_skill_projection_observations(
+            &paths,
+            &args.skill,
+            "released",
+            None,
+            None,
+            Some(tag.clone()),
+        )
+        .map_err(map_registry_state)?;
+        let state_commit = commit_registry_state(
+            &self.ctx,
+            &format!("release({}): record registry operation", args.skill),
+        )?;
+
+        let mut meta = Meta {
+            op_id: Some(op_id),
+            ..Meta::default()
+        };
         maybe_autosync_or_queue(
             &self.ctx,
             "release",
             request_id,
-            json!({"skill": args.skill, "tag": tag}),
+            json!({"skill": args.skill, "tag": tag, "state_commit": state_commit}),
             &mut meta,
         )?;
 
         Ok((
-            json!({"skill": args.skill, "version": args.version, "tag": tag}),
+            json!({"skill": args.skill, "version": args.version, "tag": tag, "state_commit": state_commit}),
             meta,
         ))
     }
@@ -57,6 +91,7 @@ impl App {
         let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
         self.ensure_write_repo_ready()?;
         ensure_skill_exists(&self.ctx, &args.skill)?;
+        let paths = self.ensure_registry_layout()?;
         if args.to.is_some() && args.steps.is_some() {
             return Err(CommandFailure::new(
                 ErrorCode::ArgInvalid,
@@ -71,6 +106,7 @@ impl App {
         };
 
         let _lock = self.ctx.lock_skill(&args.skill).map_err(map_lock)?;
+        let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
         gitops::resolve_ref(&self.ctx, &reference).map_err(map_git)?;
 
         let skill_rel = format!("skills/{}", args.skill);
@@ -90,16 +126,51 @@ impl App {
         let message = format!("rollback({}): restore from {}", args.skill, reference);
         let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
 
-        let mut meta = Meta::default();
+        let op_id = record_registry_operation(
+            &paths,
+            "skill.rollback",
+            json!({
+                "skill": args.skill,
+                "reference": reference,
+                "request_id": request_id
+            }),
+            json!({
+                "commit": commit,
+                "noop": false
+            }),
+        )
+        .map_err(map_registry_state)?;
+        record_skill_projection_observations(
+            &paths,
+            &args.skill,
+            "rollback",
+            Some(skill_rel.clone()),
+            Some(previous_head),
+            Some(reference.clone()),
+        )
+        .map_err(map_registry_state)?;
+        let state_commit = commit_registry_state(
+            &self.ctx,
+            &format!("rollback({}): record registry operation", args.skill),
+        )?;
+
+        let mut meta = Meta {
+            op_id: Some(op_id),
+            ..Meta::default()
+        };
         maybe_autosync_or_queue(
             &self.ctx,
             "rollback",
             request_id,
-            json!({"skill": args.skill, "commit": commit, "reference": reference}),
+            json!({
+                "skill": args.skill,
+                "commit": commit,
+                "reference": reference,
+                "state_commit": state_commit
+            }),
             &mut meta,
         )?;
 
-        let paths = RegistryStatePaths::from_app_context(&self.ctx);
         if let Ok(Some(snapshot)) = paths.maybe_load_snapshot() {
             let stale: Vec<_> = snapshot
                 .projections
@@ -117,7 +188,13 @@ impl App {
         }
 
         Ok((
-            json!({"skill": args.skill, "reference": reference, "commit": commit, "noop": false}),
+            json!({
+                "skill": args.skill,
+                "reference": reference,
+                "commit": commit,
+                "state_commit": state_commit,
+                "noop": false
+            }),
             meta,
         ))
     }
@@ -136,4 +213,32 @@ impl App {
             Meta::default(),
         ))
     }
+}
+
+fn record_skill_projection_observations(
+    paths: &RegistryStatePaths,
+    skill_id: &str,
+    kind: &str,
+    path: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(snapshot) = paths.maybe_load_snapshot()? {
+        for projection in snapshot
+            .projections
+            .projections
+            .iter()
+            .filter(|projection| projection.skill_id == skill_id)
+        {
+            record_registry_observation(
+                paths,
+                &projection.instance_id,
+                kind,
+                path.clone(),
+                from.clone(),
+                to.clone(),
+            )?;
+        }
+    }
+    Ok(())
 }

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -12,8 +12,7 @@ use crate::types::ErrorCode;
 use super::helpers::{
     backup_path_if_exists, commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock,
     map_registry_state, maybe_autosync_or_queue, record_registry_observation,
-    record_registry_operation, restore_path_from_backup, restore_registry_audit_state,
-    snapshot_registry_audit_state, validate_skill_name,
+    record_registry_operation, restore_path_from_backup, validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -32,9 +31,11 @@ impl App {
         let previous_head = gitops::head(&self.ctx).map_err(map_git)?;
         let previous_index = gitops::snapshot_index(&self.ctx).map_err(map_git)?;
         let tag = format!("release/{}/{}", args.skill, args.version);
-        let paths = self.ensure_registry_layout()?;
-        let registry_audit_backup =
-            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
+        let paths = RegistryStatePaths::from_app_context(&self.ctx);
+        let registry_layout_backup =
+            backup_path_if_exists(&self.ctx, &paths.registry_dir, "registry-layout")
+                .map_err(map_registry_state)?;
+        paths.ensure_layout().map_err(map_registry_state)?;
 
         gitops::create_annotated_tag(
             &self.ctx,
@@ -86,10 +87,14 @@ impl App {
             Ok((state_commit, meta))
         })();
         let (state_commit, meta) = match post_audit {
-            Ok(result) => result,
+            Ok(result) => {
+                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                result
+            }
             Err(err) => {
                 reset_command_created_commit_best_effort(self, &previous_head);
-                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
+                remove_backup_path_best_effort(registry_layout_backup.as_ref());
                 let _ = gitops::restore_index(&self.ctx, &previous_index);
                 delete_tag_best_effort(self, &tag);
                 return Err(err);
@@ -146,9 +151,11 @@ impl App {
             ));
         }
 
-        let paths = self.ensure_registry_layout()?;
-        let registry_audit_backup =
-            snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
+        let paths = RegistryStatePaths::from_app_context(&self.ctx);
+        let registry_layout_backup =
+            backup_path_if_exists(&self.ctx, &paths.registry_dir, "registry-layout")
+                .map_err(map_registry_state)?;
+        paths.ensure_layout().map_err(map_registry_state)?;
 
         let message = format!("rollback({}): restore from {}", args.skill, reference);
         let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
@@ -203,13 +210,15 @@ impl App {
         let (state_commit, mut meta) = match post_audit {
             Ok(result) => {
                 remove_backup_path_best_effort(skill_backup.as_ref());
+                remove_backup_path_best_effort(registry_layout_backup.as_ref());
                 result
             }
             Err(err) => {
                 reset_command_created_commit_best_effort(self, &previous_head);
-                restore_skill_path_best_effort(&skill_path, skill_backup.as_ref());
+                restore_path_best_effort(&skill_path, skill_backup.as_ref());
                 remove_backup_path_best_effort(skill_backup.as_ref());
-                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
+                restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
+                remove_backup_path_best_effort(registry_layout_backup.as_ref());
                 let _ = gitops::restore_index(&self.ctx, &previous_index);
                 return Err(err);
             }
@@ -267,7 +276,7 @@ fn reset_command_created_commit_best_effort(app: &App, previous_head: &str) {
     let _ = gitops::run_git_allow_failure(&app.ctx, &["reset", "--soft", previous_head]);
 }
 
-fn restore_skill_path_best_effort(path: &Path, backup: Option<&serde_json::Value>) {
+fn restore_path_best_effort(path: &Path, backup: Option<&serde_json::Value>) {
     if let Some(backup) = backup {
         let _ = restore_path_from_backup(path, backup);
     } else {

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -35,14 +35,23 @@ impl App {
         let registry_layout_backup =
             backup_path_if_exists(&self.ctx, &paths.registry_dir, "registry-layout")
                 .map_err(map_registry_state)?;
-        paths.ensure_layout().map_err(map_registry_state)?;
+        if let Err(err) = paths.ensure_layout() {
+            restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
+            remove_backup_path_best_effort(registry_layout_backup.as_ref());
+            let _ = gitops::restore_index(&self.ctx, &previous_index);
+            return Err(map_registry_state(err));
+        }
 
-        gitops::create_annotated_tag(
+        if let Err(err) = gitops::create_annotated_tag(
             &self.ctx,
             &tag,
             &format!("release {} {}", args.skill, args.version),
-        )
-        .map_err(map_git)?;
+        ) {
+            restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
+            remove_backup_path_best_effort(registry_layout_backup.as_ref());
+            let _ = gitops::restore_index(&self.ctx, &previous_index);
+            return Err(map_git(err));
+        }
 
         let post_audit: std::result::Result<(Option<String>, Meta), CommandFailure> = (|| {
             let op_id = record_registry_operation(
@@ -138,13 +147,33 @@ impl App {
         let skill_path = self.ctx.root.join(&skill_rel);
         let skill_backup = backup_path_if_exists(&self.ctx, &skill_path, "skill-rollback")
             .map_err(map_registry_state)?;
-        gitops::checkout_path_from_ref(&self.ctx, &reference, Path::new(&skill_rel))
-            .map_err(map_git)?;
-        gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
+        if let Err(err) =
+            gitops::checkout_path_from_ref(&self.ctx, &reference, Path::new(&skill_rel))
+        {
+            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            remove_backup_path_best_effort(skill_backup.as_ref());
+            let _ = gitops::restore_index(&self.ctx, &previous_index);
+            return Err(map_git(err));
+        }
+        if let Err(err) = gitops::stage_path(&self.ctx, Path::new(&skill_rel)) {
+            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            remove_backup_path_best_effort(skill_backup.as_ref());
+            let _ = gitops::restore_index(&self.ctx, &previous_index);
+            return Err(map_git(err));
+        }
 
-        let changed = gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel))
-            .map_err(map_git)?;
+        let changed = match gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel)) {
+            Ok(changed) => changed,
+            Err(err) => {
+                restore_path_best_effort(&skill_path, skill_backup.as_ref());
+                remove_backup_path_best_effort(skill_backup.as_ref());
+                let _ = gitops::restore_index(&self.ctx, &previous_index);
+                return Err(map_git(err));
+            }
+        };
         if !changed {
+            remove_backup_path_best_effort(skill_backup.as_ref());
+            let _ = gitops::restore_index(&self.ctx, &previous_index);
             return Ok((
                 json!({"skill": args.skill, "reference": reference, "noop": true}),
                 Meta::default(),
@@ -155,10 +184,27 @@ impl App {
         let registry_layout_backup =
             backup_path_if_exists(&self.ctx, &paths.registry_dir, "registry-layout")
                 .map_err(map_registry_state)?;
-        paths.ensure_layout().map_err(map_registry_state)?;
+        if let Err(err) = paths.ensure_layout() {
+            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            remove_backup_path_best_effort(skill_backup.as_ref());
+            restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
+            remove_backup_path_best_effort(registry_layout_backup.as_ref());
+            let _ = gitops::restore_index(&self.ctx, &previous_index);
+            return Err(map_registry_state(err));
+        }
 
         let message = format!("rollback({}): restore from {}", args.skill, reference);
-        let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
+        let commit = match gitops::commit(&self.ctx, &message) {
+            Ok(commit) => commit,
+            Err(err) => {
+                restore_path_best_effort(&skill_path, skill_backup.as_ref());
+                remove_backup_path_best_effort(skill_backup.as_ref());
+                restore_path_best_effort(&paths.registry_dir, registry_layout_backup.as_ref());
+                remove_backup_path_best_effort(registry_layout_backup.as_ref());
+                let _ = gitops::restore_index(&self.ctx, &previous_index);
+                return Err(map_git(err));
+            }
+        };
 
         let post_audit: std::result::Result<(Option<String>, Meta), CommandFailure> = (|| {
             let op_id = record_registry_operation(

--- a/src/panel/skill_history.rs
+++ b/src/panel/skill_history.rs
@@ -182,7 +182,19 @@ pub(super) async fn registry_skill_history(
     let mut warnings = Vec::new();
     let mut skipped_warning_count = 0usize;
     for instance_id in &instance_ids {
-        let obs_path = paths.observations_dir.join(format!("{instance_id}.jsonl"));
+        let obs_path = match paths.observation_file_for_instance(instance_id) {
+            Ok(path) => path,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    registry_error(
+                        CMD,
+                        "OBS_READ_ERROR",
+                        format!("failed to read observations for {instance_id}: {e:#}"),
+                    ),
+                );
+            }
+        };
         match load_obs_bounded(&obs_path, 200) {
             Ok((obs, obs_warnings)) => {
                 events.extend(obs);
@@ -398,6 +410,31 @@ mod tests {
         assert_eq!(payload["data"]["skill"], json!("my-skill"));
         assert_eq!(payload["data"]["count"], json!(0));
         assert!(payload["data"]["events"].as_array().unwrap().is_empty());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn rejects_unsafe_projection_instance_id() {
+        let root = std::env::temp_dir().join(format!("loom-hist-unsafe-id-{}", Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let paths = setup_registry(&root);
+        add_skill_rule(&paths, "my-skill");
+        add_projection(&paths, "my-skill", "../escaped");
+        let state = make_state(&root);
+
+        let (status, Json(payload)) =
+            registry_skill_history(AxumPath("my-skill".to_string()), State(state)).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(payload["ok"], json!(false));
+        assert_eq!(payload["error"]["code"], json!("OBS_READ_ERROR"));
+        assert!(
+            payload["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("unsafe filename characters")
+        );
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/state_model/persistence.rs
+++ b/src/state_model/persistence.rs
@@ -204,6 +204,15 @@ impl RegistryStatePaths {
         read_json_lines(&self.observations_dir.join(name))
     }
 
+    pub fn append_observation(&self, value: &RegistryObservationEvent) -> Result<()> {
+        append_json_line(
+            &self
+                .observations_dir
+                .join(format!("{}.jsonl", value.instance_id)),
+            value,
+        )
+    }
+
     pub fn save_targets(&self, value: &RegistryTargetsFile) -> Result<()> {
         write_json_file(&self.targets_file, value)
     }

--- a/src/state_model/persistence.rs
+++ b/src/state_model/persistence.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
@@ -201,14 +201,18 @@ impl RegistryStatePaths {
     }
 
     pub fn load_observations_file(&self, name: &str) -> Result<Vec<RegistryObservationEvent>> {
-        read_json_lines(&self.observations_dir.join(name))
+        let instance_id = name.strip_suffix(".jsonl").unwrap_or(name);
+        read_json_lines(&self.observation_file_for_instance(instance_id)?)
+    }
+
+    pub fn observation_file_for_instance(&self, instance_id: &str) -> Result<PathBuf> {
+        validate_observation_instance_id(instance_id)?;
+        Ok(self.observations_dir.join(format!("{instance_id}.jsonl")))
     }
 
     pub fn append_observation(&self, value: &RegistryObservationEvent) -> Result<()> {
         append_json_line(
-            &self
-                .observations_dir
-                .join(format!("{}.jsonl", value.instance_id)),
+            &self.observation_file_for_instance(&value.instance_id)?,
             value,
         )
     }
@@ -267,18 +271,35 @@ fn validate_schema_version(version: u32) -> Result<()> {
     Ok(())
 }
 
+fn validate_observation_instance_id(instance_id: &str) -> Result<()> {
+    if instance_id.is_empty() {
+        return Err(anyhow!("observation instance_id must not be empty"));
+    }
+    if !instance_id
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return Err(anyhow!(
+            "observation instance_id '{}' contains unsafe filename characters",
+            instance_id
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::{
-        RegistryBindingRule, RegistryBindingsFile, RegistryOperationRecord, RegistryOpsCheckpoint,
-        RegistryProjectionInstance, RegistryProjectionTarget, RegistryProjectionsFile,
-        RegistryRulesFile, RegistrySchemaFile, RegistrySnapshot, RegistryStatePaths,
-        RegistryTargetCapabilities, RegistryTargetsFile, RegistryWorkspaceBinding,
-        RegistryWorkspaceMatcher,
+        RegistryBindingRule, RegistryBindingsFile, RegistryObservationEvent,
+        RegistryOperationRecord, RegistryOpsCheckpoint, RegistryProjectionInstance,
+        RegistryProjectionTarget, RegistryProjectionsFile, RegistryRulesFile, RegistrySchemaFile,
+        RegistrySnapshot, RegistryStatePaths, RegistryTargetCapabilities, RegistryTargetsFile,
+        RegistryWorkspaceBinding, RegistryWorkspaceMatcher,
     };
     use chrono::Utc;
     use serde_json::json;
-    use std::path::Path;
+    use std::{fs, path::Path};
+    use uuid::Uuid;
 
     #[test]
     fn builds_expected_registry_paths() {
@@ -292,6 +313,36 @@ mod tests {
             paths.observations_dir,
             Path::new("/tmp/loom/state/registry/observations")
         );
+    }
+
+    #[test]
+    fn observation_file_rejects_path_like_instance_ids() {
+        let root = std::env::temp_dir().join(format!("loom-observation-safe-{}", Uuid::new_v4()));
+        fs::create_dir_all(&root).expect("create temp root");
+        let paths = RegistryStatePaths::from_root(&root);
+        paths.ensure_layout().expect("ensure layout");
+
+        let now = Utc::now();
+        let event = RegistryObservationEvent {
+            event_id: "event_1".to_string(),
+            instance_id: "../escaped".to_string(),
+            kind: "projected".to_string(),
+            path: None,
+            from: None,
+            to: None,
+            observed_at: now,
+        };
+
+        let err = paths
+            .append_observation(&event)
+            .expect_err("path-like instance id must be rejected");
+        assert!(err.to_string().contains("unsafe filename characters"));
+        assert!(
+            !root.join("state/registry/escaped.jsonl").exists(),
+            "unsafe instance id must not write outside observations dir"
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -18,6 +18,14 @@ fn read_checkpoint(root: &std::path::Path) -> String {
     fs::read_to_string(root.join("state/registry/ops/checkpoint.json")).expect("read checkpoint")
 }
 
+fn read_observation_log(root: &std::path::Path, instance_id: &str) -> String {
+    fs::read_to_string(
+        root.join("state/registry/observations")
+            .join(format!("{instance_id}.jsonl")),
+    )
+    .expect("read observation log")
+}
+
 fn git_ok(root: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .arg("-C")
@@ -123,6 +131,11 @@ fn skill_capture_copies_live_projection_back_into_source_and_commits() {
             .map(|value| !value.is_empty()),
         Some(true)
     );
+    let instance_id = capture_env["data"]["capture"]["instance_id"]
+        .as_str()
+        .expect("capture instance id");
+    let observations = read_observation_log(root.path(), instance_id);
+    assert!(observations.contains("\"kind\":\"captured\""));
 
     let backup_path = capture_env["data"]["capture"]["backup"]["backup_path"]
         .as_str()

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 mod common;
 
 use common::actions::{binding_add, save_skill, skill_project, target_add};
-use common::{TestDir, run_loom, run_loom_with_env, write_skill};
+use common::{TestDir, run_loom, run_loom_with_env, write_minimal_registry_state, write_skill};
 
 fn write_example_skill(root: &std::path::Path, skill: &str) {
     write_skill(root, skill, &format!("# {}\n\nexample skill\n", skill));
@@ -419,6 +419,67 @@ fn skill_rollback_removes_new_registry_layout_after_late_audit_failure() {
 }
 
 #[test]
+fn skill_rollback_restores_legacy_v3_layout_after_late_audit_failure() {
+    let root = TestDir::new("registry-skill-rollback-legacy-v3-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v2\n",
+    );
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+    write_minimal_registry_state(root.path(), 1);
+    fs::rename(
+        root.path().join("state/registry"),
+        root.path().join("state/v3"),
+    )
+    .expect("move registry to legacy v3");
+    assert!(root.path().join("state/v3").exists());
+    assert!(!root.path().join("state/registry").exists());
+    let legacy_ops_before = fs::read_to_string(root.path().join("state/v3/ops/operations.jsonl"))
+        .expect("read legacy ops");
+    let head_before = git_head(root.path());
+
+    let (rollback_output, rollback_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_rollback_after_state_commit")],
+        &["skill", "rollback", "model-onboarding", "--to", "HEAD~1"],
+    );
+
+    assert!(
+        !rollback_output.status.success(),
+        "rollback unexpectedly succeeded"
+    );
+    assert_eq!(rollback_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert!(root.path().join("state/v3").exists());
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "failed rollback should restore legacy v3 instead of keeping migrated registry"
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("state/v3/ops/operations.jsonl"))
+            .expect("read legacy ops"),
+        legacy_ops_before
+    );
+    let source = fs::read_to_string(root.path().join("skills/model-onboarding/SKILL.md"))
+        .expect("read source skill");
+    assert!(source.contains("source v2"));
+}
+
+#[test]
 fn skill_release_records_operation() {
     let root = TestDir::new("registry-skill-release-audit");
     write_example_skill(root.path(), "model-onboarding");
@@ -489,6 +550,56 @@ fn skill_release_removes_new_registry_layout_after_late_failure() {
         "failed release should remove newly-created registry layout"
     );
     assert_eq!(git_status_short_for(root.path(), &["state/registry"]), "");
+}
+
+#[test]
+fn skill_release_restores_legacy_v3_layout_after_late_failure() {
+    let root = TestDir::new("registry-skill-release-legacy-v3-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+    write_minimal_registry_state(root.path(), 1);
+    fs::rename(
+        root.path().join("state/registry"),
+        root.path().join("state/v3"),
+    )
+    .expect("move registry to legacy v3");
+    assert!(root.path().join("state/v3").exists());
+    assert!(!root.path().join("state/registry").exists());
+    let legacy_ops_before = fs::read_to_string(root.path().join("state/v3/ops/operations.jsonl"))
+        .expect("read legacy ops");
+    let head_before = git_head(root.path());
+
+    let (release_output, release_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_release_after_state_commit")],
+        &["skill", "release", "model-onboarding", "v1.0.0"],
+    );
+
+    assert!(
+        !release_output.status.success(),
+        "release unexpectedly succeeded"
+    );
+    assert_eq!(release_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert!(
+        !git_tag_exists(root.path(), "release/model-onboarding/v1.0.0"),
+        "failed release should delete the release tag"
+    );
+    assert!(root.path().join("state/v3").exists());
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "failed release should restore legacy v3 instead of keeping migrated registry"
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("state/v3/ops/operations.jsonl"))
+            .expect("read legacy ops"),
+        legacy_ops_before
+    );
 }
 
 #[test]

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 use serde_json::Value;
 
@@ -27,6 +28,47 @@ fn read_observation_log(root: &std::path::Path, instance_id: &str) -> String {
             .join(format!("{instance_id}.jsonl")),
     )
     .expect("read observation log")
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stderr={} stdout={}",
+        args,
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn git_head(root: &Path) -> String {
+    git_output(root, &["rev-parse", "HEAD"])
+}
+
+fn git_status_short_for(root: &Path, pathspecs: &[&str]) -> String {
+    let mut args = vec!["status", "--short", "--"];
+    args.extend(pathspecs);
+    git_output(root, &args)
+}
+
+fn git_tag_exists(root: &Path, tag: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .args(["rev-parse", "--verify", "--quiet", tag])
+        .status()
+        .expect("run git")
+        .success()
 }
 
 #[test]
@@ -232,6 +274,94 @@ fn skill_rollback_noop_does_not_initialize_registry() {
 }
 
 #[test]
+fn skill_rollback_rolls_back_commits_and_worktree_after_late_audit_failure() {
+    let root = TestDir::new("registry-skill-rollback-late-audit-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+    let (project_output, project_env) = skill_project(
+        root.path(),
+        "model-onboarding",
+        "bind_claude_project_a",
+        Some("copy"),
+    );
+    assert!(project_output.status.success(), "project should succeed");
+    let instance_id = project_env["data"]["projection"]["instance_id"]
+        .as_str()
+        .expect("projection instance id")
+        .to_string();
+
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v2\n",
+    );
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let operations_before = read_operations_log(root.path());
+    let checkpoint_before = read_checkpoint(root.path());
+    let observations_before = read_observation_log(root.path(), &instance_id);
+    let head_before = git_head(root.path());
+
+    let (rollback_output, rollback_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_rollback_after_state_commit")],
+        &["skill", "rollback", "model-onboarding", "--to", "HEAD~1"],
+    );
+
+    assert!(
+        !rollback_output.status.success(),
+        "rollback unexpectedly succeeded"
+    );
+    assert_eq!(rollback_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert_eq!(read_operations_log(root.path()), operations_before);
+    assert_eq!(read_checkpoint(root.path()), checkpoint_before);
+    assert_eq!(
+        read_observation_log(root.path(), &instance_id),
+        observations_before
+    );
+    let source = fs::read_to_string(root.path().join("skills/model-onboarding/SKILL.md"))
+        .expect("read source skill");
+    assert!(source.contains("source v2"));
+    assert_eq!(
+        git_status_short_for(root.path(), &["skills/model-onboarding", "state/registry"]),
+        ""
+    );
+}
+
+#[test]
 fn skill_release_records_operation() {
     let root = TestDir::new("registry-skill-release-audit");
     write_example_skill(root.path(), "model-onboarding");
@@ -263,6 +393,50 @@ fn skill_release_records_operation() {
     let operations = read_operations_log(root.path());
     assert!(operations.contains("\"intent\":\"skill.release\""));
     assert!(operations.contains("\"version\":\"v1.0.0\""));
+}
+
+#[test]
+fn skill_release_rolls_back_audit_commit_and_tag_after_late_failure() {
+    let root = TestDir::new("registry-skill-release-audit-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+
+    let operations_before = read_operations_log(root.path());
+    let checkpoint_before = read_checkpoint(root.path());
+    let head_before = git_head(root.path());
+
+    let (release_output, release_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_release_after_state_commit")],
+        &["skill", "release", "model-onboarding", "v1.0.0"],
+    );
+
+    assert!(
+        !release_output.status.success(),
+        "release unexpectedly succeeded"
+    );
+    assert_eq!(release_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert!(
+        !git_tag_exists(root.path(), "release/model-onboarding/v1.0.0"),
+        "failed release should delete the release tag"
+    );
+    assert_eq!(read_operations_log(root.path()), operations_before);
+    assert_eq!(read_checkpoint(root.path()), checkpoint_before);
+    assert_eq!(git_status_short_for(root.path(), &["state/registry"]), "");
 }
 
 #[test]

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -21,6 +21,14 @@ fn read_checkpoint(root: &std::path::Path) -> String {
     fs::read_to_string(root.join("state/registry/ops/checkpoint.json")).expect("read checkpoint")
 }
 
+fn read_observation_log(root: &std::path::Path, instance_id: &str) -> String {
+    fs::read_to_string(
+        root.join("state/registry/observations")
+            .join(format!("{instance_id}.jsonl")),
+    )
+    .expect("read observation log")
+}
+
 #[test]
 fn skill_project_creates_projection_rule_and_instance() {
     let root = TestDir::new("registry-skill-project");
@@ -77,6 +85,12 @@ fn skill_project_creates_projection_rule_and_instance() {
             .map(|value| !value.is_empty()),
         Some(true)
     );
+    let instance_id = project_env["data"]["projection"]["instance_id"]
+        .as_str()
+        .expect("projection instance id");
+    let observations = read_observation_log(root.path(), instance_id);
+    assert!(observations.contains("\"kind\":\"projected\""));
+    assert!(observations.contains(&format!("\"instance_id\":\"{instance_id}\"")));
 
     let projected_path = target_path.join("model-onboarding");
     assert!(projected_path.exists(), "projected path should exist");
@@ -99,6 +113,127 @@ fn skill_project_creates_projection_rule_and_instance() {
             .map(Vec::len),
         Some(1)
     );
+}
+
+#[test]
+fn skill_rollback_records_operation_and_observation() {
+    let root = TestDir::new("registry-skill-rollback-audit");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+    let (project_output, project_env) = skill_project(
+        root.path(),
+        "model-onboarding",
+        "bind_claude_project_a",
+        Some("copy"),
+    );
+    assert!(project_output.status.success(), "project should succeed");
+    let instance_id = project_env["data"]["projection"]["instance_id"]
+        .as_str()
+        .expect("projection instance id")
+        .to_string();
+
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v2\n",
+    );
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let (rollback_output, rollback_env) = run_loom(
+        root.path(),
+        &["skill", "rollback", "model-onboarding", "--to", "HEAD~1"],
+    );
+    assert!(
+        rollback_output.status.success(),
+        "rollback failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&rollback_output.stderr),
+        String::from_utf8_lossy(&rollback_output.stdout)
+    );
+    assert_eq!(rollback_env["ok"], Value::Bool(true));
+    assert_eq!(
+        rollback_env["meta"]["op_id"]
+            .as_str()
+            .map(|value| !value.is_empty()),
+        Some(true)
+    );
+
+    let operations = read_operations_log(root.path());
+    assert!(operations.contains("\"intent\":\"skill.rollback\""));
+    assert!(operations.contains("\"reference\":\"HEAD~1\""));
+
+    let observations = read_observation_log(root.path(), &instance_id);
+    assert!(observations.contains("\"kind\":\"rollback\""));
+
+    let source = fs::read_to_string(root.path().join("skills/model-onboarding/SKILL.md"))
+        .expect("read source skill");
+    assert!(source.contains("example skill"));
+    assert!(!source.contains("source v2"));
+}
+
+#[test]
+fn skill_release_records_operation() {
+    let root = TestDir::new("registry-skill-release-audit");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let (release_output, release_env) = run_loom(
+        root.path(),
+        &["skill", "release", "model-onboarding", "v1.0.0"],
+    );
+    assert!(
+        release_output.status.success(),
+        "release failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&release_output.stderr),
+        String::from_utf8_lossy(&release_output.stdout)
+    );
+    assert_eq!(release_env["ok"], Value::Bool(true));
+    assert_eq!(
+        release_env["meta"]["op_id"]
+            .as_str()
+            .map(|value| !value.is_empty()),
+        Some(true)
+    );
+
+    let operations = read_operations_log(root.path());
+    assert!(operations.contains("\"intent\":\"skill.release\""));
+    assert!(operations.contains("\"version\":\"v1.0.0\""));
 }
 
 #[test]

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -203,6 +203,35 @@ fn skill_rollback_records_operation_and_observation() {
 }
 
 #[test]
+fn skill_rollback_noop_does_not_initialize_registry() {
+    let root = TestDir::new("registry-skill-rollback-noop");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let (rollback_output, rollback_env) = run_loom(
+        root.path(),
+        &["skill", "rollback", "model-onboarding", "--to", "HEAD"],
+    );
+    assert!(
+        rollback_output.status.success(),
+        "rollback noop failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&rollback_output.stderr),
+        String::from_utf8_lossy(&rollback_output.stdout)
+    );
+    assert_eq!(rollback_env["ok"], Value::Bool(true));
+    assert_eq!(rollback_env["data"]["noop"], Value::Bool(true));
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "noop rollback should not create registry state"
+    );
+}
+
+#[test]
 fn skill_release_records_operation() {
     let root = TestDir::new("registry-skill-release-audit");
     write_example_skill(root.path(), "model-onboarding");

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -660,3 +660,71 @@ fn skill_project_rolls_back_operation_log_after_append_failure() {
     assert_eq!(read_operations_log(root.path()), operations_before);
     assert_eq!(read_checkpoint(root.path()), checkpoint_before);
 }
+
+#[test]
+fn skill_project_rolls_back_observation_after_late_audit_failure() {
+    let root = TestDir::new("v3-skill-project-observation-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let operations_before = read_operations_log(root.path());
+    let checkpoint_before = read_checkpoint(root.path());
+
+    let (project_output, project_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_project_after_observation")],
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+            "--method",
+            "copy",
+        ],
+    );
+
+    assert!(
+        !project_output.status.success(),
+        "project unexpectedly succeeded"
+    );
+    assert_eq!(project_env["ok"], Value::Bool(false));
+    assert_eq!(read_operations_log(root.path()), operations_before);
+    assert_eq!(read_checkpoint(root.path()), checkpoint_before);
+
+    let observation_path = root
+        .path()
+        .join("state/registry/observations")
+        .join("inst_model_onboarding_bind_claude_project_a_target_claude_claude_project_a.jsonl");
+    assert!(
+        !observation_path.exists(),
+        "failed project should not leave observation history"
+    );
+}

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -362,6 +362,59 @@ fn skill_rollback_rolls_back_commits_and_worktree_after_late_audit_failure() {
 }
 
 #[test]
+fn skill_rollback_removes_new_registry_layout_after_late_audit_failure() {
+    let root = TestDir::new("registry-skill-rollback-new-layout-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v2\n",
+    );
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "precondition: registry should not exist before rollback"
+    );
+    let head_before = git_head(root.path());
+
+    let (rollback_output, rollback_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_rollback_after_state_commit")],
+        &["skill", "rollback", "model-onboarding", "--to", "HEAD~1"],
+    );
+
+    assert!(
+        !rollback_output.status.success(),
+        "rollback unexpectedly succeeded"
+    );
+    assert_eq!(rollback_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "failed rollback should remove newly-created registry layout"
+    );
+    let source = fs::read_to_string(root.path().join("skills/model-onboarding/SKILL.md"))
+        .expect("read source skill");
+    assert!(source.contains("source v2"));
+    assert_eq!(
+        git_status_short_for(root.path(), &["skills/model-onboarding", "state/registry"]),
+        ""
+    );
+}
+
+#[test]
 fn skill_release_records_operation() {
     let root = TestDir::new("registry-skill-release-audit");
     write_example_skill(root.path(), "model-onboarding");
@@ -393,6 +446,45 @@ fn skill_release_records_operation() {
     let operations = read_operations_log(root.path());
     assert!(operations.contains("\"intent\":\"skill.release\""));
     assert!(operations.contains("\"version\":\"v1.0.0\""));
+}
+
+#[test]
+fn skill_release_removes_new_registry_layout_after_late_failure() {
+    let root = TestDir::new("registry-skill-release-new-layout-rollback");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "precondition: registry should not exist before release"
+    );
+    let head_before = git_head(root.path());
+
+    let (release_output, release_env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_release_after_state_commit")],
+        &["skill", "release", "model-onboarding", "v1.0.0"],
+    );
+
+    assert!(
+        !release_output.status.success(),
+        "release unexpectedly succeeded"
+    );
+    assert_eq!(release_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert!(
+        !git_tag_exists(root.path(), "release/model-onboarding/v1.0.0"),
+        "failed release should delete the release tag"
+    );
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "failed release should remove newly-created registry layout"
+    );
+    assert_eq!(git_status_short_for(root.path(), &["state/registry"]), "");
 }
 
 #[test]

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -271,6 +271,10 @@ fn skill_rollback_noop_does_not_initialize_registry() {
         !root.path().join("state/registry").exists(),
         "noop rollback should not create registry state"
     );
+    assert!(
+        !root.path().join("state/backups").exists(),
+        "noop rollback should not leave skill backups"
+    );
 }
 
 #[test]
@@ -485,6 +489,53 @@ fn skill_release_removes_new_registry_layout_after_late_failure() {
         "failed release should remove newly-created registry layout"
     );
     assert_eq!(git_status_short_for(root.path(), &["state/registry"]), "");
+}
+
+#[test]
+fn skill_release_removes_new_registry_layout_when_tag_creation_fails() {
+    let root = TestDir::new("registry-skill-release-tag-failure");
+    write_example_skill(root.path(), "model-onboarding");
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+    git_output(
+        root.path(),
+        &[
+            "tag",
+            "-a",
+            "release/model-onboarding/v1.0.0",
+            "-m",
+            "existing release",
+        ],
+    );
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "precondition: registry should not exist before release"
+    );
+    let head_before = git_head(root.path());
+
+    let (release_output, release_env) = run_loom(
+        root.path(),
+        &["skill", "release", "model-onboarding", "v1.0.0"],
+    );
+
+    assert!(
+        !release_output.status.success(),
+        "release unexpectedly succeeded"
+    );
+    assert_eq!(release_env["ok"], Value::Bool(false));
+    assert_eq!(git_head(root.path()), head_before);
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "failed release should remove newly-created registry layout"
+    );
+    assert!(
+        !root.path().join("state/backups").exists(),
+        "failed release should remove registry layout backups"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- append registry observation events for project, capture, rollback, release, and monitor-observed skill lifecycle paths
- record durable registry operations for skill rollback and skill release
- show rollback lifecycle events distinctly in the panel
- add regression tests for project/capture observations and rollback/release ops logging

Closes #72
Closes #73

## Verification
- cargo fmt -- --check
- cargo check -q
- cargo test -q --test project
- cargo test -q --test capture
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings
- cd panel && npm run typecheck (Node v22.13.0)
- cd panel && npm run test (Node v22.13.0)
- cd panel && npm run build (Node v22.13.0)