### PR TITLE
Add Panel projections page

### DIFF
--- a/panel/src/components/panel/Sidebar.tsx
+++ b/panel/src/components/panel/Sidebar.tsx
@@ -29,6 +29,7 @@ interface SidebarProps {
     skills: number;
     targets: number;
     bindings: number;
+    projections: number;
     opsAttention: number;
   };
   registryRoot: string | null;
@@ -45,6 +46,7 @@ export function Sidebar({ page, setPage, compact, counts, registryRoot }: Sideba
     { key: "skills", label: "Skills", icon: SkillIcon, count: counts.skills },
     { key: "targets", label: "Targets", icon: TargetIcon, count: counts.targets },
     { key: "bindings", label: "Bindings", icon: BindingIcon, count: counts.bindings },
+    { key: "projections", label: "Projections", icon: GitIcon, count: counts.projections },
     { key: "ops", label: "Activity", icon: OpsIcon, count: counts.opsAttention || null },
   ];
   const admin: NavEntry[] = [

--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -10,6 +10,7 @@ const CRUMBS: Record<PanelPageKey, string> = {
   skills: "Skills",
   targets: "Targets",
   bindings: "Bindings",
+  projections: "Projections",
   ops: "Activity",
   history: "Audit log",
   sync: "Git sync",

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -81,6 +81,7 @@ export type PanelPageKey =
   | "skills"
   | "targets"
   | "bindings"
+  | "projections"
   | "ops"
   | "history"
   | "sync"

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -14,6 +14,7 @@ import { SettingsPage } from "./panel/SettingsPage";
 import { SyncPage } from "./panel/SyncPage";
 import { DoctorPage } from "./panel/DoctorPage";
 import { FirstRunPage } from "./panel/FirstRunPage";
+import { ProjectionsPage } from "./panel/ProjectionsPage";
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -31,6 +32,7 @@ const VALID_PAGES: PanelPageKey[] = [
   "skills",
   "targets",
   "bindings",
+  "projections",
   "ops",
   "history",
   "sync",
@@ -200,6 +202,17 @@ export function PanelApp() {
           />
         );
         break;
+      case "projections":
+        view = (
+          <ProjectionsPage
+            projections={live.projections}
+            targets={targets}
+            bindings={bindings}
+            readOnly={readOnly}
+            onMutation={onMutation}
+          />
+        );
+        break;
       case "ops":
         view = <OpsPage ops={ops} onMutation={onMutation} readOnly={readOnly} />;
         break;
@@ -255,6 +268,7 @@ export function PanelApp() {
           skills: skills.length,
           targets: targets.length,
           bindings: bindings.length,
+          projections: live.projections.length,
           opsAttention: ops.filter((o) => o.status !== "ok").length,
         }}
         registryRoot={live.registryRoot}

--- a/panel/src/pages/panel/ProjectionsPage.tsx
+++ b/panel/src/pages/panel/ProjectionsPage.tsx
@@ -1,0 +1,299 @@
+import { useMemo, useState } from "react";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
+import type { Binding, Target } from "../../lib/types";
+import { api } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
+import { RefreshIcon } from "../../components/icons/nav_icons";
+
+interface ProjectionsPageProps {
+  projections: RegistryProjection[];
+  targets: Target[];
+  bindings: Binding[];
+  readOnly: boolean;
+  onMutation: () => void;
+}
+
+type ProjectionFilter = "all" | "healthy" | "drifted" | "orphaned";
+
+const FILTERS: ProjectionFilter[] = ["all", "healthy", "drifted", "orphaned"];
+const MONO_VALUE_STYLE = {
+  overflowWrap: "anywhere",
+  minWidth: 0,
+  whiteSpace: "normal",
+  wordBreak: "break-word",
+} as const;
+
+function shortRev(rev: string): string {
+  return rev ? rev.slice(0, 8) : "-";
+}
+
+function targetLabel(targets: Target[], targetId: string): string {
+  const target = targets.find((item) => item.id === targetId);
+  return target ? `${target.agent}/${target.profile}` : targetId;
+}
+
+function methodForProject(method: string): "symlink" | "copy" | "materialize" {
+  if (method === "copy" || method === "materialize") return method;
+  return "symlink";
+}
+
+function healthClass(projection: RegistryProjection): string {
+  if (projection.health === "healthy" && !projection.observed_drift) return "ok";
+  if (projection.health === "orphaned") return "warn";
+  return "err";
+}
+
+export function ProjectionsPage({ projections, targets, bindings, readOnly, onMutation }: ProjectionsPageProps) {
+  const [filter, setFilter] = useState<ProjectionFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [deleteLivePaths, setDeleteLivePaths] = useState(false);
+  const action = useMutation();
+
+  const filtered = useMemo(() => {
+    return projections.filter((projection) => {
+      if (filter === "all") return true;
+      if (filter === "drifted") return projection.observed_drift || projection.health === "drifted";
+      return projection.health === filter;
+    });
+  }, [filter, projections]);
+
+  const selected = projections.find((projection) => projection.instance_id === selectedId) ?? filtered[0] ?? null;
+  const selectedBinding = selected?.binding_id
+    ? bindings.find((binding) => binding.id === selected.binding_id)
+    : undefined;
+  const canProject = Boolean(selected?.binding_id) && !readOnly && !action.busy;
+  const canCapture = Boolean(selected) && !readOnly && !action.busy;
+  const canCleanOrphan =
+    Boolean(selected) && selected?.health === "orphaned" && !selected.binding_id && !readOnly && !action.busy;
+
+  const capture = () => {
+    if (!selected || !canCapture) return;
+    action.run(
+      "capture projection",
+      () => api.capture({ instance: selected.instance_id }),
+      onMutation,
+    );
+  };
+
+  const project = () => {
+    if (!selected || !selected.binding_id || !canProject) return;
+    action.run(
+      "re-project",
+      () =>
+        api.project({
+          skill: selected.skill_id,
+          binding: selected.binding_id!,
+          target: selected.target_id,
+          method: methodForProject(selected.method),
+        }),
+      onMutation,
+    );
+  };
+
+  const cleanOrphan = () => {
+    if (!canCleanOrphan) return;
+    action.run(
+      "clean orphaned projection",
+      () => api.orphanClean({ delete_live_paths: deleteLivePaths }),
+      onMutation,
+    );
+  };
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Projections</h1>
+          <div className="subtitle">Materialized skill instances across registered targets.</div>
+        </div>
+        <div className="header-actions">
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {FILTERS.map((item) => (
+              <button key={item} className={`btn ${filter === item ? "primary" : "ghost"}`} onClick={() => setFilter(item)}>
+                {item}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="page-body" style={{ padding: 0 }}>
+        <div className="two-col projections-layout">
+          <div className="projections-list">
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Instance</th>
+                  <th>Skill</th>
+                  <th>Target</th>
+                  <th>Method</th>
+                  <th>Health</th>
+                  <th>Rev</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((projection) => (
+                  <tr
+                    key={projection.instance_id}
+                    className={selected?.instance_id === projection.instance_id ? "selected" : ""}
+                    onClick={() => setSelectedId(projection.instance_id)}
+                  >
+                    <td className="mono dim">{projection.instance_id}</td>
+                    <td className="name">{projection.skill_id}</td>
+                    <td>{targetLabel(targets, projection.target_id)}</td>
+                    <td>{projection.method}</td>
+                    <td>
+                      <span className={`badge ${healthClass(projection)}`}>
+                        {projection.observed_drift ? "drifted" : projection.health}
+                      </span>
+                    </td>
+                    <td className="mono dim">{shortRev(projection.last_applied_rev)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {filtered.length === 0 && <div className="empty">No projections match this filter.</div>}
+          </div>
+          <div className="projections-detail-panel">
+            {selected ? (
+              <ProjectionDetail
+                projection={selected}
+                binding={selectedBinding}
+                targetLabel={targetLabel(targets, selected.target_id)}
+                readOnly={readOnly}
+                actionBusy={action.busy}
+                canCapture={canCapture}
+                canProject={canProject}
+                canCleanOrphan={canCleanOrphan}
+                deleteLivePaths={deleteLivePaths}
+                setDeleteLivePaths={setDeleteLivePaths}
+                onCapture={capture}
+                onProject={project}
+                onCleanOrphan={cleanOrphan}
+                message={action.error ?? action.success}
+                messageTone={action.error ? "var(--err)" : "var(--ok)"}
+              />
+            ) : (
+              <div className="empty">No projections found.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ProjectionDetail({
+  projection,
+  binding,
+  targetLabel,
+  readOnly,
+  actionBusy,
+  canCapture,
+  canProject,
+  canCleanOrphan,
+  deleteLivePaths,
+  setDeleteLivePaths,
+  onCapture,
+  onProject,
+  onCleanOrphan,
+  message,
+  messageTone,
+}: {
+  projection: RegistryProjection;
+  binding?: Binding;
+  targetLabel: string;
+  readOnly: boolean;
+  actionBusy: boolean;
+  canCapture: boolean;
+  canProject: boolean;
+  canCleanOrphan: boolean;
+  deleteLivePaths: boolean;
+  setDeleteLivePaths: (next: boolean) => void;
+  onCapture: () => void;
+  onProject: () => void;
+  onCleanOrphan: () => void;
+  message: string | null;
+  messageTone: string;
+}) {
+  return (
+    <div className="card">
+      <div className="card-head">
+        <h3>{projection.skill_id}</h3>
+        <span className={`chip ${healthClass(projection)}`}>{projection.health}</span>
+      </div>
+      <div className="card-body">
+        <div style={{ display: "grid", gap: 10, marginBottom: 14, fontSize: 12 }}>
+          <DetailRow label="Instance" value={projection.instance_id} mono />
+          <DetailRow label="Target" value={targetLabel} />
+          <DetailRow label="Binding" value={projection.binding_id ?? "-"} mono />
+          <DetailRow label="Method" value={projection.method} />
+          <DetailRow label="Revision" value={projection.last_applied_rev || "-"} mono />
+          <DetailRow label="Path" value={projection.materialized_path} mono />
+        </div>
+
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <button
+            className="btn"
+            onClick={onCapture}
+            disabled={!canCapture}
+            title={readOnly ? "registry offline" : undefined}
+          >
+            Capture
+          </button>
+          <button
+            className="btn primary"
+            onClick={onProject}
+            disabled={!canProject}
+            title={
+              readOnly
+                ? "registry offline"
+                : binding
+                  ? `project via ${binding.id}`
+                  : "projection has no binding"
+            }
+          >
+            <RefreshIcon /> {actionBusy ? "Working..." : "Re-project"}
+          </button>
+          {projection.health === "orphaned" && !projection.binding_id && (
+            <>
+              <label className="row-flex" style={{ fontSize: 12, color: "var(--ink-2)" }}>
+                <input
+                  type="checkbox"
+                  checked={deleteLivePaths}
+                  onChange={(event) => setDeleteLivePaths(event.currentTarget.checked)}
+                  disabled={readOnly || actionBusy}
+                />
+                Delete live path
+              </label>
+              <button
+                className="btn ghost danger"
+                onClick={onCleanOrphan}
+                disabled={!canCleanOrphan}
+                title={readOnly ? "registry offline" : undefined}
+              >
+                Clean orphan
+              </button>
+            </>
+          )}
+        </div>
+
+        {message && (
+          <div className="mono" style={{ color: messageTone, marginTop: 12, fontSize: 11 }}>
+            {message}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "82px minmax(0, 1fr)", gap: 12, alignItems: "start" }}>
+      <div style={{ color: "var(--ink-2)" }}>{label}</div>
+      <div className={mono ? "mono" : undefined} style={mono ? MONO_VALUE_STYLE : undefined}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -10,6 +10,7 @@ import { SettingsPage } from "./SettingsPage";
 import { OverviewPage } from "./OverviewPage";
 import { DoctorPage } from "./DoctorPage";
 import { FirstRunPage } from "./FirstRunPage";
+import { ProjectionsPage } from "./ProjectionsPage";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
 import { api, type BindingShowPayload, type CommandEnvelope, type DoctorPayload, type OpsPayload, type TargetShowPayload, type RegistryOperationRecord } from "../../lib/api/client";
 import type { Binding, Skill, Target } from "../../lib/types";
@@ -487,6 +488,108 @@ test("BindingsPage exposes orphan cleanup from live projection data", async () =
 
     await act(async () => {
       buttonByLabel(renderer!, "Clean metadata").props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(calls).toEqual([{ delete_live_paths: false }]);
+    expect(mutations).toBe(1);
+  } finally {
+    api.orphanClean = originalOrphanClean;
+  }
+});
+
+test("ProjectionsPage can capture and re-project a selected projection", async () => {
+  const originalCapture = api.capture;
+  const originalProject = api.project;
+  const captureCalls: Array<{ instance?: string }> = [];
+  const projectCalls: Array<{ skill: string; binding: string; target?: string; method?: string }> = [];
+  let mutations = 0;
+
+  api.capture = async (body) => {
+    captureCalls.push(body);
+    return { ok: true, cmd: "skill.capture", request_id: "req-capture", data: {} };
+  };
+  api.project = async (body) => {
+    projectCalls.push(body);
+    return { ok: true, cmd: "skill.project", request_id: "req-project", data: {} };
+  };
+
+  try {
+    const projection: RegistryProjection = {
+      instance_id: "inst-demo",
+      skill_id: "skill.writer",
+      binding_id: "binding-1",
+      target_id: "target-1",
+      materialized_path: "/tmp/target-1/skill.writer",
+      method: "copy",
+      last_applied_rev: "deadbeefcafebabe",
+      health: "healthy",
+    };
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ProjectionsPage
+          projections={[projection]}
+          targets={[makeTarget()]}
+          bindings={[makeBinding()]}
+          readOnly={false}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Capture").props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      buttonByLabel(renderer!, "Re-project").props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(captureCalls).toEqual([{ instance: "inst-demo" }]);
+    expect(projectCalls).toEqual([
+      { skill: "skill.writer", binding: "binding-1", target: "target-1", method: "copy" },
+    ]);
+    expect(mutations).toBe(2);
+  } finally {
+    api.capture = originalCapture;
+    api.project = originalProject;
+  }
+});
+
+test("ProjectionsPage cleans orphaned projection metadata", async () => {
+  const originalOrphanClean = api.orphanClean;
+  const calls: Array<{ delete_live_paths?: boolean }> = [];
+  api.orphanClean = async (body) => {
+    calls.push(body);
+    return { ok: true, cmd: "skill.orphan.clean", request_id: "req-clean", data: {} };
+  };
+
+  try {
+    let mutations = 0;
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ProjectionsPage
+          projections={[makeOrphanProjection()]}
+          targets={[makeTarget()]}
+          bindings={[makeBinding()]}
+          readOnly={false}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Clean orphan").props.onClick();
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/panel/src/styles/panel/data.css
+++ b/panel/src/styles/panel/data.css
@@ -56,6 +56,22 @@
   height: 100%;
 }
 
+.projections-layout {
+  gap: 0;
+}
+
+.projections-list {
+  min-width: 0;
+  overflow: auto;
+  border-right: 1px solid var(--line);
+}
+
+.projections-detail-panel {
+  min-width: 0;
+  padding: 18px;
+  overflow: auto;
+}
+
 .target-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -70,6 +86,24 @@
 }
 
 @media (max-width: 720px) {
+  .two-col {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .projections-list {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    max-height: 44vh;
+  }
+
+  .projections-list .tbl {
+    min-width: 720px;
+  }
+
+  .projections-detail-panel {
+    padding: 16px;
+  }
+
   .target-grid,
   .target-detail-grid {
     grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- add a dedicated Panel Projections page with health filters, table selection, and detail panel
- wire the page into the sidebar, page routing, topbar crumb, and navigation counts
- expose capture, re-project, and orphan cleanup actions from the projection detail surface
- add responsive layout rules so the table and detail panel stack on narrow screens

Fixes #116.

## Verification
- `cd panel && bun run typecheck`
- `cd panel && bun run test -- panel_state`
- `cd panel && bun run build`
- browser smoke at `http://127.0.0.1:43122/?v=projections`
- `git diff --check`
- `make ci`