### PR TITLE
Add skill orphan list command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,6 +147,8 @@ pub enum SkillCommand {
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum SkillOrphanCommand {
+    #[command(about = "List orphaned projection records")]
+    List,
     #[command(about = "Remove orphaned projection records (and optionally their live files)")]
     Clean(OrphanCleanArgs),
 }

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -126,6 +126,9 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
             SkillCommand::Rollback(_) => "skill.rollback",
             SkillCommand::Diff(_) => "skill.diff",
             SkillCommand::Orphan {
+                command: SkillOrphanCommand::List,
+            } => "skill.orphan.list",
+            SkillCommand::Orphan {
                 command: SkillOrphanCommand::Clean(_),
             } => "skill.orphan.clean",
         },

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -150,6 +150,9 @@ impl App {
                 SkillCommand::Rollback(args) => self.cmd_rollback(args, &request_id),
                 SkillCommand::Diff(args) => self.cmd_diff(args),
                 SkillCommand::Orphan {
+                    command: SkillOrphanCommand::List,
+                } => self.cmd_skill_orphan_list(),
+                SkillCommand::Orphan {
                     command: SkillOrphanCommand::Clean(args),
                 } => self.cmd_skill_orphan_clean(args, &request_id),
             },

--- a/src/commands/workspace_cmds.rs
+++ b/src/commands/workspace_cmds.rs
@@ -124,6 +124,10 @@ fn cleanup_orphan_live_path(
     ))
 }
 
+fn is_orphan_projection(projection: &RegistryProjectionInstance) -> bool {
+    projection.binding_id.is_none() && projection.health == "orphaned"
+}
+
 impl App {
     pub fn cmd_status(&self) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
         let skill_inventory = collect_skill_inventory(&self.ctx);
@@ -659,7 +663,7 @@ impl App {
         let mut retained = Vec::new();
 
         for proj in snapshot.projections.projections.drain(..) {
-            if proj.binding_id.is_none() && proj.health == "orphaned" {
+            if is_orphan_projection(&proj) {
                 if args.delete_live_paths {
                     match cleanup_orphan_live_path(&proj, &target_paths)? {
                         LivePathCleanup::Deleted(path) => deleted_paths.push(path),
@@ -729,6 +733,51 @@ impl App {
                 op_id: Some(op_id),
                 ..Meta::default()
             },
+        ))
+    }
+
+    pub fn cmd_skill_orphan_list(
+        &self,
+    ) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
+        let snapshot = self.require_registry_snapshot()?;
+        let projections = snapshot
+            .projections
+            .projections
+            .iter()
+            .filter(|projection| is_orphan_projection(projection))
+            .map(|projection| {
+                json!({
+                    "instance_id": projection.instance_id,
+                    "skill_id": projection.skill_id,
+                    "binding_id": projection.binding_id,
+                    "target_id": projection.target_id,
+                    "materialized_path": projection.materialized_path,
+                    "method": projection.method,
+                    "last_applied_rev": projection.last_applied_rev,
+                    "health": projection.health,
+                    "observed_drift": projection.observed_drift,
+                    "live_path_exists": Path::new(&projection.materialized_path).exists(),
+                    "updated_at": projection.updated_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        let orphaned_projection_ids = projections
+            .iter()
+            .filter_map(|projection| projection["instance_id"].as_str().map(str::to_string))
+            .collect::<Vec<_>>();
+        let orphaned_paths = projections
+            .iter()
+            .filter_map(|projection| projection["materialized_path"].as_str().map(str::to_string))
+            .collect::<Vec<_>>();
+
+        Ok((
+            json!({
+                "count": projections.len(),
+                "orphaned_projection_ids": orphaned_projection_ids,
+                "orphaned_paths": orphaned_paths,
+                "projections": projections,
+            }),
+            Meta::default(),
         ))
     }
 

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -302,6 +302,21 @@ fn skill_orphan_clean_nested_command_is_available() {
 }
 
 #[test]
+fn skill_orphan_list_nested_command_is_available() {
+    let output = Command::new(env!("CARGO_BIN_EXE_loom"))
+        .args(["skill", "orphan", "list", "--help"])
+        .output()
+        .expect("run loom");
+
+    assert!(
+        output.status.success(),
+        "orphan list help failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn skill_monitor_observed_command_is_available() {
     let output = Command::new(env!("CARGO_BIN_EXE_loom"))
         .args(["skill", "monitor-observed", "--help"])
@@ -382,7 +397,7 @@ fn skill_help_describes_every_subcommand() {
 }
 
 #[test]
-fn skill_orphan_help_describes_clean_subcommand() {
+fn skill_orphan_help_describes_subcommands() {
     let output = Command::new(env!("CARGO_BIN_EXE_loom"))
         .args(["skill", "orphan", "--help"])
         .output()
@@ -396,6 +411,10 @@ fn skill_orphan_help_describes_clean_subcommand() {
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("List orphaned projection records"),
+        "skill orphan help missing list description: {stdout}"
+    );
     assert!(
         stdout.contains("Remove orphaned projection records (and optionally their live files)"),
         "skill orphan help missing clean description: {stdout}"

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -42,7 +42,7 @@ fn bootstrap_projected_skill(root: &Path) -> (String, String, String) {
 #[test]
 fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
     let root = TestDir::new("registry-binding-remove");
-    let (target_id, binding_id, _instance_id) = bootstrap_projected_skill(root.path());
+    let (target_id, binding_id, instance_id) = bootstrap_projected_skill(root.path());
 
     let live_projection = root.path().join("live/claude-a/demo/SKILL.md");
     assert!(
@@ -81,6 +81,38 @@ fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
     assert!(
         live_projection.exists(),
         "live projection must be left in place"
+    );
+
+    let (orphan_list_output, orphan_list_env) = run_loom(root.path(), &["skill", "orphan", "list"]);
+    assert!(
+        orphan_list_output.status.success(),
+        "orphan list failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&orphan_list_output.stderr),
+        String::from_utf8_lossy(&orphan_list_output.stdout)
+    );
+    assert_eq!(orphan_list_env["ok"], Value::Bool(true));
+    assert_eq!(
+        orphan_list_env["cmd"],
+        Value::String("skill.orphan.list".to_string())
+    );
+    assert_eq!(orphan_list_env["data"]["count"], Value::from(1));
+    assert_eq!(
+        orphan_list_env["data"]["orphaned_projection_ids"][0],
+        Value::String(instance_id)
+    );
+    assert_eq!(
+        orphan_list_env["data"]["orphaned_paths"][0],
+        Value::String(root.path().join("live/claude-a/demo").display().to_string())
+    );
+    assert_eq!(
+        orphan_list_env["data"]["projections"][0]["live_path_exists"],
+        Value::Bool(true)
+    );
+    assert!(
+        !orphan_list_env["meta"]
+            .as_object()
+            .is_some_and(|meta| meta.contains_key("op_id")),
+        "read-only orphan list must not report an operation id"
     );
 
     let (_, binding_list_env) = run_loom(root.path(), &["workspace", "binding", "list"]);


### PR DESCRIPTION
## Summary
- add read-only `loom skill orphan list` for orphaned projection records
- share the orphan predicate with `skill orphan clean`
- cover CLI help and binding-removal list output, including no read-only op_id

## Verification
- `cargo fmt --check`
- `cargo test --test cli_surface --test remove`
- `make ci`

Refs #98