### PR TITLE
fix(target): default ownership to observed

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ loom panel [--port 43117]
 
 Most commands support compact `--json` for machine-readable output; add `--pretty` when you want formatted JSON for inspection. Commands default to `~/.loom-registry`; use `--root <dir>` to override that registry.
 
+`target add` defaults to `--ownership observed`; pass `--ownership managed` only for directories Loom is allowed to write.
+
 </details>
 
 ### Multi-Directory Example (Claude)

--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -287,7 +287,7 @@ Rules:
 loom --json --root <root> target add \
   --agent <agent> \
   --path <dir> \
-  --ownership <managed|observed|external>
+  [--ownership <managed|observed|external>]
 ```
 
 Write command.
@@ -295,7 +295,7 @@ Write command.
 Rules:
 
 1. registration does not project anything
-2. `ownership` must be explicit
+2. `ownership` defaults to `observed`; pass `managed` only for directories Loom may write
 
 ### 10.2 `target list`
 

--- a/docs/LOOM_COMPLETE_GUIDE_ZH.md
+++ b/docs/LOOM_COMPLETE_GUIDE_ZH.md
@@ -62,10 +62,13 @@ loom --json --root ~/loom-registry skill add /path/to/my-skill --name my-skill
 ### 5.3 注册 target（支持多目录）
 
 ```bash
-loom --json --root ~/loom-registry target add --agent claude --path "$HOME/.claude/skills" --ownership managed
-loom --json --root ~/loom-registry target add --agent claude --path "$HOME/.claude-work/skills" --ownership managed
-loom --json --root ~/loom-registry target add --agent codex --path "$HOME/.codex/skills" --ownership managed
+mkdir -p "$HOME/.loom-targets/claude/skills" "$HOME/.loom-targets/claude-work/skills" "$HOME/.loom-targets/codex/skills"
+loom --json --root ~/loom-registry target add --agent claude --path "$HOME/.loom-targets/claude/skills" --ownership managed
+loom --json --root ~/loom-registry target add --agent claude --path "$HOME/.loom-targets/claude-work/skills" --ownership managed
+loom --json --root ~/loom-registry target add --agent codex --path "$HOME/.loom-targets/codex/skills" --ownership managed
 ```
+
+已有的 agent skill 目录（例如 `~/.claude/skills`、`~/.codex/skills`）默认应使用 `observed`，不要注册成 `managed`。
 
 ### 5.4 绑定 workspace 到默认 target
 

--- a/docs/LOOM_STATE_MODEL.md
+++ b/docs/LOOM_STATE_MODEL.md
@@ -347,6 +347,8 @@ loom target show <target-id>
 loom target remove <target-id>
 ```
 
+`target add` defaults to `observed` ownership.
+
 ### 11.3 Skill
 
 ```bash

--- a/panel/src/components/panel/forms/TargetAddForm.tsx
+++ b/panel/src/components/panel/forms/TargetAddForm.tsx
@@ -13,7 +13,7 @@ interface TargetAddFormProps {
 export function TargetAddForm({ onCancel, onSuccess }: TargetAddFormProps) {
   const [agent, setAgent] = useState<string>(AGENT_OPTIONS[0].slug);
   const [path, setPath] = useState("");
-  const [ownership, setOwnership] = useState<Ownership>("managed");
+  const [ownership, setOwnership] = useState<Ownership>("observed");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -369,7 +369,7 @@ pub struct TargetAddArgs {
     pub path: String,
 
     /// Whether Loom can write to this target.
-    #[arg(long, value_enum, default_value_t = TargetOwnership::Managed)]
+    #[arg(long, value_enum, default_value_t = TargetOwnership::Observed)]
     pub ownership: TargetOwnership,
 }
 

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -323,7 +323,7 @@ pub(super) async fn registry_target_add(
             command: TargetCommand::Add(crate::cli::TargetAddArgs {
                 agent: req.agent,
                 path: req.path,
-                ownership: req.ownership.unwrap_or(TargetOwnership::Managed),
+                ownership: req.ownership.unwrap_or(TargetOwnership::Observed),
             }),
         },
     )

--- a/tests/common/actions.rs
+++ b/tests/common/actions.rs
@@ -26,6 +26,11 @@ pub fn target_add(root: &Path, agent: &str, path: &Path, ownership: &str) -> (Ou
     )
 }
 
+pub fn target_add_with_default_ownership(root: &Path, agent: &str, path: &Path) -> (Output, Value) {
+    let path = path.to_string_lossy().into_owned();
+    run_loom(root, &["target", "add", "--agent", agent, "--path", &path])
+}
+
 pub fn binding_add(
     root: &Path,
     agent: &str,

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use common::actions::{binding_add, target_add};
+use common::actions::{binding_add, target_add, target_add_with_default_ownership};
 use serde_json::Value;
 
 use common::{TestDir, run_loom, run_loom_with_env, write_minimal_registry_state};
@@ -81,6 +81,39 @@ fn target_add_bootstraps_registry_state_and_records_op() {
         "managed target path should be created"
     );
     assert!(root.path().join("state/registry/schema.json").exists());
+}
+
+#[test]
+fn target_add_defaults_to_observed_ownership() {
+    let root = TestDir::new("registry-target-add-default-observed");
+    let target_path = root.path().join("live/claude-project-a");
+    fs::create_dir_all(&target_path).expect("create observed target path");
+
+    let (output, env) = target_add_with_default_ownership(root.path(), "claude", &target_path);
+
+    assert!(
+        output.status.success(),
+        "loom failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert_eq!(
+        env["data"]["target"]["ownership"],
+        Value::String("observed".to_string())
+    );
+    assert_eq!(
+        env["data"]["target"]["capabilities"]["symlink"],
+        Value::Bool(false)
+    );
+    assert_eq!(
+        env["data"]["target"]["capabilities"]["copy"],
+        Value::Bool(false)
+    );
+    assert_eq!(
+        env["data"]["target"]["capabilities"]["watch"],
+        Value::Bool(true)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- default `loom target add` ownership to `observed` instead of `managed`
- keep panel target creation defaults aligned with the CLI/API default
- document that `managed` should be explicit for Loom-writable directories, and cover the new default with a regression test

## Why
`managed` lets Loom write to the target path. Existing agent skill directories and `workspace init --scan-existing` targets are safer as `observed`, while managed projection flows already pass `--ownership managed` explicitly.

Closes #87

## Validation
- `cargo fmt -- --check`
- `cargo check -q`
- `cargo test -q --test write target_add_defaults_to_observed_ownership`
- `cargo test -q`
- `npm run typecheck` (Node v22.13.0)
- `npm run test` (Node v22.13.0)
- `npm run build` (Node v22.13.0)
- `git diff --check`
