### PR TITLE
Add Panel first-run initialization

### DIFF
--- a/docs/LOOM_ARCHITECTURE_DECISIONS.md
+++ b/docs/LOOM_ARCHITECTURE_DECISIONS.md
@@ -116,10 +116,11 @@ This decision does not make the panel the primary control plane. The CLI remains
 
 ### 4.1 Mutation Route Table (v1 phase 1 frozen surface)
 
-The following 14 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
+The following 15 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
 
 | cmd name                 | HTTP | path                                    | CLI command                  |
 |--------------------------|------|-----------------------------------------|------------------------------|
+| workspace.init           | POST | /api/v1/workspace/init                        | Workspace::Init              |
 | target.add               | POST | /api/registry/targets                         | Target::Add                  |
 | target.remove            | POST | /api/registry/targets/{target_id}/remove      | Target::Remove               |
 | workspace.binding.add    | POST | /api/registry/bindings                        | Workspace::Binding::Add      |

--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -55,6 +55,12 @@ function statusDisplay(props: TopbarProps): { label: string; dotStyle: React.CSS
       dotStyle: { background: "var(--err)", boxShadow: "0 0 0 3px rgba(216,90,90,0.18)" },
     };
   }
+  if (props.mode === "first-run") {
+    return {
+      label: "registry setup required",
+      dotStyle: { background: "var(--warn)", boxShadow: "0 0 0 3px rgba(230,180,80,0.18)" },
+    };
+  }
   const state = (props.remoteState ?? "").toUpperCase();
   if (state === "DIVERGED" || state === "CONFLICTED") {
     return {

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -98,6 +98,15 @@ export interface RemoteStatusResponse {
   warnings?: string[];
 }
 
+export interface WorkspaceStatusPayload {
+  state_model?: string;
+  registry?: {
+    available?: boolean;
+    error?: { code?: string; message?: string };
+    counts?: Record<string, number>;
+  };
+}
+
 export interface CommandEnvelope {
   ok: boolean;
   cmd: string;
@@ -282,6 +291,10 @@ export interface RemoteSetBody {
   url: string;
 }
 
+export interface WorkspaceInitBody {
+  scan_existing?: boolean;
+}
+
 export interface SkillDiffFile {
   path: string;
   added: number;
@@ -344,6 +357,8 @@ export interface DoctorPayload {
 export const api = {
   health: (signal?: AbortSignal) => getJson<HealthPayload>("/api/health", signal),
   info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/info", signal),
+  workspaceStatus: (signal?: AbortSignal) =>
+    getJsonData<WorkspaceStatusPayload>("/api/v1/workspace/status", signal),
   skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/skills", signal),
   registryStatus: (signal?: AbortSignal) => getJson<RegistryPayload>("/api/registry/status", signal),
   workspaceDoctor: (signal?: AbortSignal) =>
@@ -374,6 +389,7 @@ export const api = {
   opsRetry: () => postJson("/api/ops/retry", {}),
   opsPurge: () => postJson("/api/ops/purge", {}),
   remoteSet: (body: RemoteSetBody) => postJson("/api/remote/set", body),
+  workspaceInit: (body: WorkspaceInitBody) => postJson("/api/v1/workspace/init", body),
 
   targetAdd: (body: TargetAddBody) => postJson("/api/registry/targets", body),
   targetRemove: (targetId: string) => postJson(`/api/registry/targets/${encodeURIComponent(targetId)}/remove`, {}),

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -14,13 +14,14 @@ import { ApiError, api } from "./client";
 
 type RegistryCounts = NonNullable<NonNullable<RegistryPayload["data"]>["counts"]>;
 
-export type PanelDataMode = "live" | "offline-empty" | "offline-stale";
+export type PanelDataMode = "live" | "first-run" | "offline-empty" | "offline-stale";
 
 export interface PanelLiveData {
   live: boolean;
   loading: boolean;
   error: string | null;
   mode: PanelDataMode;
+  setupRequired: boolean;
   lastUpdated: string | null;
   registryRoot: string | null;
   remote: RemotePayload | null;
@@ -48,6 +49,7 @@ const INITIAL_STATE: LiveState = {
   loading: true,
   error: null,
   mode: "offline-empty",
+  setupRequired: false,
   lastUpdated: null,
   registryRoot: null,
   remote: null,
@@ -76,6 +78,7 @@ function hasLastKnownData(state: LiveState): boolean {
 }
 
 function modeForState(state: Omit<LiveState, "mode">): PanelDataMode {
+  if (state.setupRequired) return "first-run";
   if (state.live) return "live";
   return hasLastKnownData(state as LiveState) ? "offline-stale" : "offline-empty";
 }
@@ -94,7 +97,8 @@ export function usePanelData(): PanelLiveData {
   );
 
   const markFailure = useCallback(
-    (cur: LiveState, message: string): LiveState => withMode({ ...cur, live: false, loading: false, error: message }),
+    (cur: LiveState, message: string): LiveState =>
+      withMode({ ...cur, live: false, setupRequired: false, loading: false, error: message }),
     [withMode],
   );
 
@@ -116,9 +120,37 @@ export function usePanelData(): PanelLiveData {
     const generation = ++generationRef.current;
 
     try {
-      const [health, info, skillsPayload, registry, remote, pending] = await Promise.all([
+      const [health, info, workspaceStatus] = await Promise.all([
         api.health(controller.signal),
         api.info(controller.signal),
+        api.workspaceStatus(controller.signal),
+      ]);
+      if (controller.signal.aborted || generation !== generationRef.current) return;
+
+      if (workspaceStatus.registry?.available === false) {
+        setState(
+          markSuccess({
+            live: true,
+            setupRequired: true,
+            loading: false,
+            error: null,
+            lastUpdated: new Date().toISOString(),
+            registryRoot: info.root ?? null,
+            remote: null,
+            health,
+            counts: EMPTY_COUNTS,
+            skills: [],
+            targets: [],
+            bindings: [],
+            ops: [],
+            projections: [],
+            pendingCount: 0,
+          }),
+        );
+        return;
+      }
+
+      const [skillsPayload, registry, remote, pending] = await Promise.all([
         api.skills(controller.signal),
         api.registryStatus(controller.signal),
         api.remoteStatus(controller.signal),
@@ -145,6 +177,7 @@ export function usePanelData(): PanelLiveData {
       setState(
         markSuccess({
           live: true,
+          setupRequired: false,
           loading: false,
           error: null,
           lastUpdated: new Date().toISOString(),

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -29,6 +29,17 @@ function installFetchMock(failingPath: string, failingResponse: Response) {
         return Promise.resolve(jsonResponse({ ok: true }));
       case "/api/info":
         return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
+      case "/api/v1/workspace/status":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "workspace.status",
+            request_id: "req-status",
+            data: { registry: { counts: {} } },
+            error: null,
+            meta: { warnings: [] },
+          }),
+        );
       case "/api/skills":
         return Promise.resolve(jsonResponse({ skills: ["typed-api-client"] }));
       case "/api/registry/status":
@@ -118,5 +129,42 @@ describe("PanelApp status failure UI", () => {
     });
 
     expect(screen.getByText(/failed to read pending queue/i)).toBeTruthy();
+  });
+
+  it("shows first-run mode when workspace status reports missing registry state", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      switch (url) {
+        case "/api/health":
+          return Promise.resolve(jsonResponse({ ok: true }));
+        case "/api/info":
+          return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
+        case "/api/v1/workspace/status":
+          return Promise.resolve(
+            jsonResponse({
+              ok: true,
+              cmd: "workspace.status",
+              request_id: "req-status",
+              data: {
+                registry: {
+                  available: false,
+                  error: { code: "ARG_INVALID", message: "registry state not initialized" },
+                },
+              },
+              error: null,
+              meta: { warnings: [] },
+            }),
+          );
+        default:
+          return Promise.reject(new Error(`unexpected fetch ${url}`));
+      }
+    });
+
+    render(<PanelApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Initialize Registry/i)).toBeTruthy();
+    });
+    expect(screen.getByText(/Scan existing agent skill directories/i)).toBeTruthy();
   });
 });

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -13,6 +13,7 @@ import { OpsPage } from "./panel/OpsPage";
 import { SettingsPage } from "./panel/SettingsPage";
 import { SyncPage } from "./panel/SyncPage";
 import { DoctorPage } from "./panel/DoctorPage";
+import { FirstRunPage } from "./panel/FirstRunPage";
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -119,7 +120,7 @@ export function PanelApp() {
   // Gate: all mutation affordances in child pages receive this prop.
   // Future shortcuts, command palette, and hotkey handlers must check readOnly
   // before calling any /api/registry/*, /api/ops/*, or /api/sync/* POST route.
-  const readOnly = !live.live;
+  const readOnly = live.mode !== "live";
   const onMutation = () => {
     setMutationVersion((cur) => cur + 1);
     live.refetch();
@@ -133,99 +134,103 @@ export function PanelApp() {
   const onViewActivity = () => setPage("ops");
 
   let view: React.ReactNode;
-  switch (page) {
-    case "overview":
-      view = (
-        <OverviewPage
-          skills={skills}
-          targets={targets}
-          ops={ops}
-          projections={projectionLinks}
-          vizMode={tweaks.vizMode}
-          setVizMode={setVizMode}
-          selectedSkill={selectedSkill}
-          selectedTarget={selectedTarget}
-          onSelectSkill={toggleSkill}
-          onSelectTarget={toggleTarget}
-          registryRoot={live.registryRoot}
-          onMutation={onMutation}
-          onNewTarget={onNewTarget}
-          onNewBinding={onNewBinding}
-          onViewActivity={onViewActivity}
-          onOpenSync={onOpenSync}
-          readOnly={readOnly}
-        />
-      );
-      break;
-    case "skills":
-      view = (
-        <SkillsPage
-          skills={skills}
-          targets={targets}
-          bindings={bindings}
-          selectedSkill={selectedSkill}
-          onSelectSkill={(id) => setSelectedSkill(id)}
-          onMutation={onMutation}
-          readOnly={readOnly}
-        />
-      );
-      break;
-    case "targets":
-      view = (
-        <TargetsPage
-          targets={targets}
-          skills={skills}
-          selectedTarget={selectedTarget}
-          onSelectTarget={toggleTarget}
-          onRemoveTarget={onRemoveTarget}
-          onMutation={onMutation}
-          readOnly={readOnly}
-          mutationVersion={mutationVersion}
-        />
-      );
-      break;
-    case "bindings":
-      view = (
-        <BindingsPage
-          bindings={bindings}
-          targets={targets}
-          projections={live.projections}
-          onMutation={onMutation}
-          readOnly={readOnly}
-          mutationVersion={mutationVersion}
-        />
-      );
-      break;
-    case "ops":
-      view = <OpsPage ops={ops} onMutation={onMutation} readOnly={readOnly} />;
-      break;
-    case "history":
-      view = (
-        <HistoryPage
-          live={live.live}
-          mode={live.mode}
-          mutationVersion={mutationVersion}
-          refreshKey={live.lastUpdated}
-        />
-      );
-      break;
-    case "sync":
-      view = (
-        <SyncPage
-          remote={live.remote}
-          pendingCount={live.pendingCount}
-          registryRoot={live.registryRoot}
-          readOnly={readOnly}
-          onMutation={onMutation}
-        />
-      );
-      break;
-    case "doctor":
-      view = <DoctorPage live={live.live} mode={live.mode} refreshKey={live.lastUpdated} />;
-      break;
-    case "settings":
-      view = <SettingsPage live={live.live} mode={live.mode} registryRoot={live.registryRoot} />;
-      break;
+  if (live.mode === "first-run") {
+    view = <FirstRunPage registryRoot={live.registryRoot} onReady={live.refetch} />;
+  } else {
+    switch (page) {
+      case "overview":
+        view = (
+          <OverviewPage
+            skills={skills}
+            targets={targets}
+            ops={ops}
+            projections={projectionLinks}
+            vizMode={tweaks.vizMode}
+            setVizMode={setVizMode}
+            selectedSkill={selectedSkill}
+            selectedTarget={selectedTarget}
+            onSelectSkill={toggleSkill}
+            onSelectTarget={toggleTarget}
+            registryRoot={live.registryRoot}
+            onMutation={onMutation}
+            onNewTarget={onNewTarget}
+            onNewBinding={onNewBinding}
+            onViewActivity={onViewActivity}
+            onOpenSync={onOpenSync}
+            readOnly={readOnly}
+          />
+        );
+        break;
+      case "skills":
+        view = (
+          <SkillsPage
+            skills={skills}
+            targets={targets}
+            bindings={bindings}
+            selectedSkill={selectedSkill}
+            onSelectSkill={(id) => setSelectedSkill(id)}
+            onMutation={onMutation}
+            readOnly={readOnly}
+          />
+        );
+        break;
+      case "targets":
+        view = (
+          <TargetsPage
+            targets={targets}
+            skills={skills}
+            selectedTarget={selectedTarget}
+            onSelectTarget={toggleTarget}
+            onRemoveTarget={onRemoveTarget}
+            onMutation={onMutation}
+            readOnly={readOnly}
+            mutationVersion={mutationVersion}
+          />
+        );
+        break;
+      case "bindings":
+        view = (
+          <BindingsPage
+            bindings={bindings}
+            targets={targets}
+            projections={live.projections}
+            onMutation={onMutation}
+            readOnly={readOnly}
+            mutationVersion={mutationVersion}
+          />
+        );
+        break;
+      case "ops":
+        view = <OpsPage ops={ops} onMutation={onMutation} readOnly={readOnly} />;
+        break;
+      case "history":
+        view = (
+          <HistoryPage
+            live={live.live}
+            mode={live.mode}
+            mutationVersion={mutationVersion}
+            refreshKey={live.lastUpdated}
+          />
+        );
+        break;
+      case "sync":
+        view = (
+          <SyncPage
+            remote={live.remote}
+            pendingCount={live.pendingCount}
+            registryRoot={live.registryRoot}
+            readOnly={readOnly}
+            onMutation={onMutation}
+          />
+        );
+        break;
+      case "doctor":
+        view = <DoctorPage live={live.live} mode={live.mode} refreshKey={live.lastUpdated} />;
+        break;
+      case "settings":
+        view = <SettingsPage live={live.live} mode={live.mode} registryRoot={live.registryRoot} />;
+        break;
+    }
   }
 
   return (
@@ -289,9 +294,9 @@ export function LiveDataBanner({
 }: {
   error: string | null;
   loading: boolean;
-  mode: "live" | "offline-empty" | "offline-stale";
+  mode: "live" | "first-run" | "offline-empty" | "offline-stale";
 }) {
-  if (mode === "live") return null;
+  if (mode === "live" || mode === "first-run") return null;
 
   if (loading && mode === "offline-empty") {
     return (

--- a/panel/src/pages/panel/FirstRunPage.tsx
+++ b/panel/src/pages/panel/FirstRunPage.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { api, ApiError, type CommandEnvelope } from "../../lib/api/client";
+
+interface FirstRunPageProps {
+  registryRoot: string | null;
+  onReady: () => void;
+}
+
+function countArray(data: Record<string, unknown> | undefined, key: string): number {
+  const value = data?.[key];
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function resultText(envelope: CommandEnvelope | null): string | null {
+  if (!envelope) return null;
+  const imported = countArray(envelope.data, "imported");
+  const skipped = countArray(envelope.data, "skipped");
+  return `Initialized. ${imported} observed targets imported, ${skipped} paths skipped.`;
+}
+
+export function FirstRunPage({ registryRoot, onReady }: FirstRunPageProps) {
+  const [scanExisting, setScanExisting] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CommandEnvelope | null>(null);
+
+  const initialize = async () => {
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const envelope = await api.workspaceInit({ scan_existing: scanExisting });
+      setResult(envelope);
+      onReady();
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
+      setError(message);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Initialize Registry</h1>
+          <div className="subtitle">
+            {registryRoot ?? "Registry root not connected"} needs state before Loom can show targets and bindings.
+          </div>
+        </div>
+      </div>
+      <div className="page-body">
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div className="card-head">
+            <h3>First run</h3>
+            {running && <span className="chip">initializing...</span>}
+            {result && <span className="chip ok">ready</span>}
+          </div>
+          <div className="card-body">
+            <label style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 14 }}>
+              <input
+                type="checkbox"
+                checked={scanExisting}
+                onChange={(event) => setScanExisting(event.currentTarget.checked)}
+              />
+              <span>Scan existing agent skill directories</span>
+            </label>
+            {error && <div style={{ color: "var(--err)", fontSize: 12, marginBottom: 12 }}>{error}</div>}
+            {resultText(result) && (
+              <div style={{ color: "var(--ok)", fontSize: 12, marginBottom: 12 }}>{resultText(result)}</div>
+            )}
+            <button className="btn primary" onClick={initialize} disabled={running}>
+              {running ? "Initializing..." : "Initialize"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -9,8 +9,9 @@ import { TargetsPage } from "./TargetsPage";
 import { SettingsPage } from "./SettingsPage";
 import { OverviewPage } from "./OverviewPage";
 import { DoctorPage } from "./DoctorPage";
+import { FirstRunPage } from "./FirstRunPage";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
-import { api, type BindingShowPayload, type DoctorPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import { api, type BindingShowPayload, type CommandEnvelope, type DoctorPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
 import type { Binding, Skill, Target } from "../../lib/types";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
 
@@ -264,6 +265,52 @@ test("HistoryPage treats succeeded operations as successful", () => {
 test("LiveDataBanner renders nothing during live refetch loading", () => {
   const html = renderToStaticMarkup(<LiveDataBanner error={null} loading={true} mode="live" />);
   expect(html).toBe("");
+});
+
+test("LiveDataBanner renders nothing in first-run mode", () => {
+  const html = renderToStaticMarkup(<LiveDataBanner error={null} loading={false} mode="first-run" />);
+  expect(html).toBe("");
+});
+
+test("FirstRunPage initializes the registry with scan enabled", async () => {
+  const originalInit = api.workspaceInit;
+  const calls: Array<{ scan_existing?: boolean }> = [];
+  const envelope: CommandEnvelope = {
+    ok: true,
+    cmd: "workspace.init",
+    request_id: "req-1",
+    data: {
+      initialized: true,
+      scanned: true,
+      imported: [{ target_id: "target-1" }],
+      skipped: [{ agent: "codex" }, { agent: "cursor" }],
+    },
+    error: undefined,
+    meta: { warnings: [] },
+  };
+  api.workspaceInit = async (body) => {
+    calls.push(body);
+    return envelope;
+  };
+
+  try {
+    let ready = 0;
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<FirstRunPage registryRoot="/tmp/loom" onReady={() => ready += 1} />);
+    });
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Initialize").props.onClick();
+    });
+    await flush();
+
+    expect(calls).toEqual([{ scan_existing: true }]);
+    expect(ready).toBe(1);
+    expect(markup(renderer!).includes("1 observed targets imported")).toBe(true);
+  } finally {
+    api.workspaceInit = originalInit;
+  }
 });
 
 test("OverviewPage disables add binding until a target exists", async () => {

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use crate::cli::{
     AddArgs, CaptureArgs, Command, HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand,
     OrphanCleanArgs, ProjectArgs, ProjectionMethod, RemoteCommand, SkillOrphanCommand, SyncCommand,
-    TargetCommand, TargetOwnership, WorkspaceBindingCommand, WorkspaceCommand,
+    TargetCommand, TargetOwnership, WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs,
 };
 use crate::commands::{
     App, CommandFailure, collect_skill_inventory, redact_sensitive_string, remote_status_payload,
@@ -27,7 +27,7 @@ use super::auth::{
 };
 use super::{
     BindingAddRequest, CaptureRequest, HistoryRepairRequest, OrphanCleanRequest, PanelState,
-    ProjectRequest, RemoteSetRequest, SkillAddRequest, TargetAddRequest,
+    ProjectRequest, RemoteSetRequest, SkillAddRequest, TargetAddRequest, WorkspaceInitRequest,
 };
 
 /// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The core CLI path enforces
@@ -77,6 +77,27 @@ pub(super) async fn v1_workspace_status(
         ctx: state.ctx.as_ref().clone(),
     };
     panel_command_envelope("workspace.status", app.cmd_status())
+}
+
+pub(super) async fn v1_workspace_init(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<WorkspaceInitRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "workspace.init") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "workspace.init",
+        StatusCode::CREATED,
+        Command::Workspace {
+            command: WorkspaceCommand::Init(WorkspaceInitArgs {
+                scan_existing: req.scan_existing,
+            }),
+        },
+    )
 }
 
 pub(super) async fn v1_workspace_doctor(

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -89,6 +89,12 @@ pub(super) struct RemoteSetRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct WorkspaceInitRequest {
+    #[serde(default)]
+    pub(super) scan_existing: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct OrphanCleanRequest {
     #[serde(default)]
     pub(super) delete_live_paths: bool,
@@ -117,6 +123,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v1/health", get(health))
         .route("/api/v1/overview", get(v1_overview))
         .route("/api/v1/workspace/status", get(v1_workspace_status))
+        .route("/api/v1/workspace/init", post(v1_workspace_init))
         .route("/api/v1/workspace/doctor", get(v1_workspace_doctor))
         .route("/api/v1/targets", get(v1_registry_targets))
         .route("/api/v1/bindings", get(v1_registry_bindings))

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::cli::{
     BindingAddArgs, CaptureArgs, Command, OpsCommand, ProjectArgs, ProjectionMethod, RemoteCommand,
     SkillCommand, SyncCommand, TargetAddArgs, TargetCommand, TargetOwnership,
-    WorkspaceBindingCommand, WorkspaceCommand, WorkspaceMatcherKind,
+    WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs, WorkspaceMatcherKind,
 };
 use crate::panel::auth::{
     ensure_mutation_authorized, error_envelope, request_origin_matches, run_panel_command,
@@ -13,9 +13,10 @@ use serde_json::json;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 // Exhaustive list of every panel mutation command. Must stay in sync with the
-// 14-row table in docs/LOOM_ARCHITECTURE_DECISIONS.md section 4.1 and the
+// 15-row table in docs/LOOM_ARCHITECTURE_DECISIONS.md section 4.1 and the
 // route registrations in `run_panel`.
 const MUTATION_COMMANDS: &[&str] = &[
+    "workspace.init",
     "target.add",
     "target.remove",
     "workspace.binding.add",
@@ -33,8 +34,8 @@ const MUTATION_COMMANDS: &[&str] = &[
 ];
 
 #[test]
-fn mutation_commands_count_is_fourteen() {
-    assert_eq!(MUTATION_COMMANDS.len(), 14);
+fn mutation_commands_count_is_fifteen() {
+    assert_eq!(MUTATION_COMMANDS.len(), 15);
 }
 
 #[test]
@@ -155,6 +156,32 @@ fn run_panel_command_exposes_workspace_remote_set() {
     assert_eq!(payload["cmd"], json!("workspace.remote"));
     assert_eq!(payload["data"]["remote"], json!("origin"));
     assert_eq!(payload["data"]["url"], json!(url));
+
+    cleanup_root(root);
+}
+
+#[test]
+fn run_panel_command_exposes_workspace_init() {
+    let (root, state) = make_test_state();
+
+    let (status, Json(payload)) = run_panel_command(
+        &state,
+        "workspace.init",
+        StatusCode::CREATED,
+        Command::Workspace {
+            command: WorkspaceCommand::Init(WorkspaceInitArgs {
+                scan_existing: false,
+            }),
+        },
+    );
+
+    assert_eq!(status, StatusCode::CREATED, "{payload}");
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("workspace.init"));
+    assert_eq!(payload["data"]["initialized"], json!(true));
+    assert_eq!(payload["data"]["scanned"], json!(false));
+    assert_eq!(payload["meta"].get("op_id"), None);
+    assert!(root.join("state/registry/schema.json").exists());
 
     cleanup_root(root);
 }


### PR DESCRIPTION
## Summary
- add authorized v1 workspace initialization route backed by the existing CLI command
- detect missing registry state from workspace status and enter Panel first-run mode
- add a first-run page that initializes the registry and optionally scans existing agent skill dirs

## Verification
- cargo test -q panel::tests::security
- cd panel && bun run typecheck
- cd panel && bun run test -- PanelApp panel_state
- make ci