### PR TITLE
Align V1 health envelope

### DIFF
--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -61,6 +61,10 @@ pub(super) async fn health() -> Json<serde_json::Value> {
     Json(json!({"ok": true, "service": "loom-panel"}))
 }
 
+pub(super) async fn v1_health() -> (StatusCode, Json<serde_json::Value>) {
+    panel_v1_ok("panel.health", json!({"service": "loom-panel"}))
+}
+
 pub(super) async fn v1_overview(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -120,7 +120,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
     let app = Router::new()
         .route("/", get(frontend_index))
         .route("/api/health", get(health))
-        .route("/api/v1/health", get(health))
+        .route("/api/v1/health", get(v1_health))
         .route("/api/v1/overview", get(v1_overview))
         .route("/api/v1/workspace/status", get(v1_workspace_status))
         .route("/api/v1/workspace/init", post(v1_workspace_init))

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::panel::handlers::{
     OpsQuery, info, pending, registry_ops, registry_orphan_clean, remote_set, remote_status,
-    v1_overview, v1_registry_ops, v1_registry_targets, v1_workspace_status,
+    v1_health, v1_overview, v1_registry_ops, v1_registry_targets, v1_workspace_status,
 };
 use crate::state_model::{
     REGISTRY_SCHEMA_VERSION, RegistryOperationRecord, RegistryProjectionInstance,
@@ -66,6 +66,18 @@ fn registry_ops_returns_bounded_newest_first_rows() {
     assert!(operations[0].get("effects").is_none());
 
     let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn v1_health_returns_cli_envelope_shape() {
+    let (status, Json(payload)) = v1_health().await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("panel.health"));
+    assert_eq!(payload["error"], Value::Null);
+    assert_eq!(payload["data"]["service"], json!("loom-panel"));
+    assert_eq!(payload["meta"]["warnings"], json!([]));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- keep legacy `/api/health` unchanged
- route `/api/v1/health` through a V1 envelope response
- add a handler test for `cmd`, `error:null`, and `meta.warnings`

Fixes #114.

## Verification
- `cargo fmt --check`
- `cargo test -q panel::tests::handlers::v1`
- `cargo test --test write without_registry_operation`
- `cargo test --test doctor workspace_doctor_marks_pending_queue_warnings_unhealthy`
- `git diff --check`
- `make ci`