### PR TITLE
Align agent directory defaults

### DIFF
--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -211,6 +211,12 @@ Response shape:
   "remote": {
     "configured": false,
     "sync_state": "LOCAL_ONLY"
+  },
+  "agent_dir_defaults": {
+    "agent_dirs": [
+      { "agent": "claude", "env_var": "CLAUDE_SKILLS_DIR", "path": "/home/me/.claude/skills" },
+      { "agent": "codex", "env_var": "CODEX_SKILLS_DIR", "path": "/home/me/.codex/skills" }
+    ]
   }
 }
 ```

--- a/docs/LOOM_COMPLETE_GUIDE_ZH.md
+++ b/docs/LOOM_COMPLETE_GUIDE_ZH.md
@@ -146,6 +146,7 @@ loom --json --root ~/loom-registry skill capture my-skill --instance <instance-i
 - `agent_dir_defaults`：环境默认目录（诊断用途）
 - `registered_targets`：registry 内已注册 target（真实执行对象）
 
+`agent_dir_defaults.agent_dirs` 会列出 V1 支持的 10 个 agent 默认目录；
 请以 `registered_targets` 和 `registry.targets` 为准。
 
 ## 9. 一键 Agent E2E

--- a/docs/STATUS_FIELD_CLASSIFICATION.md
+++ b/docs/STATUS_FIELD_CLASSIFICATION.md
@@ -101,14 +101,22 @@ Resolution order for skill directories is:
 
 | Variable | Hard default when unset | Source citation |
 |----------|------------------------|-----------------|
-| `CLAUDE_SKILLS_DIR` | `$HOME/.claude/skills` | [source: src/state/mod.rs:55–57] |
-| `CODEX_SKILLS_DIR` | `$HOME/.codex/skills` | [source: src/state/mod.rs:59–61] |
+| `CLAUDE_SKILLS_DIR` | `$HOME/.claude/skills` | `src/state/mod.rs` default agent map |
+| `CODEX_SKILLS_DIR` | `$HOME/.codex/skills` | `src/state/mod.rs` default agent map |
+| `CURSOR_SKILLS_DIR` | `$HOME/.cursor/skills` | `src/state/mod.rs` default agent map |
+| `WINDSURF_SKILLS_DIR` | `$HOME/.windsurf/skills` | `src/state/mod.rs` default agent map |
+| `CLINE_SKILLS_DIR` | `$HOME/.cline/skills` | `src/state/mod.rs` default agent map |
+| `COPILOT_SKILLS_DIR` | `$HOME/.github/copilot/skills` | `src/state/mod.rs` default agent map |
+| `AIDER_SKILLS_DIR` | `$HOME/.aider/skills` | `src/state/mod.rs` default agent map |
+| `OPENCODE_SKILLS_DIR` | `$HOME/.opencode/skills` | `src/state/mod.rs` default agent map |
+| `GEMINI_CLI_SKILLS_DIR` | `$HOME/.gemini/skills` | `src/state/mod.rs` default agent map |
+| `GOOSE_SKILLS_DIR` | `$HOME/.config/goose/skills` | `src/state/mod.rs` default agent map |
 
 `resolve_agent_skill_dirs()` returns the first directory from each variable
-([source: src/state/mod.rs:51–64]).
+and exposes the full `agent_dirs` list for status and panel diagnostics.
 
-`resolve_agent_skill_source_dirs()` expands both variables into a merged, deduplicated
-list of source scan paths ([source: src/state/mod.rs:66–84]).
+`resolve_agent_skill_source_dirs()` expands all supported variables into a merged,
+deduplicated list of source scan paths.
 
 ### Why this matters for status classification
 
@@ -118,6 +126,6 @@ influence which skills are *available for registration*, but once a rule or proj
 is registered its `skill_id` is authoritative registered state.
 
 No `/api/registry/status` (or `/api/registry/workspace`) field is computed by scanning the
-filesystem paths that `CLAUDE_SKILLS_DIR` or `CODEX_SKILLS_DIR` point to.  Advisory
+filesystem paths that these agent directory variables point to.  Advisory
 skill directory hints appear only in diagnostic or migration endpoints, never in the
 counts returned by `status_view()`.

--- a/panel/src/pages/panel/SettingsPage.tsx
+++ b/panel/src/pages/panel/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
 import type { InfoPayload } from "../../types";
 import { api, ApiError } from "../../lib/api/client";
+import { AGENT_OPTIONS } from "../../lib/agent_options";
 
 interface SettingsPageProps {
   live: boolean;
@@ -14,6 +15,23 @@ type InfoState =
   | { kind: "loading" }
   | { kind: "ready"; info: InfoPayload }
   | { kind: "error"; message: string };
+
+const AGENT_LABELS = new Map(AGENT_OPTIONS.map((agent) => [agent.slug, agent.label]));
+
+function labelForAgent(agent: string): string {
+  return AGENT_LABELS.get(agent) ?? agent;
+}
+
+function agentRows(info: InfoPayload): Array<{ agent: string; path: string | undefined }> {
+  if (info.agent_dirs?.length) {
+    return info.agent_dirs.map((dir) => ({ agent: dir.agent, path: dir.path }));
+  }
+
+  return [
+    { agent: "claude", path: info.claude_dir },
+    { agent: "codex", path: info.codex_dir },
+  ].filter((row) => row.path);
+}
 
 export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
   const [info, setInfo] = useState<InfoState>({ kind: "idle" });
@@ -60,8 +78,11 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
     rows.push(
       { label: "State dir", value: x.state_dir, mono: true },
       { label: "Registry targets file", value: x.registry_targets_file, mono: true },
-      { label: "Claude dir", value: x.claude_dir, mono: true },
-      { label: "Codex dir", value: x.codex_dir, mono: true },
+      ...agentRows(x).map((row) => ({
+        label: `${labelForAgent(row.agent)} dir`,
+        value: row.path,
+        mono: true,
+      })),
       { label: "Remote URL", value: x.remote_url, mono: true },
     );
   }
@@ -73,7 +94,7 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
           <h1>Settings</h1>
           <div className="subtitle">
             Where Loom keeps its state. These paths come from <span className="mono">/api/info</span> and mirror the CLI
-            output of <span className="mono">loom info</span>.
+            output of <span className="mono">loom workspace status</span>.
           </div>
         </div>
       </div>

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -877,3 +877,41 @@ test("SettingsPage skips live info fetches when offline", async () => {
     api.info = originalInfo;
   }
 });
+
+test("SettingsPage renders all live agent directories", async () => {
+  const originalInfo = api.info;
+  api.info = async () => ({
+    root: "/tmp/loom",
+    state_dir: "/tmp/loom/.loom",
+    registry_targets_file: "/tmp/loom/.loom/registry/targets.json",
+    agent_dirs: [
+      { agent: "claude", env_var: "CLAUDE_SKILLS_DIR", path: "/tmp/home/.claude/skills" },
+      { agent: "codex", env_var: "CODEX_SKILLS_DIR", path: "/tmp/home/.codex/skills" },
+      { agent: "cursor", env_var: "CURSOR_SKILLS_DIR", path: "/tmp/home/.cursor/skills" },
+      { agent: "windsurf", env_var: "WINDSURF_SKILLS_DIR", path: "/tmp/home/.windsurf/skills" },
+      { agent: "cline", env_var: "CLINE_SKILLS_DIR", path: "/tmp/home/.cline/skills" },
+      { agent: "copilot", env_var: "COPILOT_SKILLS_DIR", path: "/tmp/home/.github/copilot/skills" },
+      { agent: "aider", env_var: "AIDER_SKILLS_DIR", path: "/tmp/home/.aider/skills" },
+      { agent: "opencode", env_var: "OPENCODE_SKILLS_DIR", path: "/tmp/home/.opencode/skills" },
+      { agent: "gemini-cli", env_var: "GEMINI_CLI_SKILLS_DIR", path: "/tmp/home/.gemini/skills" },
+      { agent: "goose", env_var: "GOOSE_SKILLS_DIR", path: "/tmp/home/.config/goose/skills" },
+    ],
+    remote_url: "git@example.com:loom.git",
+  });
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<SettingsPage live={true} mode="live" registryRoot="/tmp/loom" />);
+    });
+    await flush();
+
+    const html = markup(renderer!);
+    expect(html.includes("Gemini CLI dir")).toBe(true);
+    expect(html.includes("/tmp/home/.gemini/skills")).toBe(true);
+    expect(html.includes("Goose dir")).toBe(true);
+    expect(html.includes("/tmp/home/.config/goose/skills")).toBe(true);
+  } finally {
+    api.info = originalInfo;
+  }
+});

--- a/panel/src/types.ts
+++ b/panel/src/types.ts
@@ -25,6 +25,11 @@ export type InfoPayload = {
   registry_targets_file?: string;
   claude_dir?: string;
   codex_dir?: string;
+  agent_dirs?: Array<{
+    agent: string;
+    env_var?: string;
+    path: string;
+  }>;
   remote_url?: string;
 };
 

--- a/src/commands/workspace_cmds.rs
+++ b/src/commands/workspace_cmds.rs
@@ -205,7 +205,16 @@ impl App {
             "git": {"head": head, "branch": branch, "status_short": status_short},
             "agent_dir_defaults": {
                 "claude_dir": target_dirs.claude.display().to_string(),
-                "codex_dir": target_dirs.codex.display().to_string()
+                "codex_dir": target_dirs.codex.display().to_string(),
+                "agent_dirs": target_dirs
+                    .all
+                    .iter()
+                    .map(|dir| json!({
+                        "agent": dir.agent,
+                        "env_var": dir.env_var,
+                        "path": dir.path.display().to_string()
+                    }))
+                    .collect::<Vec<_>>()
             },
             "registered_targets": {
                 "count": registered_target_count,

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -244,6 +244,15 @@ pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Va
             "registry_targets_file": registry_paths.targets_file.display().to_string(),
             "claude_dir": target_dirs.claude.display().to_string(),
             "codex_dir": target_dirs.codex.display().to_string(),
+            "agent_dirs": target_dirs
+                .all
+                .iter()
+                .map(|dir| json!({
+                    "agent": dir.agent,
+                    "env_var": dir.env_var,
+                    "path": dir.path.display().to_string()
+                }))
+                .collect::<Vec<_>>(),
             "remote_url": remote_url,
         }),
         warnings,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -44,24 +44,57 @@ pub struct PendingOpsReport {
 }
 
 #[derive(Debug, Clone)]
+pub struct AgentSkillDir {
+    pub agent: &'static str,
+    pub env_var: &'static str,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
 pub struct AgentSkillDirs {
     pub claude: PathBuf,
     pub codex: PathBuf,
+    pub all: Vec<AgentSkillDir>,
 }
+
+const DEFAULT_AGENT_SKILL_DIRS: [(&str, &str, &str); 10] = [
+    ("claude", "CLAUDE_SKILLS_DIR", ".claude/skills"),
+    ("codex", "CODEX_SKILLS_DIR", ".codex/skills"),
+    ("cursor", "CURSOR_SKILLS_DIR", ".cursor/skills"),
+    ("windsurf", "WINDSURF_SKILLS_DIR", ".windsurf/skills"),
+    ("cline", "CLINE_SKILLS_DIR", ".cline/skills"),
+    ("copilot", "COPILOT_SKILLS_DIR", ".github/copilot/skills"),
+    ("aider", "AIDER_SKILLS_DIR", ".aider/skills"),
+    ("opencode", "OPENCODE_SKILLS_DIR", ".opencode/skills"),
+    ("gemini-cli", "GEMINI_CLI_SKILLS_DIR", ".gemini/skills"),
+    ("goose", "GOOSE_SKILLS_DIR", ".config/goose/skills"),
+];
 
 pub fn resolve_agent_skill_dirs(root: &Path) -> AgentSkillDirs {
     let home = env::var("HOME").unwrap_or_else(|_| "~".to_string());
     let dotenv = load_dotenv_map(root);
 
-    let claude = env_or_dotenv("CLAUDE_SKILLS_DIR", &dotenv)
-        .and_then(|raw| parse_dir_list_env(&raw).into_iter().next())
-        .unwrap_or_else(|| PathBuf::from(format!("{}/.claude/skills", home)));
+    let all = DEFAULT_AGENT_SKILL_DIRS
+        .iter()
+        .map(|(agent, env_var, default_suffix)| AgentSkillDir {
+            agent,
+            env_var,
+            path: first_agent_skill_dir(env_var, default_suffix, &home, &dotenv),
+        })
+        .collect::<Vec<_>>();
 
-    let codex = env_or_dotenv("CODEX_SKILLS_DIR", &dotenv)
-        .and_then(|raw| parse_dir_list_env(&raw).into_iter().next())
+    let claude = all
+        .iter()
+        .find(|dir| dir.agent == "claude")
+        .map(|dir| dir.path.clone())
+        .unwrap_or_else(|| PathBuf::from(format!("{}/.claude/skills", home)));
+    let codex = all
+        .iter()
+        .find(|dir| dir.agent == "codex")
+        .map(|dir| dir.path.clone())
         .unwrap_or_else(|| PathBuf::from(format!("{}/.codex/skills", home)));
 
-    AgentSkillDirs { claude, codex }
+    AgentSkillDirs { claude, codex, all }
 }
 
 pub fn resolve_agent_skill_source_dirs(root: &Path) -> Vec<PathBuf> {
@@ -69,19 +102,30 @@ pub fn resolve_agent_skill_source_dirs(root: &Path) -> Vec<PathBuf> {
     let dotenv = load_dotenv_map(root);
     let mut dirs = Vec::new();
 
-    if let Some(raw) = env_or_dotenv("CODEX_SKILLS_DIR", &dotenv) {
-        dirs.extend(parse_dir_list_env(&raw));
-    } else {
-        dirs.push(PathBuf::from(format!("{}/.codex/skills", home)));
-    }
-
-    if let Some(raw) = env_or_dotenv("CLAUDE_SKILLS_DIR", &dotenv) {
-        dirs.extend(parse_dir_list_env(&raw));
-    } else {
-        dirs.push(PathBuf::from(format!("{}/.claude/skills", home)));
+    for (_, env_var, default_suffix) in DEFAULT_AGENT_SKILL_DIRS {
+        if let Some(raw) = env_or_dotenv(env_var, &dotenv) {
+            dirs.extend(parse_dir_list_env(&raw));
+        } else {
+            dirs.push(default_agent_skill_dir(&home, default_suffix));
+        }
     }
 
     dedupe_paths_keep_order(dirs)
+}
+
+fn first_agent_skill_dir(
+    env_var: &str,
+    default_suffix: &str,
+    home: &str,
+    dotenv: &BTreeMap<String, String>,
+) -> PathBuf {
+    env_or_dotenv(env_var, dotenv)
+        .and_then(|raw| parse_dir_list_env(&raw).into_iter().next())
+        .unwrap_or_else(|| default_agent_skill_dir(home, default_suffix))
+}
+
+fn default_agent_skill_dir(home: &str, suffix: &str) -> PathBuf {
+    PathBuf::from(home).join(suffix)
 }
 
 fn env_or_dotenv(key: &str, dotenv: &BTreeMap<String, String>) -> Option<String> {

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use common::{TestDir, run_loom, write_minimal_registry_state};
+use common::{TestDir, run_loom, run_loom_with_env, write_file, write_minimal_registry_state};
 
 fn overwrite_schema_version(path: &Path, version: u32) {
     let raw = fs::read_to_string(path).expect("read registry file");
@@ -106,6 +106,82 @@ fn workspace_status_succeeds_when_registry_state_is_missing() {
         Value::String("registry".to_string())
     );
     assert_eq!(env["data"]["registry"]["available"], Value::Bool(false));
+}
+
+#[test]
+fn workspace_status_reports_all_supported_agent_dir_defaults() {
+    let root = TestDir::new("registry-status-agent-dirs");
+    let fake_home = TestDir::new("registry-status-agent-dirs-home");
+    write_file(
+        &root.path().join(".env"),
+        "OPENCODE_SKILLS_DIR=/tmp/opencode-primary,/tmp/opencode-secondary\n",
+    );
+
+    let home_str = fake_home.path().to_string_lossy().into_owned();
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("HOME", &home_str)],
+        &["workspace", "status"],
+    );
+    assert!(
+        output.status.success(),
+        "loom failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let agent_dirs = env["data"]["agent_dir_defaults"]["agent_dirs"]
+        .as_array()
+        .expect("agent_dirs must be an array");
+    assert_eq!(agent_dirs.len(), 10);
+
+    let path_for = |agent: &str| {
+        agent_dirs
+            .iter()
+            .find(|dir| dir["agent"] == Value::String(agent.to_string()))
+            .and_then(|dir| dir["path"].as_str())
+            .unwrap_or_else(|| panic!("missing agent dir for {agent}"))
+            .to_string()
+    };
+    assert_eq!(
+        path_for("claude"),
+        fake_home
+            .path()
+            .join(".claude/skills")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        path_for("copilot"),
+        fake_home
+            .path()
+            .join(".github/copilot/skills")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        path_for("gemini-cli"),
+        fake_home
+            .path()
+            .join(".gemini/skills")
+            .display()
+            .to_string()
+    );
+    assert_eq!(path_for("opencode"), "/tmp/opencode-primary");
+
+    let source_dirs = env["data"]["inventory"]["source_dirs"]
+        .as_array()
+        .expect("source_dirs must be an array")
+        .iter()
+        .filter_map(|path| path.as_str())
+        .collect::<Vec<_>>();
+    assert!(source_dirs.contains(&"/tmp/opencode-primary"));
+    assert!(source_dirs.contains(&"/tmp/opencode-secondary"));
+    assert!(
+        source_dirs
+            .iter()
+            .any(|path| path.ends_with(".config/goose/skills"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- centralize default skill directories for all 10 supported V1 agents
- expose the full agent directory list through workspace status and panel info
- render all live agent directories in Panel settings and document the expanded env vars

## Verification
- cargo fmt --check
- cargo test --test status workspace_status_reports_all_supported_agent_dir_defaults
- cd panel && bun run typecheck
- cd panel && bun run test -- panel_state
- make ci