### PR TITLE
Use real operation history for Panel activity

### DIFF
--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -5,7 +5,7 @@ import type { RegistryTarget } from "../../generated/RegistryTarget";
 import type { PendingOp } from "../../types";
 import { normalizeAgentSlug } from "../agent_options";
 import type { AgentSlug, Binding, Op, Ownership, ProjectionMethod, Skill, Target } from "../types";
-import type { SkillSummaryPayload } from "./client";
+import type { RegistryOperationRecord, SkillSummaryPayload } from "./client";
 
 /**
  * Return the backend slug verbatim (lowercased + trimmed). Unknown slugs
@@ -188,6 +188,26 @@ export function adaptPendingOp(op: PendingOp, index: number): Op {
     method: methodField,
     time: op.created_at ? relativeTime(op.created_at) : "queued",
   };
+}
+
+export function adaptRegistryOperation(op: RegistryOperationRecord): Op {
+  return {
+    id: op.op_id,
+    status: operationStatus(op),
+    kind: op.intent,
+    skill: op.skill ?? op.intent,
+    target: op.target ?? op.binding ?? "—",
+    method: op.method ? toMethod(op.method) : "—",
+    time: op.updated_at ? relativeTime(op.updated_at) : "—",
+    reason: op.last_error?.message,
+  };
+}
+
+function operationStatus(op: RegistryOperationRecord): Op["status"] {
+  const status = op.status.toLowerCase();
+  if (op.last_error || status === "failed" || status === "error") return "err";
+  if (!op.ack || status === "pending" || status === "queued") return "pending";
+  return "ok";
 }
 
 export function adaptProjectionOp(p: RegistryProjection, index: AdapterIndex): Op {

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -15,6 +15,11 @@ export interface RegistryOperationRecord {
   intent: string;
   status: string;
   ack: boolean;
+  request_id?: string | null;
+  skill?: string | null;
+  target?: string | null;
+  binding?: string | null;
+  method?: string | null;
   payload?: unknown;
   effects?: unknown;
   last_error?: { code: string; message: string };

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -5,7 +5,7 @@ import type { Binding, Op, Skill, Target } from "../types";
 import {
   adaptBinding,
   adaptPendingOp,
-  adaptProjectionOp,
+  adaptRegistryOperation,
   adaptSkill,
   adaptSkillSummary,
   adaptTarget,
@@ -151,11 +151,12 @@ export function usePanelData(): PanelLiveData {
         return;
       }
 
-      const [skillsPayload, registry, remote, pending] = await Promise.all([
+      const [skillsPayload, registry, remote, pending, activity] = await Promise.all([
         api.skills(controller.signal),
         api.registryStatus(controller.signal),
         api.remoteStatus(controller.signal),
         api.pending(controller.signal),
+        api.ops({ limit: 30 }, controller.signal),
       ]);
       if (controller.signal.aborted || generation !== generationRef.current) return;
 
@@ -174,8 +175,8 @@ export function usePanelData(): PanelLiveData {
       const bindings = registryBindings.map((b) => adaptBinding(b, rules));
 
       const pendingOps: Op[] = (pending.ops ?? []).map(adaptPendingOp);
-      const projectionOps: Op[] = projections.map((p) => adaptProjectionOp(p, index));
-      const ops = [...pendingOps, ...projectionOps].slice(0, 30);
+      const activityOps: Op[] = (activity.data?.operations ?? []).map(adaptRegistryOperation);
+      const ops = [...pendingOps, ...activityOps].slice(0, 30);
 
       setState(
         markSuccess({

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -84,6 +84,17 @@ function installFetchMock(failingPath: string, failingResponse: Response) {
         );
       case "/api/pending":
         return Promise.resolve(url === failingPath ? failingResponse : jsonResponse({ count: 0, ops: [] }));
+      case "/api/v1/ops?limit=30":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "registry.ops",
+            request_id: "req-ops",
+            data: { count: 0, loaded_count: 0, offset: 0, limit: 30, has_more: false, operations: [] },
+            error: null,
+            meta: { warnings: [] },
+          }),
+        );
       default:
         return Promise.reject(new Error(`unexpected fetch ${url}`));
     }

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -22,7 +22,7 @@ use crate::commands::{
 use crate::envelope::Envelope;
 use crate::gitops;
 use crate::state::resolve_agent_skill_dirs;
-use crate::state_model::{RegistrySnapshot, RegistryStatePaths};
+use crate::state_model::{RegistryOperationRecord, RegistrySnapshot, RegistryStatePaths};
 use crate::types::ErrorCode;
 
 use super::auth::{
@@ -171,11 +171,17 @@ pub(super) async fn v1_registry_ops(
                 .iter()
                 .rev()
                 .map(|op| {
+                    let summary = operation_summary(op);
                     json!({
                         "op_id": op.op_id,
                         "intent": op.intent,
                         "status": op.status,
                         "ack": op.ack,
+                        "request_id": summary.request_id,
+                        "skill": summary.skill,
+                        "target": summary.target,
+                        "binding": summary.binding,
+                        "method": summary.method,
                         "last_error": op.last_error,
                         "created_at": op.created_at,
                         "updated_at": op.updated_at,
@@ -199,6 +205,51 @@ pub(super) async fn v1_registry_ops(
         }
         Err(err) => panel_v1_registry_error(err),
     }
+}
+
+#[derive(Default)]
+struct OperationSummary {
+    request_id: Option<String>,
+    skill: Option<String>,
+    target: Option<String>,
+    binding: Option<String>,
+    method: Option<String>,
+}
+
+fn operation_summary(op: &RegistryOperationRecord) -> OperationSummary {
+    OperationSummary {
+        request_id: json_string_field(&op.payload, &["request_id"]),
+        skill: operation_skill_summary(op),
+        target: json_string_field(&op.payload, &["target_id", "target"]),
+        binding: json_string_field(&op.payload, &["binding_id", "binding"]),
+        method: json_string_field(&op.payload, &["method"]),
+    }
+}
+
+fn operation_skill_summary(op: &RegistryOperationRecord) -> Option<String> {
+    if let Some(skill) = json_string_field(&op.payload, &["skill_id", "skill"]) {
+        return Some(skill);
+    }
+    for field in ["imported", "updated"] {
+        let skills = op
+            .effects
+            .get(field)
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|item| item.get("skill").and_then(serde_json::Value::as_str))
+            .collect::<Vec<_>>();
+        if !skills.is_empty() {
+            return Some(skills.join(", "));
+        }
+    }
+    None
+}
+
+fn json_string_field(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(serde_json::Value::as_str))
+        .map(ToString::to_string)
 }
 
 pub(super) async fn v1_registry_projections(

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -69,6 +69,55 @@ fn registry_ops_returns_bounded_newest_first_rows() {
 }
 
 #[tokio::test]
+async fn v1_registry_ops_returns_activity_summary_fields() {
+    let (root, state) = make_test_state();
+    let paths = RegistryStatePaths::from_app_context(state.ctx.as_ref());
+    paths.ensure_layout().expect("ensure registry layout");
+    let now = Utc::now();
+    paths
+        .append_operation(&RegistryOperationRecord {
+            op_id: "op-activity".to_string(),
+            intent: "skill.project".to_string(),
+            status: "succeeded".to_string(),
+            ack: false,
+            payload: json!({
+                "skill_id": "demo-skill",
+                "binding_id": "binding-1",
+                "target_id": "target-1",
+                "method": "copy",
+                "request_id": "req-1"
+            }),
+            effects: json!({}),
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("append op");
+
+    let (status, Json(payload)) = v1_registry_ops(
+        Query(OpsQuery {
+            limit: Some(10),
+            offset: Some(0),
+        }),
+        State(state),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let op = &payload["data"]["operations"][0];
+    assert_eq!(op["op_id"], json!("op-activity"));
+    assert_eq!(op["skill"], json!("demo-skill"));
+    assert_eq!(op["binding"], json!("binding-1"));
+    assert_eq!(op["target"], json!("target-1"));
+    assert_eq!(op["method"], json!("copy"));
+    assert_eq!(op["request_id"], json!("req-1"));
+    assert!(op.get("payload").is_none());
+    assert!(op.get("effects").is_none());
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
 async fn v1_health_returns_cli_envelope_shape() {
     let (status, Json(payload)) = v1_health().await;
 


### PR DESCRIPTION
Closes #132

## Summary
- expose lightweight operation summary fields from `/api/v1/ops` for activity rendering
- load real registry operations into the Panel Activity list
- keep full operation payload/effects omitted from the list endpoint

## Verification
- `cargo fmt --check`
- `cargo test -q panel::tests::handlers::v1_registry_ops_returns_activity_summary_fields`
- `cd panel && bun run typecheck`
- `cd panel && bun run test -- PanelApp panel_state`
- `cd panel && bun run build`
- `git diff --check`
- `make ci`