### PR TITLE
Use union read model for Panel skills

### DIFF
--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -5,6 +5,7 @@ import type { RegistryTarget } from "../../generated/RegistryTarget";
 import type { PendingOp } from "../../types";
 import { normalizeAgentSlug } from "../agent_options";
 import type { AgentSlug, Binding, Op, Ownership, ProjectionMethod, Skill, Target } from "../types";
+import type { SkillSummaryPayload } from "./client";
 
 /**
  * Return the backend slug verbatim (lowercased + trimmed). Unknown slugs
@@ -106,8 +107,40 @@ export function adaptSkill(
     id: `s-${name}`,
     name,
     tag: inferTag(name),
+    sourceStatus: "present",
+    releaseTags: [],
+    snapshotTags: [],
     latestRev,
     ruleCount,
+    bindingCount: ruleCount,
+    projectionCount: projForSkill.length,
+    changed,
+    targets: targetIds,
+  };
+}
+
+export function adaptSkillSummary(summary: SkillSummaryPayload): Skill {
+  const name = summary.skill_id;
+  const releaseTags = summary.release_tags ?? [];
+  const snapshotTags = summary.snapshot_tags ?? [];
+  const tag = releaseTags[0] ?? (snapshotTags.length > 0 ? "snapshot" : inferTag(name));
+  const targetIds = summary.target_ids ?? [];
+  const latestRev = summary.latest_rev ? summary.latest_rev.slice(0, 8) : "—";
+  const changed = summary.latest_updated_at ? relativeTime(summary.latest_updated_at) : "—";
+  const bindingCount = summary.bindings_count ?? 0;
+  const projectionCount = summary.projections_count ?? targetIds.length;
+
+  return {
+    id: `s-${name}`,
+    name,
+    tag,
+    sourceStatus: summary.source_status ?? "missing",
+    releaseTags,
+    snapshotTags,
+    latestRev,
+    ruleCount: bindingCount,
+    bindingCount,
+    projectionCount,
     changed,
     targets: targetIds,
   };

--- a/panel/src/lib/api/client.test.ts
+++ b/panel/src/lib/api/client.test.ts
@@ -100,4 +100,24 @@ describe("api v1 routes", () => {
       "/api/v1/ops/history/repair",
     ]);
   });
+
+  it("uses the v1 endpoint for the skills read model", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        cmd: "registry.skills",
+        request_id: "req-1",
+        data: { skills: [] },
+        error: null,
+        meta: { warnings: [] },
+      }),
+    } as unknown as Response);
+
+    await api.skills();
+
+    expect(fetchSpy).toHaveBeenCalledWith("/api/v1/skills", { signal: undefined });
+  });
 });

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -89,8 +89,24 @@ export interface TargetShowPayload {
   error?: { code?: string; message?: string };
 }
 
+export interface SkillSummaryPayload {
+  skill_id: string;
+  source_status?: "present" | "missing" | "non-compliant";
+  source_path?: string | null;
+  latest_rev?: string | null;
+  latest_updated_at?: string | null;
+  bindings_count?: number;
+  projections_count?: number;
+  target_ids?: string[];
+  release_tags?: string[];
+  snapshot_tags?: string[];
+  observed_imported?: boolean;
+  sources?: string[];
+}
+
 export interface SkillsPayload {
-  skills?: string[];
+  skills?: Array<string | SkillSummaryPayload>;
+  skill_names?: string[];
 }
 
 export interface RemoteStatusResponse {
@@ -372,7 +388,7 @@ export const api = {
   info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/info", signal),
   workspaceStatus: (signal?: AbortSignal) =>
     getJsonData<WorkspaceStatusPayload>("/api/v1/workspace/status", signal),
-  skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/skills", signal),
+  skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/v1/skills", signal),
   registryStatus: (signal?: AbortSignal) => getJson<RegistryPayload>("/api/registry/status", signal),
   workspaceDoctor: (signal?: AbortSignal) =>
     getJsonData<DoctorPayload>("/api/v1/workspace/doctor", signal),

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -7,6 +7,7 @@ import {
   adaptPendingOp,
   adaptProjectionOp,
   adaptSkill,
+  adaptSkillSummary,
   adaptTarget,
   buildAdapterIndex,
 } from "./adapters";
@@ -166,8 +167,10 @@ export function usePanelData(): PanelLiveData {
 
       const index = buildAdapterIndex(registryTargets, projections);
       const targets = registryTargets.map((t) => adaptTarget(t, index));
-      const skillNames = skillsPayload.skills ?? [];
-      const skills = skillNames.map((name) => adaptSkill(name, index, rules));
+      const skillItems = skillsPayload.skills ?? [];
+      const skills = skillItems.map((item) =>
+        typeof item === "string" ? adaptSkill(item, index, rules) : adaptSkillSummary(item),
+      );
       const bindings = registryBindings.map((b) => adaptBinding(b, rules));
 
       const pendingOps: Op[] = (pending.ops ?? []).map(adaptPendingOp);

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -28,6 +28,7 @@ export type AgentKind = AgentSlug;
 export type Ownership = "managed" | "observed" | "external";
 export type ProjectionMethod = "symlink" | "copy" | "materialize";
 export type OpStatus = "ok" | "pending" | "err";
+export type SkillSourceStatus = "present" | "missing" | "non-compliant";
 
 export interface Target {
   id: string;
@@ -43,6 +44,9 @@ export interface Skill {
   id: string;
   name: string;
   tag: string;
+  sourceStatus: SkillSourceStatus;
+  releaseTags: string[];
+  snapshotTags: string[];
   /**
    * Short form of the latest applied projection revision (first 8 chars
    * of the git hash). Displayed as "latest rev" in UI. Distinct from any
@@ -51,6 +55,8 @@ export interface Skill {
   latestRev: string;
   /** Number of rules (binding → target routing entries) that mention this skill. */
   ruleCount: number;
+  bindingCount: number;
+  projectionCount: number;
   /** Relative time since the skill's newest projection was last updated. */
   changed: string;
   targets: string[];

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -40,8 +40,29 @@ function installFetchMock(failingPath: string, failingResponse: Response) {
             meta: { warnings: [] },
           }),
         );
-      case "/api/skills":
-        return Promise.resolve(jsonResponse({ skills: ["typed-api-client"] }));
+      case "/api/v1/skills":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "registry.skills",
+            request_id: "req-skills",
+            data: {
+              skills: [
+                {
+                  skill_id: "typed-api-client",
+                  source_status: "present",
+                  bindings_count: 0,
+                  projections_count: 0,
+                  target_ids: [],
+                  release_tags: [],
+                  snapshot_tags: [],
+                },
+              ],
+            },
+            error: null,
+            meta: { warnings: [] },
+          }),
+        );
       case "/api/registry/status":
         return Promise.resolve(
           url === failingPath

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -23,8 +23,13 @@ const mockSkill: Skill = {
   id: "skill-1",
   name: "my-skill",
   tag: "latest",
+  sourceStatus: "present",
+  releaseTags: [],
+  snapshotTags: [],
   latestRev: "abc12345",
   ruleCount: 2,
+  bindingCount: 2,
+  projectionCount: 0,
   changed: "1h ago",
   targets: [],
 };

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -108,10 +108,11 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
               <thead>
                 <tr>
                   <th>Name</th>
-                  <th>Tag</th>
+                  <th>Source</th>
                   <th>Latest rev</th>
-                  <th>Rules</th>
-                  <th>Targets</th>
+                  <th>Tags</th>
+                  <th>Bindings</th>
+                  <th>Projections</th>
                   <th>Changed</th>
                 </tr>
               </thead>
@@ -124,17 +125,18 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
                   >
                     <td className="name">{s.name}</td>
                     <td>
-                      <span className="chip">{s.tag}</span>
+                      <span className={`chip ${s.sourceStatus}`}>{s.sourceStatus}</span>
                     </td>
                     <td className="mono">{s.latestRev}</td>
-                    <td className="mono dim">{s.ruleCount}</td>
-                    <td className="mono">{s.targets.length}</td>
+                    <td className="mono dim">{formatSkillTags(s)}</td>
+                    <td className="mono dim">{s.bindingCount}</td>
+                    <td className="mono">{s.projectionCount}</td>
                     <td className="mono dim">{s.changed}</td>
                   </tr>
                 ))}
                 {filtered.length === 0 && (
                   <tr>
-                    <td colSpan={6} style={{ color: "var(--ink-3)", padding: 22, textAlign: "center" }}>
+                    <td colSpan={7} style={{ color: "var(--ink-3)", padding: 22, textAlign: "center" }}>
                       {emptyMessage}
                     </td>
                   </tr>
@@ -204,6 +206,16 @@ function summarizePolicy(skillBindings: Binding[]): string {
   const kinds = Object.keys(counts);
   if (kinds.length === 1) return `${kinds[0]} · ${skillBindings.length} binding${skillBindings.length === 1 ? "" : "s"}`;
   return kinds.map((k) => `${counts[k]} ${k}`).join(" · ");
+}
+
+function formatSkillTags(skill: Skill): string {
+  const tags = [
+    ...skill.releaseTags.map((tag) => `release:${tag}`),
+    ...skill.snapshotTags.map((tag) => `snapshot:${tag}`),
+  ];
+  if (tags.length === 0) return "—";
+  if (tags.length <= 2) return tags.join(" ");
+  return `${tags[0]} +${tags.length - 1}`;
 }
 
 type DetailTab = "history" | "diff" | "targets";
@@ -309,12 +321,16 @@ function SkillDetail({
       <h4>{skill.name}</h4>
       <div className="dpath">skills/{skill.name}@{skill.latestRev}</div>
       <div className="kv">
-        <div className="k">Tag</div>
-        <div className="v">{skill.tag}</div>
+        <div className="k">Source</div>
+        <div className="v">{skill.sourceStatus}</div>
         <div className="k">Latest rev</div>
         <div className="v">{skill.latestRev}</div>
-        <div className="k">Rules</div>
-        <div className="v">{skill.ruleCount} on chain</div>
+        <div className="k">Tags</div>
+        <div className="v">{formatSkillTags(skill)}</div>
+        <div className="k">Bindings</div>
+        <div className="v">{skill.bindingCount}</div>
+        <div className="k">Projections</div>
+        <div className="v">{skill.projectionCount}</div>
         <div className="k">Policy</div>
         <div className="v">{policyLabel}</div>
       </div>

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -111,8 +111,13 @@ function makeSkill(): Skill {
     id: "s-skill.writer",
     name: "skill.writer",
     tag: "v1",
+    sourceStatus: "present",
+    releaseTags: ["v1"],
+    snapshotTags: [],
     latestRev: "abc12345",
     ruleCount: 1,
+    bindingCount: 1,
+    projectionCount: 1,
     changed: "now",
     targets: ["target-1"],
   };

--- a/panel/src/styles/panel/primitives.css
+++ b/panel/src/styles/panel/primitives.css
@@ -156,6 +156,24 @@
   color: var(--ink-1);
 }
 
+.chip.present {
+  color: var(--ok);
+  border-color: rgba(111, 183, 138, 0.32);
+  background: rgba(111, 183, 138, 0.08);
+}
+
+.chip.missing {
+  color: var(--warn);
+  border-color: rgba(213, 172, 85, 0.34);
+  background: rgba(213, 172, 85, 0.08);
+}
+
+.chip.non-compliant {
+  color: var(--err);
+  border-color: rgba(216, 90, 90, 0.34);
+  background: rgba(216, 90, 90, 0.08);
+}
+
 .chip.method {
   background: transparent;
   border-color: var(--line-hi);

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -1,4 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
 use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 
 use axum::{
     Json,
@@ -17,8 +20,10 @@ use crate::commands::{
     App, CommandFailure, collect_skill_inventory, redact_sensitive_string, remote_status_payload,
 };
 use crate::envelope::Envelope;
+use crate::gitops;
 use crate::state::resolve_agent_skill_dirs;
-use crate::state_model::RegistryStatePaths;
+use crate::state_model::{RegistrySnapshot, RegistryStatePaths};
+use crate::types::ErrorCode;
 
 use super::auth::{
     ensure_mutation_authorized, error_envelope, load_registry_snapshot, registry_error,
@@ -43,6 +48,31 @@ fn policy_profile_looks_sane(value: &str) -> bool {
 
 const DEFAULT_OPS_PAGE_SIZE: usize = 100;
 const MAX_OPS_PAGE_SIZE: usize = 250;
+
+#[derive(Debug, Default)]
+struct SkillReadRow {
+    skill_id: String,
+    source_path: Option<PathBuf>,
+    source_status: Option<&'static str>,
+    sources: BTreeSet<&'static str>,
+    binding_ids: BTreeSet<String>,
+    target_ids: BTreeSet<String>,
+    projection_count: usize,
+    latest_rev: Option<String>,
+    latest_updated_at: Option<String>,
+    release_tags: Vec<String>,
+    snapshot_tags: Vec<String>,
+    observed_imported: bool,
+}
+
+impl SkillReadRow {
+    fn new(skill_id: String) -> Self {
+        Self {
+            skill_id,
+            ..Self::default()
+        }
+    }
+}
 
 #[derive(Debug, Default, Deserialize)]
 pub(super) struct ProjectionsQuery {
@@ -226,6 +256,216 @@ pub(super) async fn v1_registry_targets(
         ),
         Err(err) => panel_v1_registry_error(err),
     }
+}
+
+pub(super) async fn v1_skills(
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match build_skill_read_model(&state) {
+        Ok((skills, warnings, registry_available)) => (
+            StatusCode::OK,
+            Json(json!(Envelope::ok(
+                "registry.skills",
+                uuid::Uuid::new_v4().to_string(),
+                json!({
+                    "state_model": "union",
+                    "registry_available": registry_available,
+                    "count": skills.len(),
+                    "skills": skills,
+                }),
+                crate::envelope::Meta {
+                    warnings,
+                    ..crate::envelope::Meta::default()
+                }
+            ))),
+        ),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!(Envelope::err(
+                "registry.skills",
+                uuid::Uuid::new_v4().to_string(),
+                ErrorCode::InternalError,
+                err.to_string(),
+                serde_json::Value::Object(Default::default())
+            ))),
+        ),
+    }
+}
+
+fn build_skill_read_model(
+    state: &PanelState,
+) -> anyhow::Result<(Vec<serde_json::Value>, Vec<String>, bool)> {
+    let mut warnings = Vec::new();
+    let mut rows: BTreeMap<String, SkillReadRow> = BTreeMap::new();
+
+    add_source_skill_rows(&state.ctx.skills_dir, &mut rows)?;
+
+    let paths = RegistryStatePaths::from_app_context(&state.ctx);
+    let snapshot = paths.maybe_load_snapshot()?;
+    let registry_available = snapshot.is_some();
+    if let Some(snapshot) = snapshot.as_ref() {
+        add_registry_skill_rows(snapshot, &mut rows);
+        add_observed_import_rows(snapshot, &mut rows);
+    } else {
+        warnings.push(format!(
+            "registry state not initialized under {}",
+            paths.registry_dir.display()
+        ));
+    }
+
+    add_skill_tags(state, &mut rows, &mut warnings)?;
+
+    Ok((
+        rows.into_values()
+            .map(skill_row_to_json)
+            .collect::<Vec<_>>(),
+        warnings,
+        registry_available,
+    ))
+}
+
+fn skill_row<'a>(
+    rows: &'a mut BTreeMap<String, SkillReadRow>,
+    skill_id: &str,
+) -> &'a mut SkillReadRow {
+    rows.entry(skill_id.to_string())
+        .or_insert_with(|| SkillReadRow::new(skill_id.to_string()))
+}
+
+fn add_source_skill_rows(
+    skills_dir: &Path,
+    rows: &mut BTreeMap<String, SkillReadRow>,
+) -> anyhow::Result<()> {
+    if !skills_dir.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(skills_dir)? {
+        let entry = entry?;
+        let skill_id = entry.file_name().to_string_lossy().to_string();
+        let path = entry.path();
+        let row = skill_row(rows, &skill_id);
+        row.sources.insert("source");
+        row.source_path = Some(path.clone());
+        row.source_status = Some(if path.is_dir() && path.join("SKILL.md").is_file() {
+            "present"
+        } else {
+            "non-compliant"
+        });
+    }
+    Ok(())
+}
+
+fn add_registry_skill_rows(snapshot: &RegistrySnapshot, rows: &mut BTreeMap<String, SkillReadRow>) {
+    for rule in &snapshot.rules.rules {
+        let row = skill_row(rows, &rule.skill_id);
+        row.sources.insert("rule");
+        row.binding_ids.insert(rule.binding_id.clone());
+        row.target_ids.insert(rule.target_id.clone());
+    }
+
+    for projection in &snapshot.projections.projections {
+        let row = skill_row(rows, &projection.skill_id);
+        row.sources.insert("projection");
+        if let Some(binding_id) = projection.binding_id.as_ref() {
+            row.binding_ids.insert(binding_id.clone());
+        }
+        row.target_ids.insert(projection.target_id.clone());
+        row.projection_count += 1;
+        if !projection.last_applied_rev.is_empty()
+            && row.latest_rev.is_none()
+            && projection.updated_at.is_none()
+        {
+            row.latest_rev = Some(projection.last_applied_rev.clone());
+        }
+        if let Some(updated_at) = projection.updated_at {
+            let updated_at = updated_at.to_rfc3339();
+            if row
+                .latest_updated_at
+                .as_ref()
+                .is_none_or(|current| updated_at > *current)
+            {
+                row.latest_updated_at = Some(updated_at);
+                row.latest_rev = Some(projection.last_applied_rev.clone());
+            }
+        }
+    }
+}
+
+fn add_observed_import_rows(
+    snapshot: &RegistrySnapshot,
+    rows: &mut BTreeMap<String, SkillReadRow>,
+) {
+    for op in &snapshot.operations {
+        if op.intent != "skill.import_observed" && op.intent != "skill.monitor_observed" {
+            continue;
+        }
+        for field in ["imported", "updated"] {
+            if let Some(items) = op.effects.get(field).and_then(serde_json::Value::as_array) {
+                for item in items {
+                    if let Some(skill_id) = item.get("skill").and_then(serde_json::Value::as_str) {
+                        let row = skill_row(rows, skill_id);
+                        row.sources.insert("observed");
+                        row.observed_imported = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn add_skill_tags(
+    state: &PanelState,
+    rows: &mut BTreeMap<String, SkillReadRow>,
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    if !gitops::repo_is_initialized(&state.ctx)? {
+        warnings.push(
+            "git repository not initialized; release and snapshot tags unavailable".to_string(),
+        );
+        return Ok(());
+    }
+
+    let output = gitops::run_git_allow_failure(&state.ctx, &["tag", "--list"])?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "failed to list git tags: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    for tag in String::from_utf8_lossy(&output.stdout).lines() {
+        if let Some(rest) = tag.strip_prefix("release/") {
+            if let Some((skill_id, version)) = rest.split_once('/') {
+                let row = skill_row(rows, skill_id);
+                row.sources.insert("release_tag");
+                row.release_tags.push(version.to_string());
+            }
+        } else if let Some(rest) = tag.strip_prefix("snapshot/")
+            && let Some((skill_id, snapshot)) = rest.split_once('/')
+        {
+            let row = skill_row(rows, skill_id);
+            row.sources.insert("snapshot_tag");
+            row.snapshot_tags.push(snapshot.to_string());
+        }
+    }
+    Ok(())
+}
+
+fn skill_row_to_json(row: SkillReadRow) -> serde_json::Value {
+    let source_status = row.source_status.unwrap_or("missing");
+    json!({
+        "skill_id": row.skill_id,
+        "source_status": source_status,
+        "source_path": row.source_path.map(|path| path.display().to_string()),
+        "latest_rev": row.latest_rev,
+        "latest_updated_at": row.latest_updated_at,
+        "bindings_count": row.binding_ids.len(),
+        "projections_count": row.projection_count,
+        "target_ids": row.target_ids.into_iter().collect::<Vec<_>>(),
+        "release_tags": row.release_tags,
+        "snapshot_tags": row.snapshot_tags,
+        "observed_imported": row.observed_imported,
+        "sources": row.sources.into_iter().collect::<Vec<_>>(),
+    })
 }
 
 pub(super) async fn info(State(state): State<PanelState>) -> Json<serde_json::Value> {

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -161,7 +161,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
             "/api/v1/bindings/{binding_id}/remove",
             post(registry_binding_remove),
         )
-        .route("/api/v1/skills", post(registry_skill_add))
+        .route("/api/v1/skills", get(v1_skills).post(registry_skill_add))
         .route(
             "/api/v1/skills/{skill_name}/save",
             post(registry_skill_save),

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -1,11 +1,11 @@
 use super::*;
 use crate::panel::handlers::{
     OpsQuery, info, pending, registry_ops, registry_orphan_clean, remote_set, remote_status,
-    v1_health, v1_overview, v1_registry_ops, v1_registry_targets, v1_workspace_status,
+    v1_health, v1_overview, v1_registry_ops, v1_registry_targets, v1_skills, v1_workspace_status,
 };
 use crate::state_model::{
-    REGISTRY_SCHEMA_VERSION, RegistryOperationRecord, RegistryProjectionInstance,
-    RegistryProjectionsFile,
+    REGISTRY_SCHEMA_VERSION, RegistryBindingRule, RegistryOperationRecord,
+    RegistryProjectionInstance, RegistryProjectionsFile, RegistryRulesFile,
 };
 use axum::{
     Json,
@@ -139,6 +139,103 @@ async fn v1_registry_targets_success_uses_cli_envelope_shape() {
     assert_eq!(payload["cmd"], json!("registry.targets"));
     assert_eq!(payload["error"], Value::Null);
     assert_eq!(payload["data"]["count"], json!(0));
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
+async fn v1_skills_returns_union_read_model() {
+    let (root, state) = make_test_state();
+    write_registry_snapshot(&root, REGISTRY_SCHEMA_VERSION);
+    let paths = RegistryStatePaths::from_root(&root);
+    let source_dir = root.join("skills/present-skill");
+    fs::create_dir_all(&source_dir).expect("create present skill");
+    fs::write(source_dir.join("SKILL.md"), "# present\n").expect("write skill");
+    fs::create_dir_all(root.join("skills/broken-skill")).expect("create broken skill");
+
+    paths
+        .save_rules(&RegistryRulesFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            rules: vec![
+                RegistryBindingRule {
+                    binding_id: "binding-1".to_string(),
+                    skill_id: "present-skill".to_string(),
+                    target_id: "target-1".to_string(),
+                    method: "symlink".to_string(),
+                    watch_policy: "observe_only".to_string(),
+                    created_at: Some(Utc::now()),
+                },
+                RegistryBindingRule {
+                    binding_id: "binding-2".to_string(),
+                    skill_id: "rule-only".to_string(),
+                    target_id: "target-2".to_string(),
+                    method: "copy".to_string(),
+                    watch_policy: "observe_only".to_string(),
+                    created_at: Some(Utc::now()),
+                },
+            ],
+        })
+        .expect("save rules");
+    paths
+        .save_projections(&RegistryProjectionsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            projections: vec![RegistryProjectionInstance {
+                instance_id: "inst-projected".to_string(),
+                skill_id: "projected-only".to_string(),
+                binding_id: None,
+                target_id: "target-3".to_string(),
+                materialized_path: "/tmp/projected".to_string(),
+                method: "copy".to_string(),
+                last_applied_rev: "abcdef1234567890".to_string(),
+                health: "healthy".to_string(),
+                observed_drift: Some(false),
+                updated_at: Some(Utc::now()),
+            }],
+        })
+        .expect("save projections");
+    paths
+        .append_operation(&RegistryOperationRecord {
+            op_id: "op-observed".to_string(),
+            intent: "skill.import_observed".to_string(),
+            status: "succeeded".to_string(),
+            ack: false,
+            payload: json!({}),
+            effects: json!({"imported": [{"skill": "observed-only"}]}),
+            last_error: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+        .expect("append op");
+
+    let (status, Json(payload)) = v1_skills(State(state)).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("registry.skills"));
+    assert_eq!(payload["error"], Value::Null);
+    assert_eq!(payload["data"]["count"], json!(5));
+
+    let skills = payload["data"]["skills"].as_array().expect("skills array");
+    let by_id = |skill_id: &str| {
+        skills
+            .iter()
+            .find(|item| item["skill_id"] == json!(skill_id))
+            .unwrap_or_else(|| panic!("missing skill {skill_id}: {skills:?}"))
+    };
+
+    assert_eq!(by_id("present-skill")["source_status"], json!("present"));
+    assert_eq!(by_id("present-skill")["bindings_count"], json!(1));
+    assert_eq!(
+        by_id("broken-skill")["source_status"],
+        json!("non-compliant")
+    );
+    assert_eq!(by_id("rule-only")["source_status"], json!("missing"));
+    assert_eq!(by_id("projected-only")["projections_count"], json!(1));
+    assert_eq!(
+        by_id("projected-only")["latest_rev"],
+        json!("abcdef1234567890")
+    );
+    assert_eq!(by_id("observed-only")["observed_imported"], json!(true));
 
     cleanup_root(root);
 }


### PR DESCRIPTION
Closes #127.

## Summary
- add `GET /api/v1/skills` with a union read model from `skills/`, registry rules, projections, and observed import/monitor operation records
- return source status, latest rev, release/snapshot tags, binding/projection counts, and target ids
- switch the Panel client and Skills table to the v1 skills model with present/missing/non-compliant status chips

## Verification
- cargo fmt --check
- cargo test -q panel::tests::handlers::v1_skills_returns_union_read_model
- cargo test -q panel::tests::
- cd panel && bun run typecheck
- cd panel && bun run test -- client PanelApp SkillsPage panel_state
- cd panel && bun run build
- local browser smoke at http://127.0.0.1:43124/?v=skills
- git diff --check
- make ci