### PR TITLE
Add Panel doctor page

### DIFF
--- a/panel/src/components/panel/Sidebar.tsx
+++ b/panel/src/components/panel/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   HomeIcon,
   OpsIcon,
   SettingsIcon,
+  ShieldIcon,
   SkillIcon,
   TargetIcon,
 } from "../icons/nav_icons";
@@ -49,6 +50,7 @@ export function Sidebar({ page, setPage, compact, counts, registryRoot }: Sideba
   const admin: NavEntry[] = [
     { key: "history", label: "Audit log", icon: HistoryIcon },
     { key: "sync", label: "Git sync", icon: GitIcon },
+    { key: "doctor", label: "Doctor", icon: ShieldIcon },
     { key: "settings", label: "Settings", icon: SettingsIcon },
   ];
 

--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -13,6 +13,7 @@ const CRUMBS: Record<PanelPageKey, string> = {
   ops: "Activity",
   history: "Audit log",
   sync: "Git sync",
+  doctor: "Doctor",
   settings: "Settings",
 };
 

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -325,11 +325,29 @@ export interface SkillHistoryPayload {
   meta?: { warnings?: string[] };
 }
 
+export interface DoctorCheck {
+  section: string;
+  id: string;
+  ok: boolean;
+  severity: "ok" | "warning" | "error" | string;
+  message: string;
+  next_action?: string | null;
+  details?: Record<string, unknown>;
+}
+
+export interface DoctorPayload {
+  healthy: boolean;
+  checks_v1: DoctorCheck[];
+  checks?: Record<string, unknown>;
+}
+
 export const api = {
   health: (signal?: AbortSignal) => getJson<HealthPayload>("/api/health", signal),
   info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/info", signal),
   skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/skills", signal),
   registryStatus: (signal?: AbortSignal) => getJson<RegistryPayload>("/api/registry/status", signal),
+  workspaceDoctor: (signal?: AbortSignal) =>
+    getJsonData<DoctorPayload>("/api/v1/workspace/doctor", signal),
   opsHistoryDiagnose: (signal?: AbortSignal) =>
     getJson<OpsHistoryDiagnosePayload>("/api/registry/ops/diagnose", signal),
   ops: (options?: { limit?: number; offset?: number }, signal?: AbortSignal) => {

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -84,6 +84,7 @@ export type PanelPageKey =
   | "ops"
   | "history"
   | "sync"
+  | "doctor"
   | "settings";
 
 export type VizMode = "loom" | "force" | "tree";

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -12,6 +12,7 @@ import { HistoryPage } from "./panel/HistoryPage";
 import { OpsPage } from "./panel/OpsPage";
 import { SettingsPage } from "./panel/SettingsPage";
 import { SyncPage } from "./panel/SyncPage";
+import { DoctorPage } from "./panel/DoctorPage";
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -32,6 +33,7 @@ const VALID_PAGES: PanelPageKey[] = [
   "ops",
   "history",
   "sync",
+  "doctor",
   "settings",
 ];
 
@@ -217,6 +219,9 @@ export function PanelApp() {
           onMutation={onMutation}
         />
       );
+      break;
+    case "doctor":
+      view = <DoctorPage live={live.live} mode={live.mode} refreshKey={live.lastUpdated} />;
       break;
     case "settings":
       view = <SettingsPage live={live.live} mode={live.mode} registryRoot={live.registryRoot} />;

--- a/panel/src/pages/panel/DoctorPage.tsx
+++ b/panel/src/pages/panel/DoctorPage.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from "react";
+import { RefreshIcon, ShieldIcon } from "../../components/icons/nav_icons";
+import { api, ApiError, type DoctorCheck, type DoctorPayload } from "../../lib/api/client";
+import type { PanelDataMode } from "../../lib/api/usePanelData";
+
+interface DoctorPageProps {
+  live: boolean;
+  mode: PanelDataMode;
+  refreshKey: string | null;
+}
+
+type DoctorState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; payload: DoctorPayload }
+  | { kind: "error"; message: string };
+
+export function DoctorPage({ live, mode, refreshKey }: DoctorPageProps) {
+  const [state, setState] = useState<DoctorState>({ kind: "idle" });
+  const [manualTick, setManualTick] = useState(0);
+
+  useEffect(() => {
+    if (!live) {
+      setState({ kind: "idle" });
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({ kind: "loading" });
+    api
+      .workspaceDoctor(controller.signal)
+      .then((payload) => {
+        if (controller.signal.aborted) return;
+        setState({ kind: "ready", payload });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => controller.abort();
+  }, [live, refreshKey, manualTick]);
+
+  const checks = state.kind === "ready" ? state.payload.checks_v1 ?? [] : [];
+  const failed = checks.filter((check) => !check.ok);
+  const grouped = useMemo(() => groupChecks(checks), [checks]);
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Doctor</h1>
+          <div className="subtitle">Live registry health from the workspace doctor contract.</div>
+        </div>
+        <div className="header-actions">
+          <button className="btn ghost" onClick={() => setManualTick((cur) => cur + 1)} disabled={!live || state.kind === "loading"}>
+            <RefreshIcon /> {state.kind === "loading" ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+      </div>
+      <div className="page-body">
+        {!live && (
+          <div className="empty" style={{ marginBottom: 16 }}>
+            {mode === "offline-stale"
+              ? "Doctor is paused while the live API is offline."
+              : "Doctor needs the live panel API."}
+          </div>
+        )}
+        {state.kind === "error" && (
+          <div className="empty" style={{ marginBottom: 16, color: "var(--err)" }}>
+            {state.message}
+          </div>
+        )}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 18 }}>
+          <Kpi
+            label="Health"
+            value={state.kind === "ready" ? (state.payload.healthy ? "healthy" : "attention") : state.kind}
+            tone={state.kind === "ready" && !state.payload.healthy ? "err" : undefined}
+          />
+          <Kpi label="Checks" value={checks.length} />
+          <Kpi label="Needs action" value={failed.length} tone={failed.length > 0 ? "pending" : undefined} />
+        </div>
+
+        {state.kind === "loading" && <div className="empty mono">loading...</div>}
+        {state.kind === "ready" && checks.length === 0 && <div className="empty">No doctor checks returned.</div>}
+        {state.kind === "ready" && checks.length > 0 && (
+          <div style={{ display: "grid", gap: 12 }}>
+            {grouped.map(([section, sectionChecks]) => (
+              <div className="card" key={section}>
+                <div className="card-head">
+                  <h3>{sectionLabel(section)}</h3>
+                  <span className={`chip ${sectionChecks.every((check) => check.ok) ? "ok" : "warn"}`}>
+                    {sectionChecks.filter((check) => !check.ok).length} / {sectionChecks.length}
+                  </span>
+                </div>
+                <div className="card-body" style={{ padding: 0 }}>
+                  <table className="tbl" style={{ fontSize: 12 }}>
+                    <tbody>
+                      {sectionChecks.map((check) => (
+                        <DoctorRow key={check.id} check={check} />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function DoctorRow({ check }: { check: DoctorCheck }) {
+  return (
+    <tr>
+      <td style={{ width: 170 }}>
+        <span className="row-flex">
+          <ShieldIcon />
+          <span className="mono dim">{check.id}</span>
+        </span>
+      </td>
+      <td style={{ width: 96 }}>
+        <span className={`chip ${check.ok ? "ok" : check.severity === "warning" ? "warn" : "danger"}`}>
+          {check.ok ? "ok" : check.severity}
+        </span>
+      </td>
+      <td>
+        <div style={{ color: "var(--ink-1)" }}>{check.message}</div>
+        {!check.ok && check.next_action && (
+          <div style={{ color: "var(--ink-3)", marginTop: 3 }}>{check.next_action}</div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function groupChecks(checks: DoctorCheck[]): Array<[string, DoctorCheck[]]> {
+  const groups = new Map<string, DoctorCheck[]>();
+  for (const check of checks) {
+    const existing = groups.get(check.section);
+    if (existing) existing.push(check);
+    else groups.set(check.section, [check]);
+  }
+  return [...groups.entries()];
+}
+
+function sectionLabel(section: string): string {
+  return section.replace(/_/g, " ");
+}
+
+function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {
+  const color = tone === "pending" ? "var(--pending)" : tone === "err" ? "var(--err)" : "var(--ink-0)";
+  return (
+    <div className="kpi">
+      <div className="label">{label}</div>
+      <div className="value" style={{ color }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -8,8 +8,9 @@ import { HistoryPage, bucket } from "./HistoryPage";
 import { TargetsPage } from "./TargetsPage";
 import { SettingsPage } from "./SettingsPage";
 import { OverviewPage } from "./OverviewPage";
+import { DoctorPage } from "./DoctorPage";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
-import { api, type BindingShowPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import { api, type BindingShowPayload, type DoctorPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
 import type { Binding, Skill, Target } from "../../lib/types";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
 
@@ -227,6 +228,32 @@ function opsPayload(operation: RegistryOperationRecord): OpsPayload {
       operations: [operation],
       checkpoint: { last_scanned_op_id: operation.op_id },
     },
+  };
+}
+
+function doctorPayload(): DoctorPayload {
+  return {
+    healthy: false,
+    checks_v1: [
+      {
+        section: "git",
+        id: "git_fsck",
+        ok: true,
+        severity: "ok",
+        message: "git object database is healthy",
+        next_action: null,
+        details: {},
+      },
+      {
+        section: "pending_queue",
+        id: "pending_queue_warnings",
+        ok: false,
+        severity: "warning",
+        message: "pending queue has malformed or ignored entries",
+        next_action: "inspect state/pending_ops.jsonl and repair or purge malformed queue entries",
+        details: { warning_count: 1 },
+      },
+    ],
   };
 }
 
@@ -484,6 +511,59 @@ test("HistoryPage refetches when the shared live refresh key changes", async () 
     expect(markup(renderer!).includes("op-old")).toBe(false);
   } finally {
     api.ops = originalOps;
+  }
+});
+
+test("DoctorPage renders structured workspace doctor checks", async () => {
+  const originalDoctor = api.workspaceDoctor;
+  let calls = 0;
+  api.workspaceDoctor = async () => {
+    calls += 1;
+    return doctorPayload();
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<DoctorPage live={true} mode="live" refreshKey="tick-1" />);
+    });
+    await flush();
+
+    expect(calls).toBe(1);
+    expect(markup(renderer!).includes("pending_queue_warnings")).toBe(true);
+    expect(markup(renderer!).includes("pending queue has malformed or ignored entries")).toBe(true);
+    expect(markup(renderer!).includes("inspect state/pending_ops.jsonl")).toBe(true);
+
+    await act(async () => {
+      renderer!.update(<DoctorPage live={true} mode="live" refreshKey="tick-2" />);
+    });
+    await flush();
+
+    expect(calls).toBe(2);
+  } finally {
+    api.workspaceDoctor = originalDoctor;
+  }
+});
+
+test("DoctorPage skips live fetches while offline", async () => {
+  const originalDoctor = api.workspaceDoctor;
+  let calls = 0;
+  api.workspaceDoctor = async () => {
+    calls += 1;
+    return doctorPayload();
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<DoctorPage live={false} mode="offline-empty" refreshKey={null} />);
+    });
+    await flush();
+
+    expect(calls).toBe(0);
+    expect(markup(renderer!).includes("Doctor needs the live panel API.")).toBe(true);
+  } finally {
+    api.workspaceDoctor = originalDoctor;
   }
 });
 


### PR DESCRIPTION
## Summary
- add a Doctor page wired to `/api/v1/workspace/doctor`
- group structured `checks_v1` rows by section with status and next-action details
- add Doctor navigation, topbar crumbs, and Panel tests for live/offline behavior

## Verification
- `cd panel && bun install --frozen-lockfile && bun run test -- panel_state`
- `cd panel && bun run typecheck`
- `make ci`
- local Panel smoke on http://127.0.0.1:43120 for `/api/v1/workspace/doctor`

Refs #98