### PR TITLE
Record skill save registry operation

### DIFF
--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -637,12 +637,81 @@ impl App {
             return Ok((json!({"skill": args.skill, "noop": true}), Meta::default()));
         }
 
+        let paths = RegistryStatePaths::from_app_context(&self.ctx);
+        let had_registry_layout = paths.registry_dir.exists();
+        let had_legacy_layout = paths.legacy_state_dir_exists();
+        paths.ensure_layout().map_err(map_registry_state)?;
+        let registry_backup = snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
         let message = args
             .message
             .clone()
             .unwrap_or_else(|| format!("save({}): event", args.skill));
-        let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
-        let mut meta = Meta::default();
+        let op_id = match record_registry_operation(
+            &paths,
+            "skill.save",
+            json!({
+                "skill": args.skill,
+                "request_id": request_id
+            }),
+            json!({
+                "noop": false
+            }),
+        ) {
+            Ok(op_id) => op_id,
+            Err(err) => {
+                let _ =
+                    gitops::run_git_allow_failure(&self.ctx, &["reset", "HEAD", "--", &skill_rel]);
+                rollback_registry_audit_after_failure(
+                    &self.ctx,
+                    &paths,
+                    &registry_backup,
+                    had_registry_layout,
+                    had_legacy_layout,
+                );
+                return Err(map_registry_state(err));
+            }
+        };
+        if let Err(err) = maybe_skill_fault("skill_save_after_operation") {
+            let _ = gitops::run_git_allow_failure(&self.ctx, &["reset", "HEAD", "--", &skill_rel]);
+            rollback_registry_audit_after_failure(
+                &self.ctx,
+                &paths,
+                &registry_backup,
+                had_registry_layout,
+                had_legacy_layout,
+            );
+            return Err(err);
+        }
+        if let Err(err) = stage_registry_state(&self.ctx, &paths) {
+            let _ = gitops::run_git_allow_failure(&self.ctx, &["reset", "HEAD", "--", &skill_rel]);
+            rollback_registry_audit_after_failure(
+                &self.ctx,
+                &paths,
+                &registry_backup,
+                had_registry_layout,
+                had_legacy_layout,
+            );
+            return Err(err);
+        }
+        let commit = match gitops::commit(&self.ctx, &message) {
+            Ok(commit) => commit,
+            Err(err) => {
+                let _ =
+                    gitops::run_git_allow_failure(&self.ctx, &["reset", "HEAD", "--", &skill_rel]);
+                rollback_registry_audit_after_failure(
+                    &self.ctx,
+                    &paths,
+                    &registry_backup,
+                    had_registry_layout,
+                    had_legacy_layout,
+                );
+                return Err(map_git(err));
+            }
+        };
+        let mut meta = Meta {
+            op_id: Some(op_id),
+            ..Meta::default()
+        };
         maybe_autosync_or_queue(
             &self.ctx,
             "save",
@@ -1703,6 +1772,36 @@ fn reset_command_created_commits(ctx: &crate::state::AppContext, previous_head: 
 fn unstage_registry_state(ctx: &crate::state::AppContext) {
     let _ = gitops::run_git_allow_failure(ctx, &["reset", "HEAD", "--", "state/registry"]);
     let _ = gitops::run_git_allow_failure(ctx, &["reset", "HEAD", "--", "state/v3"]);
+}
+
+fn stage_registry_state(
+    ctx: &crate::state::AppContext,
+    paths: &RegistryStatePaths,
+) -> std::result::Result<(), CommandFailure> {
+    gitops::run_git(ctx, &["add", "-A", "--", "state/registry"]).map_err(map_git)?;
+    let legacy_v3_tracked =
+        gitops::run_git_allow_failure(ctx, &["ls-files", "--error-unmatch", "--", "state/v3"])
+            .map_err(map_git)?
+            .status
+            .success();
+    if paths.state_dir.join("v3").exists() || legacy_v3_tracked {
+        gitops::run_git(ctx, &["add", "-A", "--", "state/v3"]).map_err(map_git)?;
+    }
+    Ok(())
+}
+
+fn rollback_registry_audit_after_failure(
+    ctx: &crate::state::AppContext,
+    paths: &RegistryStatePaths,
+    registry_backup: &RegistryAuditStateBackup,
+    had_registry_layout: bool,
+    had_legacy_layout: bool,
+) {
+    let _ = restore_registry_audit_state(paths, registry_backup);
+    if !had_registry_layout && !had_legacy_layout {
+        let _ = remove_path_if_exists(&paths.registry_dir);
+    }
+    unstage_registry_state(ctx);
 }
 
 fn rollback_import_after_commit(

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -36,6 +36,10 @@ fn git_output(root: &Path, args: &[&str]) -> String {
         .arg(root)
         .arg("-c")
         .arg("commit.gpgsign=false")
+        .arg("-c")
+        .arg("user.name=Loom Test")
+        .arg("-c")
+        .arg("user.email=loom@example.invalid")
         .args(args)
         .output()
         .expect("run git");
@@ -51,6 +55,19 @@ fn git_output(root: &Path, args: &[&str]) -> String {
 
 fn git_head(root: &Path) -> String {
     git_output(root, &["rev-parse", "HEAD"])
+}
+
+fn commit_skill_without_registry(root: &Path, skill: &str, message: &str) {
+    if !root.join(".git").exists() {
+        git_output(root, &["init"]);
+    }
+    let skill_rel = format!("skills/{skill}");
+    git_output(root, &["add", "--", &skill_rel]);
+    git_output(root, &["commit", "-m", message, "--", &skill_rel]);
+    assert!(
+        !root.join("state/registry").exists(),
+        "test helper should not initialize registry state"
+    );
 }
 
 fn git_status_short_for(root: &Path, pathspecs: &[&str]) -> String {
@@ -262,12 +279,7 @@ fn skill_rollback_records_operation_and_observation() {
 fn skill_rollback_noop_does_not_initialize_registry() {
     let root = TestDir::new("registry-skill-rollback-noop");
     write_example_skill(root.path(), "model-onboarding");
-    assert!(
-        save_skill(root.path(), "model-onboarding")
-            .0
-            .status
-            .success()
-    );
+    commit_skill_without_registry(root.path(), "model-onboarding", "seed skill");
 
     let (rollback_output, rollback_env) = run_loom(
         root.path(),
@@ -383,24 +395,14 @@ fn skill_rollback_rolls_back_commits_and_worktree_after_late_audit_failure() {
 fn skill_rollback_removes_new_registry_layout_after_late_audit_failure() {
     let root = TestDir::new("registry-skill-rollback-new-layout-rollback");
     write_example_skill(root.path(), "model-onboarding");
-    assert!(
-        save_skill(root.path(), "model-onboarding")
-            .0
-            .status
-            .success()
-    );
+    commit_skill_without_registry(root.path(), "model-onboarding", "seed skill");
 
     write_skill(
         root.path(),
         "model-onboarding",
         "# model-onboarding\n\nsource v2\n",
     );
-    assert!(
-        save_skill(root.path(), "model-onboarding")
-            .0
-            .status
-            .success()
-    );
+    commit_skill_without_registry(root.path(), "model-onboarding", "update skill");
     assert!(
         !root.path().join("state/registry").exists(),
         "precondition: registry should not exist before rollback"
@@ -531,12 +533,7 @@ fn skill_release_records_operation() {
 fn skill_release_removes_new_registry_layout_after_late_failure() {
     let root = TestDir::new("registry-skill-release-new-layout-rollback");
     write_example_skill(root.path(), "model-onboarding");
-    assert!(
-        save_skill(root.path(), "model-onboarding")
-            .0
-            .status
-            .success()
-    );
+    commit_skill_without_registry(root.path(), "model-onboarding", "seed skill");
     assert!(
         !root.path().join("state/registry").exists(),
         "precondition: registry should not exist before release"
@@ -620,12 +617,7 @@ fn skill_release_restores_legacy_v3_layout_after_late_failure() {
 fn skill_release_removes_new_registry_layout_when_tag_creation_fails() {
     let root = TestDir::new("registry-skill-release-tag-failure");
     write_example_skill(root.path(), "model-onboarding");
-    assert!(
-        save_skill(root.path(), "model-onboarding")
-            .0
-            .status
-            .success()
-    );
+    commit_skill_without_registry(root.path(), "model-onboarding", "seed skill");
     git_output(
         root.path(),
         &[

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -84,8 +84,8 @@ fn target_add_bootstraps_registry_state_and_records_op() {
 }
 
 #[test]
-fn skill_save_without_registry_operation_does_not_return_op_id() {
-    let root = TestDir::new("registry-skill-save-no-fake-op-id");
+fn skill_save_records_registry_operation_and_op_id() {
+    let root = TestDir::new("registry-skill-save-op-id");
     write_skill(root.path(), "demo", "# demo\n\nv1\n");
 
     let (output, env) = run_loom(root.path(), &["skill", "save", "demo"]);
@@ -97,8 +97,35 @@ fn skill_save_without_registry_operation_does_not_return_op_id() {
         String::from_utf8_lossy(&output.stdout)
     );
     assert_eq!(env["ok"], Value::Bool(true));
-    assert_eq!(env["meta"].get("op_id"), None);
-    assert_eq!(operations_log(root.path()), "");
+    let op_id = env["meta"]["op_id"].as_str().expect("save op_id");
+    assert!(op_id.starts_with("op_"), "unexpected op_id: {op_id}");
+    let operations = operations_log(root.path());
+    assert!(operations.contains(&format!(r#""op_id":"{op_id}""#)));
+    assert!(operations.contains(r#""intent":"skill.save""#));
+    assert!(operations.contains(r#""skill":"demo""#));
+}
+
+#[test]
+fn skill_save_rolls_back_registry_operation_after_audit_failure() {
+    let root = TestDir::new("registry-skill-save-audit-rollback");
+    write_skill(root.path(), "demo", "# demo\n\nv1\n");
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("LOOM_FAULT_INJECT", "skill_save_after_operation")],
+        &["skill", "save", "demo"],
+    );
+
+    assert!(!output.status.success(), "save unexpectedly succeeded");
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert!(
+        !root.path().join("state/registry").exists(),
+        "fresh registry layout should be removed after failed save audit"
+    );
+    assert!(
+        git_ok(root.path(), &["log", "--oneline", "--", "skills/demo"]).is_empty(),
+        "skill commit should be rolled back"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- record a real `skill.save` registry operation when `skill save` commits changed skill content
- return the real `op_*` in `meta.op_id` while preserving noop saves with no op id
- commit skill content and registry audit state together so `save` does not insert an extra audit-only commit before rollback targets
- roll back fresh registry audit state if save audit recording fails
- keep `skill snapshot` from returning a fake op id; conflict-free snapshot audit is tracked separately in #119

Fixes #118.

## Verification
- `cargo fmt --check`
- `cargo test --test write`
- `cargo test --test project`
- `cargo test --test reliability sync_`
- `git diff --check`
- `make ci`