### PR TITLE
Add Panel orphan cleanup

### DIFF
--- a/docs/LOOM_ARCHITECTURE_DECISIONS.md
+++ b/docs/LOOM_ARCHITECTURE_DECISIONS.md
@@ -116,7 +116,7 @@ This decision does not make the panel the primary control plane. The CLI remains
 
 ### 4.1 Mutation Route Table (v1 phase 1 frozen surface)
 
-The following 13 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
+The following 14 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
 
 | cmd name                 | HTTP | path                                    | CLI command                  |
 |--------------------------|------|-----------------------------------------|------------------------------|
@@ -126,6 +126,7 @@ The following 13 routes are the complete mutation surface for phase 1. Every row
 | workspace.binding.remove | POST | /api/registry/bindings/{binding_id}/remove    | Workspace::Binding::Remove   |
 | skill.project            | POST | /api/registry/project                         | Skill::Project               |
 | skill.capture            | POST | /api/registry/capture                         | Skill::Capture               |
+| skill.orphan.clean       | POST | /api/registry/orphans/clean                   | Skill::Orphan::Clean         |
 | workspace.remote.set     | POST | /api/remote/set                         | Workspace::Remote::Set       |
 | ops.retry                | POST | /api/ops/retry                          | Ops::Retry                   |
 | ops.purge                | POST | /api/ops/purge                          | Ops::Purge                   |

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -270,6 +270,10 @@ export interface CaptureBody {
   message?: string;
 }
 
+export interface OrphanCleanBody {
+  delete_live_paths?: boolean;
+}
+
 export interface HistoryRepairBody {
   strategy: "local" | "remote";
 }
@@ -360,6 +364,7 @@ export const api = {
   skillAdd: (body: SkillAddBody) => postJson("/api/registry/skills", body),
   project: (body: ProjectBody) => postJson("/api/registry/project", body),
   capture: (body: CaptureBody) => postJson("/api/registry/capture", body),
+  orphanClean: (body: OrphanCleanBody) => postJson("/api/registry/orphans/clean", body),
 
   syncPush: () => postJson("/api/sync/push", {}),
   syncPull: () => postJson("/api/sync/pull", {}),

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -187,6 +187,7 @@ export function PanelApp() {
         <BindingsPage
           bindings={bindings}
           targets={targets}
+          projections={live.projections}
           onMutation={onMutation}
           readOnly={readOnly}
           mutationVersion={mutationVersion}

--- a/panel/src/pages/panel/BindingsPage.tsx
+++ b/panel/src/pages/panel/BindingsPage.tsx
@@ -5,19 +5,40 @@ import { PlusIcon } from "../../components/icons/nav_icons";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
 import { api, ApiError, type BindingShowPayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
 
 interface BindingsPageProps {
   bindings: Binding[];
   targets: Target[];
+  projections?: RegistryProjection[];
   onMutation: () => void;
   readOnly: boolean;
   mutationVersion: number;
 }
 
-export function BindingsPage({ bindings, targets, onMutation, readOnly, mutationVersion }: BindingsPageProps) {
+export function BindingsPage({
+  bindings,
+  targets,
+  projections = [],
+  onMutation,
+  readOnly,
+  mutationVersion,
+}: BindingsPageProps) {
   const [addOpen, setAddOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [deleteLivePaths, setDeleteLivePaths] = useState(false);
   const sel = bindings.find((b) => b.id === selectedId) ?? null;
+  const cleanOrphans = useMutation();
+  const orphanProjections = projections.filter((p) => !p.binding_id && p.health === "orphaned");
+
+  const runCleanOrphans = () => {
+    if (readOnly || orphanProjections.length === 0) return;
+    cleanOrphans.run(
+      "clean orphaned projections",
+      () => api.orphanClean({ delete_live_paths: deleteLivePaths }),
+      onMutation,
+    );
+  };
 
   useEffect(() => {
     if (readOnly) setAddOpen(false);
@@ -45,6 +66,62 @@ export function BindingsPage({ bindings, targets, onMutation, readOnly, mutation
         </div>
       </div>
       <div className="page-body" style={{ padding: 0 }}>
+        {orphanProjections.length > 0 && (
+          <div
+            style={{
+              margin: "0 28px 12px",
+              padding: "10px 12px",
+              borderRadius: 6,
+              border: "1px solid rgba(216,167,50,0.35)",
+              background: "rgba(216,167,50,0.08)",
+              display: "flex",
+              gap: 12,
+              alignItems: "center",
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ minWidth: 220 }}>
+              <div style={{ color: "var(--warn)", fontWeight: 700, fontSize: 12 }}>
+                {orphanProjections.length} orphaned projection{orphanProjections.length === 1 ? "" : "s"}
+              </div>
+              <div className="mono" style={{ color: "var(--ink-2)", fontSize: 11, marginTop: 3 }}>
+                {orphanProjections.map((p) => p.instance_id).join(", ")}
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+              <label className="row-flex" style={{ fontSize: 12, color: "var(--ink-2)" }}>
+                <input
+                  type="checkbox"
+                  checked={deleteLivePaths}
+                  onChange={(event) => setDeleteLivePaths(event.currentTarget.checked)}
+                  disabled={readOnly || cleanOrphans.busy}
+                />
+                Delete live paths
+              </label>
+              <button
+                className="btn ghost danger"
+                onClick={runCleanOrphans}
+                disabled={readOnly || cleanOrphans.busy}
+                title={readOnly ? "registry offline" : "clean orphaned projection metadata"}
+              >
+                {cleanOrphans.busy ? "Cleaning..." : "Clean metadata"}
+              </button>
+            </div>
+            {(cleanOrphans.error || cleanOrphans.success) && (
+              <div
+                className="mono"
+                style={{
+                  flexBasis: "100%",
+                  color: cleanOrphans.error ? "var(--err)" : "var(--ok)",
+                  fontSize: 11,
+                }}
+              >
+                {cleanOrphans.error ?? cleanOrphans.success}
+              </div>
+            )}
+          </div>
+        )}
         {addOpen && (
           <div style={{ padding: "0 28px 12px" }}>
             <BindingAddForm
@@ -151,7 +228,6 @@ function BindingDetail({
   onRemoved: (bindingId: string) => void;
 }) {
   const [state, setState] = useState<DetailState>({ kind: "idle" });
-  const [orphanedIds, setOrphanedIds] = useState<string[]>([]);
   const project = useMutation();
   const remove = useMutation();
 
@@ -205,16 +281,10 @@ function BindingDetail({
   const runRemove = () => {
     if (readOnly) return;
     if (!window.confirm(`Delete binding ${binding.id}? This removes the binding metadata from the registry.`)) return;
-    let orphaned: string[] = [];
     remove.run(
       "delete binding",
-      async () => {
-        const res = await api.bindingRemove(binding.id);
-        const ids = res.data?.orphaned_projection_ids;
-        if (Array.isArray(ids)) orphaned = ids as string[];
-      },
+      () => api.bindingRemove(binding.id),
       () => {
-        if (orphaned.length > 0) setOrphanedIds(orphaned);
         onRemoved(binding.id);
         onMutation();
       },
@@ -253,31 +323,6 @@ function BindingDetail({
           {remove.busy ? "Deleting…" : "Delete binding"}
         </button>
       </div>
-      {orphanedIds.length > 0 && (
-        <div
-          style={{
-            marginBottom: 12,
-            padding: "6px 10px",
-            borderRadius: 6,
-            border: "1px solid rgba(216,167,50,0.35)",
-            background: "rgba(216,167,50,0.08)",
-            color: "var(--warn)",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-          }}
-        >
-          {orphanedIds.length} projection(s) orphaned: {orphanedIds.join(", ")}
-          {" — run "}
-          <span style={{ fontWeight: 600 }}>loom skill orphan clean</span>
-          {" to remove metadata."}
-          <button
-            style={{ marginLeft: 10, cursor: "pointer", background: "none", border: "none", color: "inherit", textDecoration: "underline", fontSize: "inherit", fontFamily: "inherit", padding: 0 }}
-            onClick={() => setOrphanedIds([])}
-          >
-            dismiss
-          </button>
-        </div>
-      )}
       {(project.error || project.success || remove.error || remove.success) && (
         <div
           style={{

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -11,6 +11,7 @@ import { OverviewPage } from "./OverviewPage";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
 import { api, type BindingShowPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
 import type { Binding, Skill, Target } from "../../lib/types";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
 
 const originalWindow = (globalThis as { window?: unknown }).window;
 const originalLocalStorage = (globalThis as { localStorage?: unknown }).localStorage;
@@ -111,6 +112,18 @@ function makeSkill(): Skill {
     ruleCount: 1,
     changed: "now",
     targets: ["target-1"],
+  };
+}
+
+function makeOrphanProjection(): RegistryProjection {
+  return {
+    instance_id: "inst-orphan",
+    skill_id: "skill.writer",
+    target_id: "target-1",
+    materialized_path: "/tmp/inst-orphan",
+    method: "copy",
+    last_applied_rev: "deadbeefcafebabe",
+    health: "orphaned",
   };
 }
 
@@ -360,6 +373,54 @@ test("BindingsPage refetches selected binding details after a successful project
   } finally {
     api.bindingShow = originalBindingShow;
     api.project = originalProject;
+  }
+});
+
+test("BindingsPage exposes orphan cleanup from live projection data", async () => {
+  const originalOrphanClean = api.orphanClean;
+  const calls: Array<{ delete_live_paths?: boolean }> = [];
+  let mutations = 0;
+
+  api.orphanClean = async (body) => {
+    calls.push(body);
+    return {
+      ok: true,
+      cmd: "skill.orphan.clean",
+      request_id: "req-orphan",
+      data: { cleaned_count: 1 },
+    };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <BindingsPage
+          bindings={[makeBinding()]}
+          targets={[makeTarget()]}
+          projections={[makeOrphanProjection()]}
+          readOnly={false}
+          mutationVersion={0}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+
+    expect(markup(renderer!).includes("inst-orphan")).toBe(true);
+    expect(markup(renderer!).includes("orphaned projection")).toBe(true);
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Clean metadata").props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(calls).toEqual([{ delete_live_paths: false }]);
+    expect(mutations).toBe(1);
+  } finally {
+    api.orphanClean = originalOrphanClean;
   }
 });
 

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -10,8 +10,8 @@ use serde_json::json;
 
 use crate::cli::{
     AddArgs, CaptureArgs, Command, HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand,
-    ProjectArgs, ProjectionMethod, RemoteCommand, SyncCommand, TargetCommand, TargetOwnership,
-    WorkspaceBindingCommand, WorkspaceCommand,
+    OrphanCleanArgs, ProjectArgs, ProjectionMethod, RemoteCommand, SkillOrphanCommand, SyncCommand,
+    TargetCommand, TargetOwnership, WorkspaceBindingCommand, WorkspaceCommand,
 };
 use crate::commands::{
     App, CommandFailure, collect_skill_inventory, redact_sensitive_string, remote_status_payload,
@@ -26,8 +26,8 @@ use super::auth::{
     status_for_registry_error_payload,
 };
 use super::{
-    BindingAddRequest, CaptureRequest, HistoryRepairRequest, PanelState, ProjectRequest,
-    RemoteSetRequest, SkillAddRequest, TargetAddRequest,
+    BindingAddRequest, CaptureRequest, HistoryRepairRequest, OrphanCleanRequest, PanelState,
+    ProjectRequest, RemoteSetRequest, SkillAddRequest, TargetAddRequest,
 };
 
 /// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The core CLI path enforces
@@ -668,6 +668,30 @@ pub(super) async fn registry_capture(
                 instance: req.instance,
                 message: req.message,
             }),
+        },
+    )
+}
+
+pub(super) async fn registry_orphan_clean(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<OrphanCleanRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "skill.orphan.clean")
+    {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "skill.orphan.clean",
+        StatusCode::OK,
+        Command::Skill {
+            command: crate::cli::SkillCommand::Orphan {
+                command: SkillOrphanCommand::Clean(OrphanCleanArgs {
+                    delete_live_paths: req.delete_live_paths,
+                }),
+            },
         },
     )
 }

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -89,6 +89,12 @@ pub(super) struct RemoteSetRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct OrphanCleanRequest {
+    #[serde(default)]
+    pub(super) delete_live_paths: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct DiffParams {
     #[serde(default)]
     pub(super) rev_a: Option<String>,
@@ -146,6 +152,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/registry/skills", post(registry_skill_add))
         .route("/api/registry/project", post(registry_project))
         .route("/api/registry/capture", post(registry_capture))
+        .route("/api/registry/orphans/clean", post(registry_orphan_clean))
         .route(
             "/api/registry/skills/{skill_name}/diff",
             get(registry_skill_diff),

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -1,9 +1,12 @@
 use super::*;
 use crate::panel::handlers::{
-    OpsQuery, info, pending, registry_ops, remote_set, remote_status, v1_overview, v1_registry_ops,
-    v1_registry_targets, v1_workspace_status,
+    OpsQuery, info, pending, registry_ops, registry_orphan_clean, remote_set, remote_status,
+    v1_overview, v1_registry_ops, v1_registry_targets, v1_workspace_status,
 };
-use crate::state_model::{REGISTRY_SCHEMA_VERSION, RegistryOperationRecord};
+use crate::state_model::{
+    REGISTRY_SCHEMA_VERSION, RegistryOperationRecord, RegistryProjectionInstance,
+    RegistryProjectionsFile,
+};
 use axum::{
     Json,
     extract::{ConnectInfo, Query},
@@ -311,6 +314,57 @@ async fn remote_set_configures_origin_from_authorized_panel_request() {
     assert_eq!(remote_status_code, StatusCode::OK);
     assert_eq!(remote_payload["data"]["remote"]["configured"], json!(true));
     assert_eq!(remote_payload["data"]["remote"]["url"], json!(url));
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
+async fn registry_orphan_clean_uses_cli_envelope_and_records_operation() {
+    let (root, state) = make_test_state();
+    write_registry_snapshot(&root, REGISTRY_SCHEMA_VERSION);
+    let paths = RegistryStatePaths::from_root(&root);
+    fs::write(
+        &paths.projections_file,
+        serde_json::to_vec_pretty(&RegistryProjectionsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            projections: vec![RegistryProjectionInstance {
+                instance_id: "inst-orphan".to_string(),
+                skill_id: "skill.writer".to_string(),
+                binding_id: None,
+                target_id: "target-1".to_string(),
+                materialized_path: root.join("live/skill.writer").display().to_string(),
+                method: "copy".to_string(),
+                last_applied_rev: "deadbeef".to_string(),
+                health: "orphaned".to_string(),
+                observed_drift: Some(false),
+                updated_at: Some(Utc::now()),
+            }],
+        })
+        .expect("serialize orphan projection"),
+    )
+    .expect("write orphan projection");
+
+    let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000);
+    let mut headers = HeaderMap::new();
+    headers.insert("origin", HeaderValue::from_static("http://127.0.0.1:43117"));
+
+    let (status, Json(payload)) = registry_orphan_clean(
+        ConnectInfo(peer),
+        headers,
+        State(state),
+        Json(super::super::OrphanCleanRequest {
+            delete_live_paths: false,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{payload}");
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("skill.orphan.clean"));
+    assert_eq!(payload["data"]["cleaned_count"], json!(1));
+    assert!(payload["meta"]["op_id"].as_str().is_some());
+    let snapshot = paths.load_snapshot().expect("load snapshot");
+    assert!(snapshot.projections.projections.is_empty());
 
     cleanup_root(root);
 }

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 // Exhaustive list of every panel mutation command. Must stay in sync with the
-// 13-row table in docs/LOOM_ARCHITECTURE_DECISIONS.md section 4.1 and the
+// 14-row table in docs/LOOM_ARCHITECTURE_DECISIONS.md section 4.1 and the
 // route registrations in `run_panel`.
 const MUTATION_COMMANDS: &[&str] = &[
     "target.add",
@@ -22,6 +22,7 @@ const MUTATION_COMMANDS: &[&str] = &[
     "workspace.binding.remove",
     "skill.project",
     "skill.capture",
+    "skill.orphan.clean",
     "workspace.remote.set",
     "ops.retry",
     "ops.purge",
@@ -32,8 +33,8 @@ const MUTATION_COMMANDS: &[&str] = &[
 ];
 
 #[test]
-fn mutation_commands_count_is_thirteen() {
-    assert_eq!(MUTATION_COMMANDS.len(), 13);
+fn mutation_commands_count_is_fourteen() {
+    assert_eq!(MUTATION_COMMANDS.len(), 14);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- surface orphaned projections on the Bindings page from live registry projection data
- add authorized Panel `skill.orphan.clean` mutation route backed by the CLI command
- update mutation-route contract docs and backend/frontend tests

## Verification
- `cargo test -q panel::tests::handlers`
- `cargo test -q panel::tests::security`
- `cd panel && bun install --frozen-lockfile && bun run test -- panel_state`
- `cd panel && bun run typecheck`
- `make ci`
- local Panel smoke on http://127.0.0.1:43119 with an orphaned projection

Refs #98