### PR TITLE
Route Panel mutations through V1 API

### DIFF
--- a/panel/src/lib/api/client.test.ts
+++ b/panel/src/lib/api/client.test.ts
@@ -36,3 +36,60 @@ describe("api.registryStatus", () => {
     await expect(api.registryStatus()).rejects.toBe(abortError);
   });
 });
+
+describe("api v1 routes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses v1 endpoints for panel mutations", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({ ok: true, cmd: "ok", request_id: "req-1", data: {} }),
+    } as unknown as Response);
+
+    await api.targetAdd({ agent: "claude", path: "/tmp/skills", ownership: "managed" });
+    await api.targetRemove("target-1");
+    await api.bindingAdd({
+      agent: "claude",
+      profile: "home",
+      matcher_kind: "path_prefix",
+      matcher_value: "/repo",
+      target: "target-1",
+      policy_profile: "safe-capture",
+    });
+    await api.bindingRemove("binding-1");
+    await api.skillAdd({ source: "/tmp/source", name: "demo" });
+    await api.project({ skill: "demo", binding: "binding-1", target: "target-1", method: "symlink" });
+    await api.capture({ instance: "inst-1" });
+    await api.orphanClean({ delete_live_paths: false });
+    await api.opsRetry();
+    await api.opsPurge();
+    await api.remoteSet({ url: "https://example.com/repo.git" });
+    await api.syncPush();
+    await api.syncPull();
+    await api.syncReplay();
+    await api.opsHistoryRepair({ strategy: "local" });
+
+    const paths = fetchSpy.mock.calls.map((call) => call[0]);
+    expect(paths).toEqual([
+      "/api/v1/targets",
+      "/api/v1/targets/target-1/remove",
+      "/api/v1/bindings",
+      "/api/v1/bindings/binding-1/remove",
+      "/api/v1/skills",
+      "/api/v1/projections/project",
+      "/api/v1/projections/capture",
+      "/api/v1/orphans/clean",
+      "/api/v1/ops/retry",
+      "/api/v1/ops/purge",
+      "/api/v1/workspace/remote",
+      "/api/v1/sync/push",
+      "/api/v1/sync/pull",
+      "/api/v1/sync/replay",
+      "/api/v1/ops/history/repair",
+    ]);
+  });
+});

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -370,7 +370,7 @@ export const api = {
     if (typeof options?.limit === "number") params.set("limit", String(options.limit));
     if (typeof options?.offset === "number") params.set("offset", String(options.offset));
     const qs = params.size > 0 ? `?${params.toString()}` : "";
-    return getJson<OpsPayload>(`/api/registry/ops${qs}`, signal);
+    return getJson<OpsPayload>(`/api/v1/ops${qs}`, signal);
   },
   bindingShow: (id: string, signal?: AbortSignal) =>
     getJson<BindingShowPayload>(`/api/registry/bindings/${encodeURIComponent(id)}`, signal),
@@ -378,32 +378,32 @@ export const api = {
     getJson<TargetShowPayload>(`/api/registry/targets/${encodeURIComponent(id)}`, signal),
   remoteStatus: async (signal?: AbortSignal) =>
     parseRemoteStatusResponse(
-      "/api/remote/status",
+      "/api/v1/sync/status",
       unwrapReadData<RemoteStatusResponse>(
-        "/api/remote/status",
-        await getJson<unknown>("/api/remote/status", signal),
+        "/api/v1/sync/status",
+        await getJson<unknown>("/api/v1/sync/status", signal),
       ),
     ),
   pending: (signal?: AbortSignal) => getJsonData<PendingPayload>("/api/pending", signal),
 
-  opsRetry: () => postJson("/api/ops/retry", {}),
-  opsPurge: () => postJson("/api/ops/purge", {}),
-  remoteSet: (body: RemoteSetBody) => postJson("/api/remote/set", body),
+  opsRetry: () => postJson("/api/v1/ops/retry", {}),
+  opsPurge: () => postJson("/api/v1/ops/purge", {}),
+  remoteSet: (body: RemoteSetBody) => postJson("/api/v1/workspace/remote", body),
   workspaceInit: (body: WorkspaceInitBody) => postJson("/api/v1/workspace/init", body),
 
-  targetAdd: (body: TargetAddBody) => postJson("/api/registry/targets", body),
-  targetRemove: (targetId: string) => postJson(`/api/registry/targets/${encodeURIComponent(targetId)}/remove`, {}),
-  bindingAdd: (body: BindingAddBody) => postJson("/api/registry/bindings", body),
-  bindingRemove: (bindingId: string) => postJson(`/api/registry/bindings/${encodeURIComponent(bindingId)}/remove`, {}),
-  skillAdd: (body: SkillAddBody) => postJson("/api/registry/skills", body),
-  project: (body: ProjectBody) => postJson("/api/registry/project", body),
-  capture: (body: CaptureBody) => postJson("/api/registry/capture", body),
-  orphanClean: (body: OrphanCleanBody) => postJson("/api/registry/orphans/clean", body),
+  targetAdd: (body: TargetAddBody) => postJson("/api/v1/targets", body),
+  targetRemove: (targetId: string) => postJson(`/api/v1/targets/${encodeURIComponent(targetId)}/remove`, {}),
+  bindingAdd: (body: BindingAddBody) => postJson("/api/v1/bindings", body),
+  bindingRemove: (bindingId: string) => postJson(`/api/v1/bindings/${encodeURIComponent(bindingId)}/remove`, {}),
+  skillAdd: (body: SkillAddBody) => postJson("/api/v1/skills", body),
+  project: (body: ProjectBody) => postJson("/api/v1/projections/project", body),
+  capture: (body: CaptureBody) => postJson("/api/v1/projections/capture", body),
+  orphanClean: (body: OrphanCleanBody) => postJson("/api/v1/orphans/clean", body),
 
-  syncPush: () => postJson("/api/sync/push", {}),
-  syncPull: () => postJson("/api/sync/pull", {}),
-  syncReplay: () => postJson("/api/sync/replay", {}),
-  opsHistoryRepair: (body: HistoryRepairBody) => postJson("/api/ops/history/repair", body),
+  syncPush: () => postJson("/api/v1/sync/push", {}),
+  syncPull: () => postJson("/api/v1/sync/pull", {}),
+  syncReplay: () => postJson("/api/v1/sync/replay", {}),
+  opsHistoryRepair: (body: HistoryRepairBody) => postJson("/api/v1/ops/history/repair", body),
 
   skillHistory: (name: string, signal?: AbortSignal) =>
     getJson<SkillHistoryPayload>(

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -48,9 +48,18 @@ function installFetchMock(failingPath: string, failingResponse: Response) {
             ? failingResponse
             : jsonResponse({ ok: true, data: { counts: {}, projections: [], rules: [], targets: [], bindings: [] } }),
         );
-      case "/api/remote/status":
+      case "/api/v1/sync/status":
         return Promise.resolve(
-          url === failingPath ? failingResponse : jsonResponse({ remote: { sync_state: "CLEAN" }, warnings: [] }),
+          url === failingPath
+            ? failingResponse
+            : jsonResponse({
+                ok: true,
+                cmd: "sync.status",
+                request_id: "req-sync",
+                data: { remote: { sync_state: "CLEAN" }, warnings: [] },
+                error: null,
+                meta: { warnings: [] },
+              }),
         );
       case "/api/pending":
         return Promise.resolve(url === failingPath ? failingResponse : jsonResponse({ count: 0, ops: [] }));
@@ -95,9 +104,9 @@ describe("PanelApp status failure UI", () => {
     expect(screen.getByText(/GET \/api\/registry\/status returned 503/i)).toBeTruthy();
   });
 
-  it("shows registry error state when /api/remote/status returns a structured backend failure", async () => {
+  it("shows registry error state when /api/v1/sync/status returns a structured backend failure", async () => {
     installFetchMock(
-      "/api/remote/status",
+      "/api/v1/sync/status",
       errorResponse(500, {
         ok: false,
         error: { code: "IO_ERROR", message: "failed to read pending_ops.jsonl" },

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -121,7 +121,7 @@ export function PanelApp() {
   const [mutationVersion, setMutationVersion] = useState(0);
   // Gate: all mutation affordances in child pages receive this prop.
   // Future shortcuts, command palette, and hotkey handlers must check readOnly
-  // before calling any /api/registry/*, /api/ops/*, or /api/sync/* POST route.
+  // before calling any /api/v1/* mutation route.
   const readOnly = live.mode !== "live";
   const onMutation = () => {
     setMutationVersion((cur) => cur + 1);

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -125,11 +125,36 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v1/workspace/status", get(v1_workspace_status))
         .route("/api/v1/workspace/init", post(v1_workspace_init))
         .route("/api/v1/workspace/doctor", get(v1_workspace_doctor))
-        .route("/api/v1/targets", get(v1_registry_targets))
-        .route("/api/v1/bindings", get(v1_registry_bindings))
+        .route("/api/v1/workspace/remote", post(remote_set))
+        .route(
+            "/api/v1/targets",
+            get(v1_registry_targets).post(registry_target_add),
+        )
+        .route(
+            "/api/v1/targets/{target_id}/remove",
+            post(registry_target_remove),
+        )
+        .route(
+            "/api/v1/bindings",
+            get(v1_registry_bindings).post(registry_binding_add),
+        )
+        .route(
+            "/api/v1/bindings/{binding_id}/remove",
+            post(registry_binding_remove),
+        )
+        .route("/api/v1/skills", post(registry_skill_add))
         .route("/api/v1/projections", get(v1_registry_projections))
+        .route("/api/v1/projections/project", post(registry_project))
+        .route("/api/v1/projections/capture", post(registry_capture))
+        .route("/api/v1/orphans/clean", post(registry_orphan_clean))
         .route("/api/v1/ops", get(v1_registry_ops))
+        .route("/api/v1/ops/retry", post(ops_retry))
+        .route("/api/v1/ops/purge", post(ops_purge))
+        .route("/api/v1/ops/history/repair", post(ops_history_repair))
         .route("/api/v1/sync/status", get(v1_sync_status))
+        .route("/api/v1/sync/push", post(sync_push))
+        .route("/api/v1/sync/pull", post(sync_pull))
+        .route("/api/v1/sync/replay", post(sync_replay))
         .route("/api/info", get(info))
         .route("/api/skills", get(skills))
         .route("/api/registry/status", get(registry_status))


### PR DESCRIPTION
## Summary
- add `/api/v1/*` mutation aliases for targets, bindings, skills, projections, orphans, ops, sync, and remote set
- move the Panel TypeScript client to those V1 mutation endpoints and `/api/v1/ops`/`/api/v1/sync/status`
- keep legacy endpoints in place for now
- add client coverage to lock the V1 mutation paths

Fixes #121.

## Verification
- `cargo fmt --check`
- `cargo test -q panel::tests::`
- `cd panel && bun run typecheck`
- `cd panel && bun run test -- client PanelApp`
- `git diff --check`
- `make ci`