### PR TITLE
feat(doctor): report agent skill directory inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Quick decision: **edits from the agent side → `capture`; edits inside the regi
 | Git-native sync + replay | ❌ | cloud sync | ❌ | **✅** |
 | Hard write guard | ❌ | ❌ | ❌ | **✅** |
 | CLI-first + Web panel | GUI only | GUI only | CLI only | **✅** |
-| Breadth of agents supported | 44 | 5 | 18 | 10 (Claude, Codex, Cursor, Windsurf, Cline, Copilot, Aider, OpenCode, Gemini CLI, Goose) |
+| Breadth of agents supported | 44 | 5 | 18 | 10 ([list](docs/SUPPORTED_AGENTS.md)) |
 | Desktop app (dmg/msi) | ✅ | ✅ | ❌ | — |
 
 **Pick Loom when** you want fine-grained control (multi-project routing, Git-backed lifecycle, git-tracked audit trail) and are comfortable on the CLI. **Pick skills-hub or cc-switch** when you want a one-click GUI with broad agent coverage and don't need projection/binding semantics.

--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ and fails the commit if rustfmt would make changes. Disable with
 
 ## Roadmap
 
-- Per-agent default path conventions & env overrides (beyond `CLAUDE_SKILLS_DIR` / `CODEX_SKILLS_DIR`) for the 8 newly added agents — paths are currently supplied explicitly via `target add --path`
-- Extend `loom workspace init --scan-existing` auto-import to the 8 newly added agents once their skill-directory conventions stabilize (currently scans Claude and Codex only)
+- Per-agent environment overrides beyond the default paths listed in [Supported Agents](docs/SUPPORTED_AGENTS.md).
+- Convert observed agent directories to managed projection targets from the Panel once users opt in.
 - Desktop packaging (Tauri) for users who prefer a GUI
 - Skill marketplace integration (upstream catalogs such as `agent-skills`)
 

--- a/docs/SUPPORTED_AGENTS.md
+++ b/docs/SUPPORTED_AGENTS.md
@@ -1,0 +1,79 @@
+# Supported Agents
+
+Loom defines a fixed list of agent kinds. Each kind has a canonical default
+skill directory that `loom workspace init --scan-existing` and the
+`workspace doctor` agent inventory check probe under `$HOME`.
+
+## Built-in agent kinds
+
+| Agent kind (`AgentKind`) | CLI value (`--agent`) | Default skill directory |
+|---|---|---|
+| `Claude` | `claude` | `$HOME/.claude/skills` |
+| `Codex` | `codex` | `$HOME/.codex/skills` |
+| `Cursor` | `cursor` | `$HOME/.cursor/skills` |
+| `Windsurf` | `windsurf` | `$HOME/.windsurf/skills` |
+| `Cline` | `cline` | `$HOME/.cline/skills` |
+| `Copilot` | `copilot` | `$HOME/.github/copilot/skills` |
+| `Aider` | `aider` | `$HOME/.aider/skills` |
+| `Opencode` | `opencode` | `$HOME/.opencode/skills` |
+| `GeminiCli` | `gemini-cli` | `$HOME/.gemini/skills` |
+| `Goose` | `goose` | `$HOME/.config/goose/skills` |
+
+The canonical source of truth is `src/cli.rs` (the `AgentKind` enum) plus
+`src/commands/workspace_cmds/shared.rs` (`DEFAULT_SCAN_AGENTS`,
+`default_skill_dir`).
+
+## How `--scan-existing` uses this list
+
+`loom workspace init --scan-existing` iterates `DEFAULT_SCAN_AGENTS`, resolves
+each default skill directory under the caller's `$HOME`, and registers any
+directory that exists as an `observed` target. Missing directories are
+reported under `skipped` with reason `does-not-exist`; non-directories are
+reported with reason `not-a-directory`.
+
+## How `workspace doctor` reports the inventory
+
+`loom workspace doctor` adds an informational check
+(`section=agents`, `id=agent_skill_inventory`, `severity=info`) that lists,
+for every built-in agent kind, the resolved default path, whether the path
+exists, and how many registered targets currently point at that path.
+
+The check is informational only and does not affect the overall `healthy`
+boolean. When `HOME` is unset or empty, the inventory is reported with
+`home_set=false` and `total=0` instead of failing the command.
+
+The same payload is also exposed under
+`data.checks.agent_skill_dirs` for callers that read the legacy nested
+`checks` object.
+
+## Registering a path outside the default list
+
+If your environment stores skills outside the canonical default (for example,
+an XDG override, a custom team layout, or an agent kind that Loom does not
+yet model), register the path explicitly instead of relying on
+`--scan-existing`:
+
+```bash
+loom --json target add \
+  --agent claude \
+  --path /custom/path/to/skills \
+  --ownership observed
+```
+
+Pick the `--agent` value that most closely matches the target tool. The
+registered target's `path` is the absolute path on disk; the agent kind is a
+label used for routing through bindings.
+
+## Adding a new agent kind
+
+Adding a new built-in agent kind is a coordinated change:
+
+1. Add the variant to `AgentKind` in `src/cli.rs`, including the kebab-case
+   serde rename so it round-trips through the JSON envelope.
+2. Add the variant to `DEFAULT_SCAN_AGENTS` and a matching arm in
+   `default_skill_dir` in `src/commands/workspace_cmds/shared.rs`.
+3. Extend `agent_kind_as_str` in `src/commands/helpers.rs`.
+4. Update this document and the `Quick Start` block of `README.md`.
+5. Cover the new variant in `tests/cli.rs` (serde round-trip) and add a
+   `workspace doctor` assertion in `tests/doctor.rs` if the new path needs an
+   inventory entry assertion.

--- a/panel/src/pages/panel/DoctorPage.tsx
+++ b/panel/src/pages/panel/DoctorPage.tsx
@@ -130,8 +130,66 @@ function DoctorRow({ check }: { check: DoctorCheck }) {
         {!check.ok && check.next_action && (
           <div style={{ color: "var(--ink-3)", marginTop: 3 }}>{check.next_action}</div>
         )}
+        {check.id === "agent_skill_inventory" && <AgentInventoryDetails details={check.details} />}
       </td>
     </tr>
+  );
+}
+
+type AgentInventoryRow = {
+  agent: string;
+  default_path: string;
+  present: boolean;
+  registered_targets?: Array<{ target_id?: string; ownership?: string }>;
+};
+
+function AgentInventoryDetails({ details }: { details?: Record<string, unknown> }) {
+  const agents = Array.isArray(details?.agents)
+    ? (details.agents.filter(isAgentInventoryRow) as AgentInventoryRow[])
+    : [];
+  if (agents.length === 0) return null;
+
+  return (
+    <div style={{ marginTop: 8, display: "grid", gap: 6 }}>
+      {agents.map((agent) => (
+        <div
+          key={agent.agent}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "92px minmax(0, 1fr) 92px",
+            gap: 8,
+            alignItems: "center",
+          }}
+        >
+          <span className="mono">{agent.agent}</span>
+          <span className="mono dim" title={agent.default_path} style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+            {agent.default_path}
+          </span>
+          <span className={`chip ${agent.present ? "ok" : "warn"}`}>
+            {agent.present ? "present" : "missing"}
+          </span>
+          {agent.registered_targets && agent.registered_targets.length > 0 && (
+            <div style={{ gridColumn: "2 / 4", display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {agent.registered_targets.map((target) => (
+                <span className="chip" key={target.target_id ?? `${agent.agent}-${target.ownership}`}>
+                  {target.ownership ?? "target"} · {target.target_id ?? "unknown"}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function isAgentInventoryRow(value: unknown): value is AgentInventoryRow {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.agent === "string" &&
+    typeof row.default_path === "string" &&
+    typeof row.present === "boolean"
   );
 }
 

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -260,6 +260,37 @@ function doctorPayload(): DoctorPayload {
         next_action: "inspect state/pending_ops.jsonl and repair or purge malformed queue entries",
         details: { warning_count: 1 },
       },
+      {
+        section: "agents",
+        id: "agent_skill_inventory",
+        ok: true,
+        severity: "info",
+        message: "detected 1 of 2 known agent skill directories",
+        next_action: null,
+        details: {
+          agents: [
+            {
+              agent: "claude",
+              default_path: "/tmp/home/.claude/skills",
+              present: true,
+              registered_target_count: 1,
+              registered_targets: [
+                {
+                  target_id: "target_claude_claude_skills",
+                  ownership: "observed",
+                },
+              ],
+            },
+            {
+              agent: "codex",
+              default_path: "/tmp/home/.codex/skills",
+              present: false,
+              registered_target_count: 0,
+              registered_targets: [],
+            },
+          ],
+        },
+      },
     ],
   };
 }
@@ -688,6 +719,12 @@ test("DoctorPage renders structured workspace doctor checks", async () => {
     expect(markup(renderer!).includes("pending_queue_warnings")).toBe(true);
     expect(markup(renderer!).includes("pending queue has malformed or ignored entries")).toBe(true);
     expect(markup(renderer!).includes("inspect state/pending_ops.jsonl")).toBe(true);
+    expect(markup(renderer!).includes("agent_skill_inventory")).toBe(true);
+    expect(markup(renderer!).includes("/tmp/home/.claude/skills")).toBe(true);
+    expect(markup(renderer!).includes("present")).toBe(true);
+    expect(markup(renderer!).includes("missing")).toBe(true);
+    expect(markup(renderer!).includes("observed")).toBe(true);
+    expect(markup(renderer!).includes("target_claude_claude_skills")).toBe(true);
 
     await act(async () => {
       renderer!.update(<DoctorPage live={true} mode="live" refreshKey="tick-2" />);

--- a/src/commands/workspace_cmds/doctor.rs
+++ b/src/commands/workspace_cmds/doctor.rs
@@ -8,8 +8,9 @@ use crate::gitops;
 use crate::state::AppContext;
 use crate::state_model::{RegistrySnapshot, RegistryStatePaths};
 
-use super::super::helpers::{map_git, map_io, map_registry_state};
+use super::super::helpers::{agent_kind_as_str, map_git, map_io, map_registry_state};
 use super::super::{App, CommandFailure};
+use super::shared::{DEFAULT_SCAN_AGENTS, default_skill_dir};
 
 impl App {
     pub fn cmd_doctor(&self) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
@@ -32,7 +33,16 @@ impl App {
         let projections_ok = projection_checks
             .iter()
             .all(|check| check.get("ok").and_then(|v| v.as_bool()).unwrap_or(false));
-        let checks_v1 = build_doctor_checks(
+
+        let home_opt = std::env::var("HOME").ok().filter(|h| !h.is_empty());
+        let agent_inventory =
+            build_agent_skill_inventory(home_opt.as_deref(), registry_snapshot.as_ref());
+        let agent_inventory_message = agent_inventory["message"]
+            .as_str()
+            .unwrap_or("agent skill directory inventory")
+            .to_string();
+
+        let mut checks_v1 = build_doctor_checks(
             &self.ctx,
             fsck_ok,
             registry_schema_ok,
@@ -40,6 +50,15 @@ impl App {
             history.conflicts.is_empty(),
             pending_report.warnings.as_slice(),
         );
+        checks_v1.push(json!({
+            "section": "agents",
+            "id": "agent_skill_inventory",
+            "ok": true,
+            "severity": "info",
+            "message": agent_inventory_message,
+            "next_action": Value::Null,
+            "details": agent_inventory.clone(),
+        }));
         let checks_v1_ok = checks_v1
             .iter()
             .all(|check| check.get("ok").and_then(|v| v.as_bool()).unwrap_or(false));
@@ -68,13 +87,51 @@ impl App {
                     "projection_drift": {
                         "ok": projections_ok,
                         "projections": projection_checks
-                    }
+                    },
+                    "agent_skill_dirs": agent_inventory
                 },
                 "checks_v1": checks_v1
             }),
             Meta::default(),
         ))
     }
+}
+
+fn build_agent_skill_inventory(home: Option<&str>, snapshot: Option<&RegistrySnapshot>) -> Value {
+    let mut agents: Vec<Value> = Vec::new();
+    if let Some(h) = home {
+        for agent in DEFAULT_SCAN_AGENTS {
+            let path = default_skill_dir(agent, h);
+            let path_str = path.display().to_string();
+            let present = path.is_dir();
+            let registered_target_count = snapshot
+                .map(|s| s.targets.targets.iter().filter(|t| t.path == path_str).count())
+                .unwrap_or(0);
+            agents.push(json!({
+                "agent": agent_kind_as_str(agent),
+                "default_path": path_str,
+                "present": present,
+                "registered_target_count": registered_target_count,
+            }));
+        }
+    }
+    let present_count = agents
+        .iter()
+        .filter(|a| a["present"].as_bool().unwrap_or(false))
+        .count();
+    let total = agents.len();
+    let message = if home.is_some() {
+        format!("detected {present_count} of {total} known agent skill directories")
+    } else {
+        "HOME not set; agent skill directory inventory unavailable".to_string()
+    };
+    json!({
+        "agents": agents,
+        "home_set": home.is_some(),
+        "present_count": present_count,
+        "total": total,
+        "message": message,
+    })
 }
 
 pub(super) fn check_projection_drift(

--- a/src/commands/workspace_cmds/doctor.rs
+++ b/src/commands/workspace_cmds/doctor.rs
@@ -104,14 +104,29 @@ fn build_agent_skill_inventory(home: Option<&str>, snapshot: Option<&RegistrySna
             let path = default_skill_dir(agent, h);
             let path_str = path.display().to_string();
             let present = path.is_dir();
-            let registered_target_count = snapshot
-                .map(|s| s.targets.targets.iter().filter(|t| t.path == path_str).count())
-                .unwrap_or(0);
+            let registered_targets: Vec<Value> = snapshot
+                .map(|s| {
+                    s.targets
+                        .targets
+                        .iter()
+                        .filter(|target| paths_equivalent(&target.path, &path))
+                        .map(|target| {
+                            json!({
+                                "target_id": target.target_id,
+                                "agent": target.agent,
+                                "ownership": target.ownership,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let registered_target_count = registered_targets.len();
             agents.push(json!({
                 "agent": agent_kind_as_str(agent),
                 "default_path": path_str,
                 "present": present,
                 "registered_target_count": registered_target_count,
+                "registered_targets": registered_targets,
             }));
         }
     }
@@ -132,6 +147,18 @@ fn build_agent_skill_inventory(home: Option<&str>, snapshot: Option<&RegistrySna
         "total": total,
         "message": message,
     })
+}
+
+fn paths_equivalent(left: &str, right: &Path) -> bool {
+    let left_path = Path::new(left);
+    if left_path == right {
+        return true;
+    }
+
+    match (fs::canonicalize(left_path), fs::canonicalize(right)) {
+        (Ok(left_canon), Ok(right_canon)) => left_canon == right_canon,
+        _ => false,
+    }
 }
 
 pub(super) fn check_projection_drift(

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -218,6 +218,7 @@ fn workspace_doctor_reports_agent_skill_inventory() {
         .find(|a| a["agent"] == "claude")
         .expect("claude entry");
     assert_eq!(claude["present"], Value::Bool(true));
+    assert_eq!(claude["registered_target_count"], Value::from(0));
 
     let codex = agents
         .iter()
@@ -240,6 +241,47 @@ fn workspace_doctor_reports_agent_skill_inventory() {
 }
 
 #[test]
+fn workspace_doctor_agent_skill_inventory_reports_registered_targets() {
+    let root = TestDir::new("doctor-agent-inventory-registered-target");
+    let fake_home = root.path().join("fake-home");
+    let claude_skills = fake_home.join(".claude/skills");
+    fs::create_dir_all(&claude_skills).expect("fake claude skill dir");
+
+    assert!(
+        target_add(root.path(), "claude", &claude_skills, "observed")
+            .0
+            .status
+            .success()
+    );
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("HOME", fake_home.to_str().expect("HOME utf-8"))],
+        &["workspace", "doctor"],
+    );
+    assert!(output.status.success(), "doctor should succeed");
+
+    let inventory = find_check(&env, "agent_skill_inventory");
+    let agents = inventory["details"]["agents"]
+        .as_array()
+        .expect("agents array");
+    let claude = agents
+        .iter()
+        .find(|a| a["agent"] == "claude")
+        .expect("claude entry");
+    assert_eq!(claude["present"], Value::Bool(true));
+    assert_eq!(claude["registered_target_count"], Value::from(1));
+    assert_eq!(
+        claude["registered_targets"][0]["ownership"],
+        Value::String("observed".to_string())
+    );
+    assert_eq!(
+        claude["registered_targets"][0]["target_id"],
+        Value::String("target_claude_claude_skills".to_string())
+    );
+}
+
+#[test]
 fn workspace_doctor_agent_skill_inventory_when_home_unset() {
     let root = TestDir::new("doctor-agent-inventory-no-home");
     let target_path = root.path().join("live/claude-project-a");
@@ -250,12 +292,11 @@ fn workspace_doctor_agent_skill_inventory_when_home_unset() {
             .success()
     );
 
-    let (output, env) = run_loom_with_env(
-        root.path(),
-        &[("HOME", "")],
-        &["workspace", "doctor"],
+    let (output, env) = run_loom_with_env(root.path(), &[("HOME", "")], &["workspace", "doctor"]);
+    assert!(
+        output.status.success(),
+        "doctor should still succeed without HOME"
     );
-    assert!(output.status.success(), "doctor should still succeed without HOME");
 
     let inventory = find_check(&env, "agent_skill_inventory");
     assert_eq!(inventory["ok"], Value::Bool(true));

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -3,7 +3,7 @@ mod common;
 use std::fs;
 
 use common::actions::{binding_add, save_skill, skill_project, target_add};
-use common::{TestDir, run_loom, write_skill};
+use common::{TestDir, run_loom, run_loom_with_env, write_skill};
 use serde_json::Value;
 
 fn find_check<'a>(env: &'a Value, id_prefix: &str) -> &'a Value {
@@ -176,4 +176,89 @@ fn workspace_doctor_marks_pending_queue_warnings_unhealthy() {
     assert_eq!(check["ok"], Value::Bool(false));
     assert_eq!(check["severity"], Value::String("warning".to_string()));
     assert_eq!(check["details"]["warning_count"], Value::from(1));
+}
+
+#[test]
+fn workspace_doctor_reports_agent_skill_inventory() {
+    let root = TestDir::new("doctor-agent-inventory");
+    let fake_home = root.path().join("fake-home");
+    fs::create_dir_all(fake_home.join(".claude/skills")).expect("fake claude skill dir");
+    fs::create_dir_all(fake_home.join(".codex/skills")).expect("fake codex skill dir");
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("HOME", fake_home.to_str().expect("HOME utf-8"))],
+        &["workspace", "doctor"],
+    );
+    assert!(output.status.success(), "doctor should succeed");
+    assert_eq!(env["ok"], Value::Bool(true));
+
+    let inventory = find_check(&env, "agent_skill_inventory");
+    assert_eq!(inventory["section"], Value::String("agents".to_string()));
+    assert_eq!(inventory["ok"], Value::Bool(true));
+    assert_eq!(inventory["severity"], Value::String("info".to_string()));
+    assert_eq!(inventory["details"]["home_set"], Value::Bool(true));
+    assert_eq!(inventory["details"]["total"], Value::from(10));
+
+    let agents = inventory["details"]["agents"]
+        .as_array()
+        .expect("agents array");
+    assert_eq!(agents.len(), 10, "all known agents must be reported");
+
+    let claude = agents
+        .iter()
+        .find(|a| a["agent"] == "claude")
+        .expect("claude entry");
+    assert_eq!(claude["present"], Value::Bool(true));
+
+    let codex = agents
+        .iter()
+        .find(|a| a["agent"] == "codex")
+        .expect("codex entry");
+    assert_eq!(codex["present"], Value::Bool(true));
+
+    let cursor = agents
+        .iter()
+        .find(|a| a["agent"] == "cursor")
+        .expect("cursor entry");
+    assert_eq!(cursor["present"], Value::Bool(false));
+
+    let legacy = &env["data"]["checks"]["agent_skill_dirs"]["agents"];
+    assert_eq!(
+        legacy.as_array().map(Vec::len),
+        Some(10),
+        "checks.agent_skill_dirs must mirror inventory"
+    );
+}
+
+#[test]
+fn workspace_doctor_agent_skill_inventory_when_home_unset() {
+    let root = TestDir::new("doctor-agent-inventory-no-home");
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[("HOME", "")],
+        &["workspace", "doctor"],
+    );
+    assert!(output.status.success(), "doctor should still succeed without HOME");
+
+    let inventory = find_check(&env, "agent_skill_inventory");
+    assert_eq!(inventory["ok"], Value::Bool(true));
+    assert_eq!(inventory["details"]["home_set"], Value::Bool(false));
+    assert_eq!(inventory["details"]["total"], Value::from(0));
 }


### PR DESCRIPTION
## Summary

Closes #147.

- `workspace doctor` adds an informational `agent_skill_inventory` check for every built-in `AgentKind`.
- Each row reports the resolved default path, whether it exists, and any registered targets pointing at that directory with `target_id` + `ownership`.
- Panel Doctor expands the inventory so first-run users can see present/missing agent skill directories and observed/managed registrations without reading JSON.
- `docs/SUPPORTED_AGENTS.md` documents the canonical agent list, default skill directories, scan behavior, and how to extend it.
- README roadmap no longer says scanning is limited to Claude/Codex.

## Why

V1 supports ten agents, but onboarding should make that local inventory visible. This keeps first-run behavior non-destructive while showing users what Loom can import or observe next.

## Test plan

- [x] `cargo nextest run --test doctor` — 7 passed
- [x] `cd panel && bun run typecheck`
- [x] `cd panel && bun run test -- panel_state.test.tsx DoctorPage` — 22 passed
- [x] `/usr/bin/time -p make ci` — Rust 251/251, Panel 40/40, E2E all pass, perf smoke `--version p95=5.5ms`, `--help p95=6.6ms`, panel gzip 90528 bytes, wall 147.98s
- [ ] GitHub Actions verify job