### PR TITLE
Record read commands in command audit

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -81,6 +81,7 @@ impl App {
             .clone()
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         let audit_required = command_requires_durable_audit(&cli.command);
+        let audit_enabled = command_records_audit(&cli.command);
         if audit_required && let Err(err) = self.ctx.ensure_not_loom_tool_repo_root() {
             let message = err.to_string();
             let message = message
@@ -91,31 +92,40 @@ impl App {
             return Ok((env, ErrorCode::ArgInvalid.exit_code()));
         }
         let mut audit_event_id = None;
-        if audit_required {
+        let mut audit_warnings = Vec::new();
+        if audit_enabled {
             let input = command_event_input(&cli, &request_id);
             match prepare_command_event_store(&self.ctx) {
                 Ok(()) => match append_command_started(&self.ctx, cmd, input, &request_id) {
                     Ok(event_id) => audit_event_id = Some(event_id),
                     Err(err) => {
+                        let warning = format!("failed to append command event: {}", err);
+                        if audit_required {
+                            let env = Envelope::err(
+                                cmd,
+                                request_id,
+                                ErrorCode::AuditError,
+                                warning,
+                                json!({}),
+                            );
+                            return Ok((env, ErrorCode::AuditError.exit_code()));
+                        }
+                        audit_warnings.push(warning);
+                    }
+                },
+                Err(err) => {
+                    let warning = format!("failed to prepare command event log: {}", err);
+                    if audit_required {
                         let env = Envelope::err(
                             cmd,
                             request_id,
                             ErrorCode::AuditError,
-                            format!("failed to append command event: {}", err),
+                            warning,
                             json!({}),
                         );
                         return Ok((env, ErrorCode::AuditError.exit_code()));
                     }
-                },
-                Err(err) => {
-                    let env = Envelope::err(
-                        cmd,
-                        request_id,
-                        ErrorCode::AuditError,
-                        format!("failed to prepare command event log: {}", err),
-                        json!({}),
-                    );
-                    return Ok((env, ErrorCode::AuditError.exit_code()));
+                    audit_warnings.push(warning);
                 }
             }
         }
@@ -163,7 +173,8 @@ impl App {
 
         match result {
             Ok((data, meta)) => {
-                let env = Envelope::ok(cmd, request_id, data, meta);
+                let mut env = Envelope::ok(cmd, request_id, data, meta);
+                env.meta.warnings.extend(audit_warnings);
                 Ok(
                     self.finish_command_audit(
                         cmd,
@@ -176,7 +187,8 @@ impl App {
             }
             Err(f) => {
                 let exit_code = f.code.exit_code();
-                let env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
+                let mut env = Envelope::err(cmd, request_id, f.code, f.message, f.details);
+                env.meta.warnings.extend(audit_warnings);
                 Ok(self.finish_command_audit(
                     cmd,
                     env,
@@ -266,6 +278,10 @@ impl App {
         paths.ensure_layout().map_err(helpers::map_registry_state)?;
         Ok(paths)
     }
+}
+
+fn command_records_audit(command: &Command) -> bool {
+    !matches!(command, Command::Panel(_))
 }
 
 fn command_requires_durable_audit(command: &Command) -> bool {

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -108,10 +108,14 @@ pub(super) async fn v1_overview(
 pub(super) async fn v1_workspace_status(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let app = App {
-        ctx: state.ctx.as_ref().clone(),
-    };
-    panel_command_envelope("workspace.status", app.cmd_status())
+    run_panel_command(
+        &state,
+        "workspace.status",
+        StatusCode::OK,
+        Command::Workspace {
+            command: WorkspaceCommand::Status,
+        },
+    )
 }
 
 pub(super) async fn v1_workspace_init(
@@ -138,19 +142,27 @@ pub(super) async fn v1_workspace_init(
 pub(super) async fn v1_workspace_doctor(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let app = App {
-        ctx: state.ctx.as_ref().clone(),
-    };
-    panel_command_envelope("workspace.doctor", app.cmd_doctor())
+    run_panel_command(
+        &state,
+        "workspace.doctor",
+        StatusCode::OK,
+        Command::Workspace {
+            command: WorkspaceCommand::Doctor,
+        },
+    )
 }
 
 pub(super) async fn v1_sync_status(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let app = App {
-        ctx: state.ctx.as_ref().clone(),
-    };
-    panel_command_envelope("sync.status", app.cmd_sync(&SyncCommand::Status))
+    run_panel_command(
+        &state,
+        "sync.status",
+        StatusCode::OK,
+        Command::Sync {
+            command: SyncCommand::Status,
+        },
+    )
 }
 
 pub(super) async fn v1_registry_ops(

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -130,7 +130,7 @@ async fn v1_health_returns_cli_envelope_shape() {
 }
 
 #[tokio::test]
-async fn v1_workspace_status_returns_cli_envelope_without_command_audit() {
+async fn v1_workspace_status_returns_cli_envelope_with_command_audit() {
     let (root, state) = make_test_state();
 
     let (status, Json(payload)) = v1_workspace_status(State(state)).await;
@@ -140,10 +140,16 @@ async fn v1_workspace_status_returns_cli_envelope_without_command_audit() {
     assert_eq!(payload["cmd"], json!("workspace.status"));
     assert_eq!(payload["data"]["state_model"], json!("registry"));
     assert_eq!(payload["data"]["registry"]["available"], json!(false));
-    assert!(
-        !root.join("state/events/commands.jsonl").exists(),
-        "read-only v1 status should not start command audit"
-    );
+    let raw = fs::read_to_string(root.join("state/events/commands.jsonl"))
+        .expect("read command event log");
+    let events = raw
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse command event"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["cmd"], json!("workspace.status"));
+    assert_eq!(events[0]["status"], json!("started"));
+    assert_eq!(events[1]["status"], json!("succeeded"));
 
     cleanup_root(root);
 }

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -209,7 +209,7 @@ fn history_event_line(scope: &str, index: usize) -> String {
 }
 
 #[test]
-fn workspace_status_is_read_only_in_empty_dir() {
+fn workspace_status_records_command_audit_without_initializing_registry() {
     let root = TestDir::new("status");
 
     let env = run_loom_ok(root.path(), &["workspace", "status"]);
@@ -217,12 +217,23 @@ fn workspace_status_is_read_only_in_empty_dir() {
     assert_eq!(env["ok"], true);
     assert!(!root.path().join(".git").exists());
     assert!(!root.path().join("state/registry").exists());
-    assert!(!root.path().join("state/events").exists());
     assert!(!root.path().join("skills").exists());
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 2);
+    assert_eq!(
+        events[0]["cmd"],
+        Value::String("workspace.status".to_string())
+    );
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
+    assert_eq!(events[1]["status"], Value::String("succeeded".to_string()));
+    assert_eq!(
+        events[1]["output"]["registry"]["available"],
+        Value::Bool(false)
+    );
 }
 
 #[test]
-fn workspace_status_ignores_unavailable_command_audit_path() {
+fn workspace_status_surfaces_unavailable_command_audit_path_warning() {
     let root = TestDir::new("status-audit-warning");
     let events_dir = root.path().join("state/events");
     if let Some(parent) = events_dir.parent() {
@@ -238,12 +249,14 @@ fn workspace_status_ignores_unavailable_command_audit_path() {
     );
     assert_eq!(env["ok"], Value::Bool(true));
     assert!(
-        !env["meta"]["warnings"]
+        env["meta"]["warnings"]
             .as_array()
             .expect("warnings array")
             .iter()
             .filter_map(serde_json::Value::as_str)
-            .any(|warning| warning.contains("command event"))
+            .any(|warning| warning.contains("failed to prepare command event log")),
+        "expected command audit warning: {}",
+        env
     );
     assert!(!root.path().join("state/registry").exists());
 }
@@ -275,7 +288,7 @@ fn failed_command_emits_durable_command_event() {
 }
 
 #[test]
-fn workspace_status_does_not_enter_command_audit_finish_path() {
+fn workspace_status_reports_terminal_command_audit_warning() {
     let root = TestDir::new("finish-append-failure");
 
     let (output, env) = run_loom_with_env(
@@ -287,14 +300,44 @@ fn workspace_status_does_not_enter_command_audit_finish_path() {
     assert!(output.status.success(), "status should still succeed");
     assert_eq!(env["ok"], Value::Bool(true));
     assert!(
-        !env["meta"]["warnings"]
+        env["meta"]["warnings"]
             .as_array()
             .expect("warnings array")
             .iter()
             .filter_map(serde_json::Value::as_str)
-            .any(|warning| warning.contains("command event"))
+            .any(|warning| warning.contains("failed to append command event")),
+        "expected command audit warning: {}",
+        env
     );
-    assert!(!root.path().join("state/events/commands.jsonl").exists());
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]["cmd"],
+        Value::String("workspace.status".to_string())
+    );
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
+}
+
+#[test]
+fn read_list_command_emits_durable_command_event_on_failure() {
+    let root = TestDir::new("read-list-command-event");
+
+    let (output, env) = run_loom_with_env(root.path(), &[], &["target", "list"]);
+
+    assert!(
+        !output.status.success(),
+        "target list unexpectedly succeeded"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    let events = read_command_events(root.path());
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["cmd"], Value::String("target.list".to_string()));
+    assert_eq!(events[0]["status"], Value::String("started".to_string()));
+    assert_eq!(events[1]["status"], Value::String("failed".to_string()));
+    assert_eq!(
+        events[1]["error"]["code"],
+        Value::String("ARG_INVALID".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #130

## Summary
- attempt command EventStore writes for read commands as well as mutations
- keep mutation audit failures hard-fail, while read audit write failures surface as envelope warnings
- route V1 workspace status/doctor and sync status through `App::execute` so those panel reads also produce command events
- update reliability and panel tests for read audit behavior

## Verification
- `cargo fmt --check`
- `cargo test -q --test reliability workspace_status_`
- `cargo test -q --test reliability read_list_command_emits_durable_command_event_on_failure`
- `cargo test -q panel::tests::handlers::v1_workspace_status_returns_cli_envelope_with_command_audit`
- `cargo test -q --test reliability`
- `cargo test -q panel::tests::handlers::`
- manual repro: `workspace status` writes started + succeeded command events without creating `.git` or registry state
- `cargo check`
- `cargo test`
- `git diff --check`
- `make ci`