### PR TITLE
Add Panel skill lifecycle actions

### DIFF
--- a/docs/LOOM_ARCHITECTURE_DECISIONS.md
+++ b/docs/LOOM_ARCHITECTURE_DECISIONS.md
@@ -116,25 +116,29 @@ This decision does not make the panel the primary control plane. The CLI remains
 
 ### 4.1 Mutation Route Table (v1 phase 1 frozen surface)
 
-The following 15 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
+The following 19 routes are the complete mutation surface for phase 1. Every row passes through `ensure_mutation_authorized` then `run_panel_command`. Adding a new POST route without a corresponding row in this table is an explicit contract break requiring a section-4 update.
 
 | cmd name                 | HTTP | path                                    | CLI command                  |
 |--------------------------|------|-----------------------------------------|------------------------------|
 | workspace.init           | POST | /api/v1/workspace/init                        | Workspace::Init              |
-| target.add               | POST | /api/registry/targets                         | Target::Add                  |
-| target.remove            | POST | /api/registry/targets/{target_id}/remove      | Target::Remove               |
-| workspace.binding.add    | POST | /api/registry/bindings                        | Workspace::Binding::Add      |
-| workspace.binding.remove | POST | /api/registry/bindings/{binding_id}/remove    | Workspace::Binding::Remove   |
-| skill.project            | POST | /api/registry/project                         | Skill::Project               |
-| skill.capture            | POST | /api/registry/capture                         | Skill::Capture               |
-| skill.orphan.clean       | POST | /api/registry/orphans/clean                   | Skill::Orphan::Clean         |
-| workspace.remote.set     | POST | /api/remote/set                         | Workspace::Remote::Set       |
-| ops.retry                | POST | /api/ops/retry                          | Ops::Retry                   |
-| ops.purge                | POST | /api/ops/purge                          | Ops::Purge                   |
-| ops.history.repair       | POST | /api/ops/history/repair                 | Ops::History::Repair         |
-| sync.push                | POST | /api/sync/push                          | Sync::Push                   |
-| sync.pull                | POST | /api/sync/pull                          | Sync::Pull                   |
-| sync.replay              | POST | /api/sync/replay                        | Sync::Replay                 |
+| target.add               | POST | /api/v1/targets                               | Target::Add                  |
+| target.remove            | POST | /api/v1/targets/{target_id}/remove            | Target::Remove               |
+| workspace.binding.add    | POST | /api/v1/bindings                              | Workspace::Binding::Add      |
+| workspace.binding.remove | POST | /api/v1/bindings/{binding_id}/remove          | Workspace::Binding::Remove   |
+| skill.project            | POST | /api/v1/projections/project                   | Skill::Project               |
+| skill.capture            | POST | /api/v1/projections/capture                   | Skill::Capture               |
+| skill.save               | POST | /api/v1/skills/{skill_name}/save              | Skill::Save                  |
+| skill.snapshot           | POST | /api/v1/skills/{skill_name}/snapshot          | Skill::Snapshot              |
+| skill.release            | POST | /api/v1/skills/{skill_name}/release           | Skill::Release               |
+| skill.rollback           | POST | /api/v1/skills/{skill_name}/rollback          | Skill::Rollback              |
+| skill.orphan.clean       | POST | /api/v1/orphans/clean                         | Skill::Orphan::Clean         |
+| workspace.remote.set     | POST | /api/v1/workspace/remote                      | Workspace::Remote::Set       |
+| ops.retry                | POST | /api/v1/ops/retry                             | Ops::Retry                   |
+| ops.purge                | POST | /api/v1/ops/purge                             | Ops::Purge                   |
+| ops.history.repair       | POST | /api/v1/ops/history/repair                    | Ops::History::Repair         |
+| sync.push                | POST | /api/v1/sync/push                             | Sync::Push                   |
+| sync.pull                | POST | /api/v1/sync/pull                             | Sync::Pull                   |
+| sync.replay              | POST | /api/v1/sync/replay                           | Sync::Replay                 |
 
 ## 5. Environment-Based Discovery
 

--- a/panel/src/lib/api/client.test.ts
+++ b/panel/src/lib/api/client.test.ts
@@ -62,6 +62,10 @@ describe("api v1 routes", () => {
     });
     await api.bindingRemove("binding-1");
     await api.skillAdd({ source: "/tmp/source", name: "demo" });
+    await api.skillSave("demo", { message: "save demo" });
+    await api.skillSnapshot("demo");
+    await api.skillRelease("demo", { version: "v1" });
+    await api.skillRollback("demo", { to: "HEAD~1" });
     await api.project({ skill: "demo", binding: "binding-1", target: "target-1", method: "symlink" });
     await api.capture({ instance: "inst-1" });
     await api.orphanClean({ delete_live_paths: false });
@@ -80,6 +84,10 @@ describe("api v1 routes", () => {
       "/api/v1/bindings",
       "/api/v1/bindings/binding-1/remove",
       "/api/v1/skills",
+      "/api/v1/skills/demo/save",
+      "/api/v1/skills/demo/snapshot",
+      "/api/v1/skills/demo/release",
+      "/api/v1/skills/demo/rollback",
       "/api/v1/projections/project",
       "/api/v1/projections/capture",
       "/api/v1/orphans/clean",

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -272,6 +272,19 @@ export interface SkillAddBody {
   name: string;
 }
 
+export interface SkillSaveBody {
+  message?: string;
+}
+
+export interface SkillReleaseBody {
+  version: string;
+}
+
+export interface SkillRollbackBody {
+  to?: string;
+  steps?: number;
+}
+
 export interface CaptureBody {
   skill?: string;
   binding?: string;
@@ -396,6 +409,14 @@ export const api = {
   bindingAdd: (body: BindingAddBody) => postJson("/api/v1/bindings", body),
   bindingRemove: (bindingId: string) => postJson(`/api/v1/bindings/${encodeURIComponent(bindingId)}/remove`, {}),
   skillAdd: (body: SkillAddBody) => postJson("/api/v1/skills", body),
+  skillSave: (name: string, body: SkillSaveBody = {}) =>
+    postJson(`/api/v1/skills/${encodeURIComponent(name)}/save`, body),
+  skillSnapshot: (name: string) =>
+    postJson(`/api/v1/skills/${encodeURIComponent(name)}/snapshot`, {}),
+  skillRelease: (name: string, body: SkillReleaseBody) =>
+    postJson(`/api/v1/skills/${encodeURIComponent(name)}/release`, body),
+  skillRollback: (name: string, body: SkillRollbackBody) =>
+    postJson(`/api/v1/skills/${encodeURIComponent(name)}/rollback`, body),
   project: (body: ProjectBody) => postJson("/api/v1/projections/project", body),
   capture: (body: CaptureBody) => postJson("/api/v1/projections/capture", body),
   orphanClean: (body: OrphanCleanBody) => postJson("/api/v1/orphans/clean", body),

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SkillsPage } from "./SkillsPage";
 import type { Skill } from "../../lib/types";
@@ -8,6 +8,10 @@ vi.mock("../../lib/api/client", () => ({
     skillHistory: vi.fn(),
     skillDiff: vi.fn(),
     capture: vi.fn(),
+    skillSave: vi.fn(),
+    skillSnapshot: vi.fn(),
+    skillRelease: vi.fn(),
+    skillRollback: vi.fn(),
   },
 }));
 
@@ -25,14 +29,14 @@ const mockSkill: Skill = {
   targets: [],
 };
 
-function renderPage() {
+function renderPage(overrides: { onMutation?: () => void } = {}) {
   return render(
     <SkillsPage
       skills={[mockSkill]}
       targets={[]}
       selectedSkill="skill-1"
       onSelectSkill={() => {}}
-      onMutation={() => {}}
+      onMutation={overrides.onMutation ?? (() => {})}
       readOnly={false}
     />,
   );
@@ -188,5 +192,50 @@ describe("SkillsPage — empty registry", () => {
     expect(
       screen.getAllByText(/loom skill add <source> --name <name>/).length,
     ).toBeGreaterThan(0);
+  });
+});
+
+describe("SkillsPage — lifecycle actions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (api.skillHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      data: { skill: "my-skill", count: 0, events: [] },
+    });
+    (api.skillSave as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, cmd: "skill.save", request_id: "req-save" });
+    (api.skillSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, cmd: "skill.snapshot", request_id: "req-snapshot" });
+    (api.skillRelease as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, cmd: "skill.release", request_id: "req-release" });
+    (api.skillRollback as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, cmd: "skill.rollback", request_id: "req-rollback" });
+  });
+
+  it("runs save, snapshot, release, and rollback for the selected skill", async () => {
+    const onMutation = vi.fn();
+    renderPage({ onMutation });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      expect(api.skillSave).toHaveBeenCalledWith("my-skill");
+      expect(screen.getByRole("button", { name: "Snapshot" })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Snapshot" }));
+    await waitFor(() => {
+      expect(api.skillSnapshot).toHaveBeenCalledWith("my-skill");
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("version"), { target: { value: "v1.0.0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Release" }));
+    await waitFor(() => {
+      expect(api.skillRelease).toHaveBeenCalledWith("my-skill", { version: "v1.0.0" });
+      expect(screen.getByRole("button", { name: "Rollback" })).not.toBeDisabled();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("HEAD~1"), { target: { value: "snapshot/my-skill/abc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rollback" }));
+
+    await waitFor(() => {
+      expect(api.skillRollback).toHaveBeenCalledWith("my-skill", { to: "snapshot/my-skill/abc" });
+      expect(onMutation).toHaveBeenCalledTimes(4);
+    });
   });
 });

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -319,6 +319,8 @@ function SkillDetail({
         <div className="v">{policyLabel}</div>
       </div>
 
+      <LifecycleActions skillName={skill.name} onMutation={onMutation} readOnly={readOnly} />
+
       <div className="tabs">
         <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")}>
           Lifecycle
@@ -359,6 +361,117 @@ function SkillDetail({
           <TargetsTab targets={targetObjs} />
         </>
       )}
+    </div>
+  );
+}
+
+function LifecycleActions({
+  skillName,
+  onMutation,
+  readOnly,
+}: {
+  skillName: string;
+  onMutation: () => void;
+  readOnly: boolean;
+}) {
+  const [version, setVersion] = useState("");
+  const [rollbackRef, setRollbackRef] = useState("");
+  const save = useMutation();
+  const snapshot = useMutation();
+  const release = useMutation();
+  const rollback = useMutation();
+
+  const runSave = () => {
+    save.run("skill save", () => api.skillSave(skillName), onMutation);
+  };
+
+  const runSnapshot = () => {
+    snapshot.run("skill snapshot", () => api.skillSnapshot(skillName), onMutation);
+  };
+
+  const submitRelease = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmed = version.trim();
+    if (!trimmed) return;
+    release.run("skill release", () => api.skillRelease(skillName, { version: trimmed }), () => {
+      setVersion("");
+      onMutation();
+    });
+  };
+
+  const submitRollback = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmed = rollbackRef.trim();
+    rollback.run(
+      "skill rollback",
+      () => api.skillRollback(skillName, trimmed ? { to: trimmed } : {}),
+      () => {
+        setRollbackRef("");
+        onMutation();
+      },
+    );
+  };
+
+  const busy = save.busy || snapshot.busy || release.busy || rollback.busy;
+  const disabled = readOnly || busy;
+  const status =
+    save.error ??
+    snapshot.error ??
+    release.error ??
+    rollback.error ??
+    save.success ??
+    snapshot.success ??
+    release.success ??
+    rollback.success;
+  const hasError = Boolean(save.error ?? snapshot.error ?? release.error ?? rollback.error);
+
+  return (
+    <div className="card" style={{ padding: 12, margin: "14px 0" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))", gap: 10 }}>
+        <button
+          className="btn ghost"
+          onClick={runSave}
+          disabled={disabled}
+          title={readOnly ? "registry offline" : undefined}
+          style={fullWidthButtonStyle}
+        >
+          {save.busy ? "saving..." : "Save"}
+        </button>
+        <button
+          className="btn ghost"
+          onClick={runSnapshot}
+          disabled={disabled}
+          title={readOnly ? "registry offline" : undefined}
+          style={fullWidthButtonStyle}
+        >
+          {snapshot.busy ? "snapshotting..." : "Snapshot"}
+        </button>
+        <form onSubmit={submitRelease} style={{ display: "flex", gap: 8, minWidth: 0 }}>
+          <input
+            value={version}
+            onChange={(event) => setVersion(event.target.value)}
+            placeholder="version"
+            style={formInputStyle}
+            disabled={disabled}
+          />
+          <button className="btn primary" type="submit" disabled={disabled || !version.trim()}>
+            {release.busy ? "releasing..." : "Release"}
+          </button>
+        </form>
+        <form onSubmit={submitRollback} style={{ display: "flex", gap: 8, minWidth: 0 }}>
+          <input
+            value={rollbackRef}
+            onChange={(event) => setRollbackRef(event.target.value)}
+            placeholder="HEAD~1"
+            style={formInputStyle}
+            disabled={disabled}
+          />
+          <button className="btn ghost danger" type="submit" disabled={disabled}>
+            {rollback.busy ? "rolling back..." : "Rollback"}
+          </button>
+        </form>
+      </div>
+      {status && <div style={hasError ? errorStyle : okStyle}>{hasError ? status : `✓ ${status}`}</div>}
     </div>
   );
 }
@@ -644,6 +757,11 @@ const formInputStyle: React.CSSProperties = {
   fontSize: 12,
   fontFamily: "var(--font-mono)",
   minWidth: 0,
+};
+
+const fullWidthButtonStyle: React.CSSProperties = {
+  width: "100%",
+  justifyContent: "center",
 };
 
 const errorStyle: React.CSSProperties = {

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -27,7 +27,8 @@ use super::auth::{
 };
 use super::{
     BindingAddRequest, CaptureRequest, HistoryRepairRequest, OrphanCleanRequest, PanelState,
-    ProjectRequest, RemoteSetRequest, SkillAddRequest, TargetAddRequest, WorkspaceInitRequest,
+    ProjectRequest, RemoteSetRequest, SkillAddRequest, SkillReleaseRequest, SkillRollbackRequest,
+    SkillSaveRequest, TargetAddRequest, WorkspaceInitRequest,
 };
 
 /// Accept `[a-z0-9_-]{1,64}` for `policy_profile`. The core CLI path enforces
@@ -677,6 +678,97 @@ pub(super) async fn registry_skill_add(
             command: crate::cli::SkillCommand::Add(AddArgs {
                 source: req.source,
                 name: req.name,
+            }),
+        },
+    )
+}
+
+pub(super) async fn registry_skill_save(
+    AxumPath(skill_name): AxumPath<String>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<SkillSaveRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "skill.save") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "skill.save",
+        StatusCode::OK,
+        Command::Skill {
+            command: crate::cli::SkillCommand::Save(crate::cli::SaveArgs {
+                skill: skill_name,
+                message: req.message,
+            }),
+        },
+    )
+}
+
+pub(super) async fn registry_skill_snapshot(
+    AxumPath(skill_name): AxumPath<String>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "skill.snapshot") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "skill.snapshot",
+        StatusCode::OK,
+        Command::Skill {
+            command: crate::cli::SkillCommand::Snapshot(crate::cli::SkillOnlyArgs {
+                skill: skill_name,
+            }),
+        },
+    )
+}
+
+pub(super) async fn registry_skill_release(
+    AxumPath(skill_name): AxumPath<String>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<SkillReleaseRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "skill.release") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "skill.release",
+        StatusCode::OK,
+        Command::Skill {
+            command: crate::cli::SkillCommand::Release(crate::cli::ReleaseArgs {
+                skill: skill_name,
+                version: req.version,
+            }),
+        },
+    )
+}
+
+pub(super) async fn registry_skill_rollback(
+    AxumPath(skill_name): AxumPath<String>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    State(state): State<PanelState>,
+    Json(req): Json<SkillRollbackRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(response) = ensure_mutation_authorized(&state, peer, &headers, "skill.rollback") {
+        return response;
+    }
+    run_panel_command(
+        &state,
+        "skill.rollback",
+        StatusCode::OK,
+        Command::Skill {
+            command: crate::cli::SkillCommand::Rollback(crate::cli::RollbackArgs {
+                skill: skill_name,
+                to: req.to,
+                steps: req.steps,
             }),
         },
     )

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -67,6 +67,25 @@ pub(super) struct SkillAddRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct SkillSaveRequest {
+    #[serde(default)]
+    pub(super) message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct SkillReleaseRequest {
+    pub(super) version: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct SkillRollbackRequest {
+    #[serde(default)]
+    pub(super) to: Option<String>,
+    #[serde(default)]
+    pub(super) steps: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct CaptureRequest {
     #[serde(default)]
     pub(super) skill: Option<String>,
@@ -143,6 +162,22 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
             post(registry_binding_remove),
         )
         .route("/api/v1/skills", post(registry_skill_add))
+        .route(
+            "/api/v1/skills/{skill_name}/save",
+            post(registry_skill_save),
+        )
+        .route(
+            "/api/v1/skills/{skill_name}/snapshot",
+            post(registry_skill_snapshot),
+        )
+        .route(
+            "/api/v1/skills/{skill_name}/release",
+            post(registry_skill_release),
+        )
+        .route(
+            "/api/v1/skills/{skill_name}/rollback",
+            post(registry_skill_rollback),
+        )
         .route("/api/v1/projections", get(v1_registry_projections))
         .route("/api/v1/projections/project", post(registry_project))
         .route("/api/v1/projections/capture", post(registry_capture))

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::cli::{
-    BindingAddArgs, CaptureArgs, Command, OpsCommand, ProjectArgs, ProjectionMethod, RemoteCommand,
-    SkillCommand, SyncCommand, TargetAddArgs, TargetCommand, TargetOwnership,
-    WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs, WorkspaceMatcherKind,
+    BindingAddArgs, CaptureArgs, Command, OpsCommand, ProjectArgs, ProjectionMethod, ReleaseArgs,
+    RemoteCommand, RollbackArgs, SaveArgs, SkillCommand, SkillOnlyArgs, SyncCommand, TargetAddArgs,
+    TargetCommand, TargetOwnership, WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs,
+    WorkspaceMatcherKind,
 };
 use crate::panel::auth::{
     ensure_mutation_authorized, error_envelope, request_origin_matches, run_panel_command,
@@ -13,7 +14,7 @@ use serde_json::json;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 // Exhaustive list of every panel mutation command. Must stay in sync with the
-// 15-row table in docs/LOOM_ARCHITECTURE_DECISIONS.md section 4.1 and the
+// 19-row table in docs/LOOM_ARCHITECTURE_DECISIONS.md section 4.1 and the
 // route registrations in `run_panel`.
 const MUTATION_COMMANDS: &[&str] = &[
     "workspace.init",
@@ -23,6 +24,10 @@ const MUTATION_COMMANDS: &[&str] = &[
     "workspace.binding.remove",
     "skill.project",
     "skill.capture",
+    "skill.save",
+    "skill.snapshot",
+    "skill.release",
+    "skill.rollback",
     "skill.orphan.clean",
     "workspace.remote.set",
     "ops.retry",
@@ -34,8 +39,8 @@ const MUTATION_COMMANDS: &[&str] = &[
 ];
 
 #[test]
-fn mutation_commands_count_is_fifteen() {
-    assert_eq!(MUTATION_COMMANDS.len(), 15);
+fn mutation_commands_count_is_nineteen() {
+    assert_eq!(MUTATION_COMMANDS.len(), 19);
 }
 
 #[test]
@@ -297,6 +302,46 @@ fn run_panel_command_returns_non_2xx_for_logical_failures_across_mutations() {
                     binding: None,
                     instance: None,
                     message: None,
+                }),
+            },
+        ),
+        (
+            "skill.save",
+            StatusCode::OK,
+            Command::Skill {
+                command: SkillCommand::Save(SaveArgs {
+                    skill: "missing-skill".to_string(),
+                    message: None,
+                }),
+            },
+        ),
+        (
+            "skill.snapshot",
+            StatusCode::OK,
+            Command::Skill {
+                command: SkillCommand::Snapshot(SkillOnlyArgs {
+                    skill: "missing-skill".to_string(),
+                }),
+            },
+        ),
+        (
+            "skill.release",
+            StatusCode::OK,
+            Command::Skill {
+                command: SkillCommand::Release(ReleaseArgs {
+                    skill: "missing-skill".to_string(),
+                    version: "v1".to_string(),
+                }),
+            },
+        ),
+        (
+            "skill.rollback",
+            StatusCode::OK,
+            Command::Skill {
+                command: SkillCommand::Rollback(RollbackArgs {
+                    skill: "missing-skill".to_string(),
+                    to: Some("HEAD~1".to_string()),
+                    steps: None,
                 }),
             },
         ),


### PR DESCRIPTION
Closes #123.

## Summary
- add v1 Panel mutation routes for skill save, snapshot, release, and rollback
- add API client methods and Skills page lifecycle controls for those commands
- update the Panel mutation contract table and tests to include the 19-route v1 surface

## Verification
- cargo fmt --check
- cargo test -q panel::tests::
- cd panel && bun run typecheck
- cd panel && bun run test -- client SkillsPage
- cd panel && bun run build
- git diff --check HEAD~1..HEAD
- make ci