### PR TITLE
Surface rollback failures in command errors

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -48,6 +48,22 @@ impl CommandFailure {
             details: json!({}),
         }
     }
+
+    pub(crate) fn with_rollback_errors(mut self, rollback_errors: Vec<serde_json::Value>) -> Self {
+        if rollback_errors.is_empty() {
+            return self;
+        }
+        let original_details = std::mem::replace(&mut self.details, json!({}));
+        self.details = json!({
+            "original_error": {
+                "code": self.code.as_str(),
+                "message": self.message.clone(),
+            },
+            "original_details": original_details,
+            "rollback_errors": rollback_errors,
+        });
+        self
+    }
 }
 
 pub struct App {

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use chrono::Utc;
-use serde_json::json;
+use serde_json::{Value, json};
 use uuid::Uuid;
 use walkdir::WalkDir;
 
@@ -231,7 +231,7 @@ impl App {
             backup_path_if_exists(&self.ctx, &materialized_path, "project.replace_projection")
                 .map_err(map_io)?;
         if let Err(err) = remove_path_if_exists(&materialized_path) {
-            rollback_project_mutation(
+            let rollback_errors = rollback_project_mutation(
                 &paths,
                 &materialized_path,
                 replaced_projection_backup.as_ref(),
@@ -239,10 +239,10 @@ impl App {
                 &snapshot.rules,
                 &snapshot.projections,
             );
-            return Err(map_io(err));
+            return Err(map_io(err).with_rollback_errors(rollback_errors));
         }
         if let Err(err) = project_skill_to_target(&skill_src, &materialized_path, args.method) {
-            rollback_project_mutation(
+            let rollback_errors = rollback_project_mutation(
                 &paths,
                 &materialized_path,
                 replaced_projection_backup.as_ref(),
@@ -250,7 +250,7 @@ impl App {
                 &snapshot.rules,
                 &snapshot.projections,
             );
-            return Err(map_project_io(args.method)(err));
+            return Err(map_project_io(args.method)(err).with_rollback_errors(rollback_errors));
         }
 
         let original_bindings = snapshot.bindings.clone();
@@ -348,16 +348,25 @@ impl App {
         let (commit, meta) = match post_materialize {
             Ok(result) => result,
             Err(err) => {
-                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
-                rollback_project_mutation(
+                let mut rollback_errors = Vec::new();
+                if let Err(restore_err) =
+                    restore_registry_audit_state(&paths, &registry_audit_backup)
+                {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_audit_state",
+                        restore_err,
+                    );
+                }
+                rollback_errors.extend(rollback_project_mutation(
                     &paths,
                     &materialized_path,
                     replaced_projection_backup.as_ref(),
                     &original_bindings,
                     &original_rules,
                     &original_projections,
-                );
-                return Err(err);
+                ));
+                return Err(err.with_rollback_errors(rollback_errors));
             }
         };
 
@@ -416,7 +425,7 @@ impl App {
                     }
                 };
             if let Err(err) = remove_path_if_exists(&skill_path) {
-                rollback_capture_mutation(
+                let mut rollback_errors = rollback_capture_mutation(
                     &self.ctx,
                     &skill_path,
                     source_backup.as_ref(),
@@ -425,17 +434,23 @@ impl App {
                     &previous_index,
                     false,
                 );
-                rollback_registry_state(
+                if let Err(restore_err) = rollback_registry_state(
                     &paths,
                     &original_bindings,
                     &original_rules,
                     &original_projections,
-                );
+                ) {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_state",
+                        restore_err,
+                    );
+                }
                 let _ = remove_path_if_exists(&tmp_path);
-                return Err(map_io(err));
+                return Err(map_io(err).with_rollback_errors(rollback_errors));
             }
             if let Err(err) = fs::rename(&tmp_path, &skill_path) {
-                rollback_capture_mutation(
+                let mut rollback_errors = rollback_capture_mutation(
                     &self.ctx,
                     &skill_path,
                     source_backup.as_ref(),
@@ -444,14 +459,20 @@ impl App {
                     &previous_index,
                     false,
                 );
-                rollback_registry_state(
+                if let Err(restore_err) = rollback_registry_state(
                     &paths,
                     &original_bindings,
                     &original_rules,
                     &original_projections,
-                );
+                ) {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_state",
+                        restore_err,
+                    );
+                }
                 let _ = remove_path_if_exists(&tmp_path);
-                return Err(map_io(err));
+                return Err(map_io(err).with_rollback_errors(rollback_errors));
             }
             source_replaced = true;
         }
@@ -459,71 +480,85 @@ impl App {
         let mut commit_created = false;
         let registry_audit_backup =
             snapshot_registry_audit_state(&paths).map_err(map_registry_state)?;
-        let post_replace = (|| {
-            maybe_skill_fault("skill_capture_after_source_replace")?;
-            gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
-            let changed = gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel))
-                .map_err(map_git)?;
-            let commit = if changed {
-                let message = args.message.clone().unwrap_or_else(|| {
-                    format!(
-                        "capture({}): from {}",
-                        projection.skill_id, projection.instance_id
+        let post_replace: std::result::Result<(Option<String>, String, bool), CommandFailure> =
+            (|| {
+                maybe_skill_fault("skill_capture_after_source_replace")?;
+                gitops::stage_path(&self.ctx, Path::new(&skill_rel)).map_err(map_git)?;
+                let changed = gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel))
+                    .map_err(map_git)?;
+                let commit = if changed {
+                    let message = args.message.clone().unwrap_or_else(|| {
+                        format!(
+                            "capture({}): from {}",
+                            projection.skill_id, projection.instance_id
+                        )
+                    });
+                    let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
+                    commit_created = true;
+                    Some(commit)
+                } else {
+                    None
+                };
+                maybe_skill_fault("skill_capture_after_commit")?;
+                let current_rev = gitops::head(&self.ctx).map_err(map_git)?;
+
+                let mut projections = original_projections.clone();
+                update_projection_after_capture(
+                    &mut projections,
+                    &projection.instance_id,
+                    &current_rev,
+                )?;
+                paths
+                    .save_bindings_rules_projections(
+                        &original_bindings,
+                        &original_rules,
+                        &projections,
                     )
-                });
-                let commit = gitops::commit(&self.ctx, &message).map_err(map_git)?;
-                commit_created = true;
-                Some(commit)
-            } else {
-                None
-            };
-            maybe_skill_fault("skill_capture_after_commit")?;
-            let current_rev = gitops::head(&self.ctx).map_err(map_git)?;
+                    .map_err(map_registry_state)?;
+                maybe_skill_fault("skill_capture_after_state_save")?;
 
-            let mut projections = original_projections.clone();
-            update_projection_after_capture(
-                &mut projections,
-                &projection.instance_id,
-                &current_rev,
-            )?;
-            paths
-                .save_bindings_rules_projections(&original_bindings, &original_rules, &projections)
+                let op_id = record_registry_operation(
+                    &paths,
+                    "skill.capture",
+                    json!({
+                        "skill_id": projection.skill_id,
+                        "binding_id": projection.binding_id,
+                        "instance_id": projection.instance_id,
+                        "request_id": request_id
+                    }),
+                    json!({
+                        "instance_id": projection.instance_id,
+                        "commit": commit
+                    }),
+                )
                 .map_err(map_registry_state)?;
-            maybe_skill_fault("skill_capture_after_state_save")?;
-
-            let op_id = record_registry_operation(
-                &paths,
-                "skill.capture",
-                json!({
-                    "skill_id": projection.skill_id,
-                    "binding_id": projection.binding_id,
-                    "instance_id": projection.instance_id,
-                    "request_id": request_id
-                }),
-                json!({
-                    "instance_id": projection.instance_id,
-                    "commit": commit
-                }),
-            )
-            .map_err(map_registry_state)?;
-            record_registry_observation(
-                &paths,
-                &projection.instance_id,
-                "captured",
-                Some(live_path.display().to_string()),
-                Some(projection.last_applied_rev.clone()),
-                Some(current_rev),
-            )
-            .map_err(map_registry_state)?;
-            maybe_skill_fault("skill_capture_after_observation")?;
-            Ok((commit, op_id, changed))
-        })();
+                record_registry_observation(
+                    &paths,
+                    &projection.instance_id,
+                    "captured",
+                    Some(live_path.display().to_string()),
+                    Some(projection.last_applied_rev.clone()),
+                    Some(current_rev),
+                )
+                .map_err(map_registry_state)?;
+                maybe_skill_fault("skill_capture_after_observation")?;
+                Ok((commit, op_id, changed))
+            })();
 
         let (commit, op_id, changed) = match post_replace {
             Ok(result) => result,
             Err(err) => {
-                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
-                rollback_capture_mutation(
+                let mut rollback_errors = Vec::new();
+                if let Err(restore_err) =
+                    restore_registry_audit_state(&paths, &registry_audit_backup)
+                {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_audit_state",
+                        restore_err,
+                    );
+                }
+                rollback_errors.extend(rollback_capture_mutation(
                     &self.ctx,
                     &skill_path,
                     source_backup.as_ref(),
@@ -531,14 +566,20 @@ impl App {
                     &previous_head,
                     &previous_index,
                     commit_created,
-                );
-                rollback_registry_state(
+                ));
+                if let Err(restore_err) = rollback_registry_state(
                     &paths,
                     &original_bindings,
                     &original_rules,
                     &original_projections,
-                );
-                return Err(err);
+                ) {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_state",
+                        restore_err,
+                    );
+                }
+                return Err(err.with_rollback_errors(rollback_errors));
             }
         };
 
@@ -576,8 +617,17 @@ impl App {
         let (state_commit, meta) = match post_state_commit {
             Ok(result) => result,
             Err(err) => {
-                let _ = restore_registry_audit_state(&paths, &registry_audit_backup);
-                rollback_capture_mutation(
+                let mut rollback_errors = Vec::new();
+                if let Err(restore_err) =
+                    restore_registry_audit_state(&paths, &registry_audit_backup)
+                {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_audit_state",
+                        restore_err,
+                    );
+                }
+                rollback_errors.extend(rollback_capture_mutation(
                     &self.ctx,
                     &skill_path,
                     source_backup.as_ref(),
@@ -585,14 +635,20 @@ impl App {
                     &previous_head,
                     &previous_index,
                     commit_created || state_commit_created,
-                );
-                rollback_registry_state(
+                ));
+                if let Err(restore_err) = rollback_registry_state(
                     &paths,
                     &original_bindings,
                     &original_rules,
                     &original_projections,
-                );
-                return Err(err);
+                ) {
+                    push_rollback_error(
+                        &mut rollback_errors,
+                        "restore_registry_state",
+                        restore_err,
+                    );
+                }
+                return Err(err.with_rollback_errors(rollback_errors));
             }
         };
 
@@ -1446,6 +1502,25 @@ fn maybe_skill_fault(tag: &str) -> std::result::Result<(), CommandFailure> {
     Ok(())
 }
 
+fn rollback_fault_active(tag: &str) -> bool {
+    std::env::var("LOOM_ROLLBACK_FAULT_INJECT").ok().as_deref() == Some(tag)
+}
+
+fn push_rollback_error(errors: &mut Vec<Value>, step: &str, message: impl ToString) {
+    errors.push(json!({
+        "step": step,
+        "message": message.to_string(),
+    }));
+}
+
+fn maybe_push_rollback_fault(errors: &mut Vec<Value>, step: &str) -> bool {
+    if rollback_fault_active(step) {
+        push_rollback_error(errors, step, format!("fault injected at {}", step));
+        return true;
+    }
+    false
+}
+
 fn rollback_project_mutation(
     paths: &RegistryStatePaths,
     materialized_path: &Path,
@@ -1453,18 +1528,30 @@ fn rollback_project_mutation(
     original_bindings: &RegistryBindingsFile,
     original_rules: &RegistryRulesFile,
     original_projections: &RegistryProjectionsFile,
-) {
+) -> Vec<Value> {
+    let mut errors = Vec::new();
     if let Some(backup) = backup {
-        let _ = restore_path_from_backup(materialized_path, backup);
+        if !maybe_push_rollback_fault(&mut errors, "restore_projection_path")
+            && let Err(err) = restore_path_from_backup(materialized_path, backup)
+        {
+            push_rollback_error(&mut errors, "restore_projection_path", err);
+        }
     } else {
-        let _ = remove_path_if_exists(materialized_path);
+        if !maybe_push_rollback_fault(&mut errors, "remove_projection_path")
+            && let Err(err) = remove_path_if_exists(materialized_path)
+        {
+            push_rollback_error(&mut errors, "remove_projection_path", err);
+        }
     }
-    rollback_registry_state(
+    if let Err(err) = rollback_registry_state(
         paths,
         original_bindings,
         original_rules,
         original_projections,
-    );
+    ) {
+        push_rollback_error(&mut errors, "restore_registry_state", err);
+    }
+    errors
 }
 
 fn rollback_capture_mutation(
@@ -1475,21 +1562,45 @@ fn rollback_capture_mutation(
     previous_head: &str,
     previous_index: &gitops::IndexSnapshot,
     commit_created: bool,
-) {
+) -> Vec<Value> {
+    let mut errors = Vec::new();
     if commit_created {
         // Preserve worktree content while removing only the command-created commit.
-        let _ = gitops::run_git_allow_failure(ctx, &["reset", "--soft", previous_head]);
+        if !maybe_push_rollback_fault(&mut errors, "reset_command_created_commit") {
+            match gitops::run_git_allow_failure(ctx, &["reset", "--soft", previous_head]) {
+                Ok(output) if output.status.success() => {}
+                Ok(output) => push_rollback_error(
+                    &mut errors,
+                    "reset_command_created_commit",
+                    String::from_utf8_lossy(&output.stderr).trim(),
+                ),
+                Err(err) => push_rollback_error(&mut errors, "reset_command_created_commit", err),
+            }
+        }
     }
 
     if source_replaced {
         if let Some(backup) = source_backup {
-            let _ = restore_path_from_backup(skill_path, backup);
+            if !maybe_push_rollback_fault(&mut errors, "restore_source_path")
+                && let Err(err) = restore_path_from_backup(skill_path, backup)
+            {
+                push_rollback_error(&mut errors, "restore_source_path", err);
+            }
         } else {
-            let _ = remove_path_if_exists(skill_path);
+            if !maybe_push_rollback_fault(&mut errors, "remove_source_path")
+                && let Err(err) = remove_path_if_exists(skill_path)
+            {
+                push_rollback_error(&mut errors, "remove_source_path", err);
+            }
         }
     }
 
-    let _ = gitops::restore_index(ctx, previous_index);
+    if !maybe_push_rollback_fault(&mut errors, "restore_git_index")
+        && let Err(err) = gitops::restore_index(ctx, previous_index)
+    {
+        push_rollback_error(&mut errors, "restore_git_index", err);
+    }
+    errors
 }
 
 fn ensure_capture_source_not_drifted(
@@ -1553,12 +1664,16 @@ fn rollback_registry_state(
     original_bindings: &RegistryBindingsFile,
     original_rules: &RegistryRulesFile,
     original_projections: &RegistryProjectionsFile,
-) {
-    let _ = paths.save_bindings_rules_projections(
+) -> anyhow::Result<()> {
+    if rollback_fault_active("restore_registry_state") {
+        anyhow::bail!("fault injected at restore_registry_state");
+    }
+    paths.save_bindings_rules_projections(
         original_bindings,
         original_rules,
         original_projections,
-    );
+    )?;
+    Ok(())
 }
 
 #[derive(Debug, Default)]

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use chrono::Utc;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::cli::{DiffArgs, ReleaseArgs, RollbackArgs};
 use crate::envelope::Meta;
@@ -101,12 +101,16 @@ impl App {
                 result
             }
             Err(err) => {
-                reset_command_created_commit_best_effort(self, &previous_head);
-                restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+                let mut rollback_errors =
+                    reset_command_created_commit_best_effort(self, &previous_head);
+                rollback_errors.extend(restore_registry_layout_best_effort(
+                    &paths,
+                    &registry_layout_backup,
+                ));
                 remove_registry_layout_backups_best_effort(&registry_layout_backup);
-                let _ = gitops::restore_index(&self.ctx, &previous_index);
+                rollback_errors.extend(restore_index_best_effort(&self.ctx, &previous_index));
                 delete_tag_best_effort(self, &tag);
-                return Err(err);
+                return Err(err.with_rollback_errors(rollback_errors));
             }
         };
 
@@ -150,13 +154,23 @@ impl App {
         if let Err(err) =
             gitops::checkout_path_from_ref(&self.ctx, &reference, Path::new(&skill_rel))
         {
-            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            restore_path_best_effort(
+                &skill_path,
+                skill_backup.as_ref(),
+                "restore_skill_path",
+                "remove_skill_path",
+            );
             remove_backup_path_best_effort(skill_backup.as_ref());
             let _ = gitops::restore_index(&self.ctx, &previous_index);
             return Err(map_git(err));
         }
         if let Err(err) = gitops::stage_path(&self.ctx, Path::new(&skill_rel)) {
-            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            restore_path_best_effort(
+                &skill_path,
+                skill_backup.as_ref(),
+                "restore_skill_path",
+                "remove_skill_path",
+            );
             remove_backup_path_best_effort(skill_backup.as_ref());
             let _ = gitops::restore_index(&self.ctx, &previous_index);
             return Err(map_git(err));
@@ -165,7 +179,12 @@ impl App {
         let changed = match gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel)) {
             Ok(changed) => changed,
             Err(err) => {
-                restore_path_best_effort(&skill_path, skill_backup.as_ref());
+                restore_path_best_effort(
+                    &skill_path,
+                    skill_backup.as_ref(),
+                    "restore_skill_path",
+                    "remove_skill_path",
+                );
                 remove_backup_path_best_effort(skill_backup.as_ref());
                 let _ = gitops::restore_index(&self.ctx, &previous_index);
                 return Err(map_git(err));
@@ -184,7 +203,12 @@ impl App {
         let registry_layout_backup =
             backup_registry_layout(&self.ctx, &paths).map_err(map_registry_state)?;
         if let Err(err) = paths.ensure_layout() {
-            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            restore_path_best_effort(
+                &skill_path,
+                skill_backup.as_ref(),
+                "restore_skill_path",
+                "remove_skill_path",
+            );
             remove_backup_path_best_effort(skill_backup.as_ref());
             restore_registry_layout_best_effort(&paths, &registry_layout_backup);
             remove_registry_layout_backups_best_effort(&registry_layout_backup);
@@ -200,7 +224,12 @@ impl App {
             &recovery_ref,
             &format!("recovery before rollback {}", args.skill),
         ) {
-            restore_path_best_effort(&skill_path, skill_backup.as_ref());
+            restore_path_best_effort(
+                &skill_path,
+                skill_backup.as_ref(),
+                "restore_skill_path",
+                "remove_skill_path",
+            );
             remove_backup_path_best_effort(skill_backup.as_ref());
             restore_registry_layout_best_effort(&paths, &registry_layout_backup);
             remove_registry_layout_backups_best_effort(&registry_layout_backup);
@@ -213,7 +242,12 @@ impl App {
             Ok(commit) => commit,
             Err(err) => {
                 delete_tag_best_effort(self, &recovery_ref);
-                restore_path_best_effort(&skill_path, skill_backup.as_ref());
+                restore_path_best_effort(
+                    &skill_path,
+                    skill_backup.as_ref(),
+                    "restore_skill_path",
+                    "remove_skill_path",
+                );
                 remove_backup_path_best_effort(skill_backup.as_ref());
                 restore_registry_layout_best_effort(&paths, &registry_layout_backup);
                 remove_registry_layout_backups_best_effort(&registry_layout_backup);
@@ -279,14 +313,26 @@ impl App {
                 result
             }
             Err(err) => {
+                let mut rollback_errors = Vec::new();
                 delete_tag_best_effort(self, &recovery_ref);
-                reset_command_created_commit_best_effort(self, &previous_head);
-                restore_path_best_effort(&skill_path, skill_backup.as_ref());
+                rollback_errors.extend(reset_command_created_commit_best_effort(
+                    self,
+                    &previous_head,
+                ));
+                rollback_errors.extend(restore_path_best_effort(
+                    &skill_path,
+                    skill_backup.as_ref(),
+                    "restore_skill_path",
+                    "remove_skill_path",
+                ));
                 remove_backup_path_best_effort(skill_backup.as_ref());
-                restore_registry_layout_best_effort(&paths, &registry_layout_backup);
+                rollback_errors.extend(restore_registry_layout_best_effort(
+                    &paths,
+                    &registry_layout_backup,
+                ));
                 remove_registry_layout_backups_best_effort(&registry_layout_backup);
-                let _ = gitops::restore_index(&self.ctx, &previous_index);
-                return Err(err);
+                rollback_errors.extend(restore_index_best_effort(&self.ctx, &previous_index));
+                return Err(err.with_rollback_errors(rollback_errors));
             }
         };
 
@@ -339,16 +385,44 @@ fn delete_tag_best_effort(app: &App, tag: &str) {
     let _ = gitops::run_git_allow_failure(&app.ctx, &["tag", "-d", tag]);
 }
 
-fn reset_command_created_commit_best_effort(app: &App, previous_head: &str) {
-    let _ = gitops::run_git_allow_failure(&app.ctx, &["reset", "--soft", previous_head]);
+fn reset_command_created_commit_best_effort(app: &App, previous_head: &str) -> Vec<Value> {
+    let mut errors = Vec::new();
+    if maybe_push_rollback_fault(&mut errors, "reset_command_created_commit") {
+        return errors;
+    }
+    match gitops::run_git_allow_failure(&app.ctx, &["reset", "--soft", previous_head]) {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => push_rollback_error(
+            &mut errors,
+            "reset_command_created_commit",
+            String::from_utf8_lossy(&output.stderr).trim(),
+        ),
+        Err(err) => push_rollback_error(&mut errors, "reset_command_created_commit", err),
+    }
+    errors
 }
 
-fn restore_path_best_effort(path: &Path, backup: Option<&serde_json::Value>) {
+fn restore_path_best_effort(
+    path: &Path,
+    backup: Option<&serde_json::Value>,
+    restore_step: &str,
+    remove_step: &str,
+) -> Vec<Value> {
+    let mut errors = Vec::new();
     if let Some(backup) = backup {
-        let _ = restore_path_from_backup(path, backup);
+        if !maybe_push_rollback_fault(&mut errors, restore_step)
+            && let Err(err) = restore_path_from_backup(path, backup)
+        {
+            push_rollback_error(&mut errors, restore_step, err);
+        }
     } else {
-        let _ = crate::state::remove_path_if_exists(path);
+        if !maybe_push_rollback_fault(&mut errors, remove_step)
+            && let Err(err) = crate::state::remove_path_if_exists(path)
+        {
+            push_rollback_error(&mut errors, remove_step, err);
+        }
     }
+    errors
 }
 
 struct RegistryLayoutBackup {
@@ -370,16 +444,75 @@ fn backup_registry_layout(
     })
 }
 
-fn restore_registry_layout_best_effort(paths: &RegistryStatePaths, backup: &RegistryLayoutBackup) {
+fn restore_registry_layout_best_effort(
+    paths: &RegistryStatePaths,
+    backup: &RegistryLayoutBackup,
+) -> Vec<Value> {
+    let mut errors = Vec::new();
     if backup.registry.is_some() {
-        restore_path_best_effort(&paths.registry_dir, backup.registry.as_ref());
+        if maybe_push_rollback_fault(&mut errors, "restore_registry_layout") {
+            // Fault injection intentionally skips the actual restore.
+        } else {
+            errors.extend(restore_path_best_effort(
+                &paths.registry_dir,
+                backup.registry.as_ref(),
+                "restore_registry_layout",
+                "remove_registry_layout",
+            ));
+        }
     } else {
-        let _ = crate::state::remove_path_if_exists(&paths.registry_dir);
+        if !maybe_push_rollback_fault(&mut errors, "remove_registry_layout")
+            && let Err(err) = crate::state::remove_path_if_exists(&paths.registry_dir)
+        {
+            push_rollback_error(&mut errors, "remove_registry_layout", err);
+        }
     }
 
     if backup.legacy_v3.is_some() {
-        restore_path_best_effort(&paths.state_dir.join("v3"), backup.legacy_v3.as_ref());
+        if maybe_push_rollback_fault(&mut errors, "restore_legacy_registry_layout") {
+            // Fault injection intentionally skips the actual restore.
+        } else {
+            errors.extend(restore_path_best_effort(
+                &paths.state_dir.join("v3"),
+                backup.legacy_v3.as_ref(),
+                "restore_legacy_registry_layout",
+                "remove_legacy_registry_layout",
+            ));
+        }
     }
+    errors
+}
+
+fn restore_index_best_effort(
+    ctx: &crate::state::AppContext,
+    previous_index: &gitops::IndexSnapshot,
+) -> Vec<Value> {
+    let mut errors = Vec::new();
+    if !maybe_push_rollback_fault(&mut errors, "restore_git_index")
+        && let Err(err) = gitops::restore_index(ctx, previous_index)
+    {
+        push_rollback_error(&mut errors, "restore_git_index", err);
+    }
+    errors
+}
+
+fn rollback_fault_active(tag: &str) -> bool {
+    std::env::var("LOOM_ROLLBACK_FAULT_INJECT").ok().as_deref() == Some(tag)
+}
+
+fn push_rollback_error(errors: &mut Vec<Value>, step: &str, message: impl ToString) {
+    errors.push(json!({
+        "step": step,
+        "message": message.to_string(),
+    }));
+}
+
+fn maybe_push_rollback_fault(errors: &mut Vec<Value>, step: &str) -> bool {
+    if rollback_fault_active(step) {
+        push_rollback_error(errors, step, format!("fault injected at {}", step));
+        return true;
+    }
+    false
 }
 
 fn remove_registry_layout_backups_best_effort(backup: &RegistryLayoutBackup) {

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -26,6 +26,15 @@ fn read_observation_log(root: &std::path::Path, instance_id: &str) -> String {
     .expect("read observation log")
 }
 
+fn rollback_error_steps(env: &Value) -> Vec<String> {
+    env["error"]["details"]["rollback_errors"]
+        .as_array()
+        .expect("rollback errors array")
+        .iter()
+        .filter_map(|error| error["step"].as_str().map(ToString::to_string))
+        .collect()
+}
+
 fn git_ok(root: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .arg("-C")
@@ -532,4 +541,94 @@ fn skill_capture_rolls_back_operation_log_after_append_failure() {
     );
     assert_eq!(read_operations_log(root.path()), operations_before);
     assert_eq!(read_checkpoint(root.path()), checkpoint_before);
+}
+
+#[test]
+fn skill_capture_reports_source_restore_rollback_failure() {
+    let root = TestDir::new("v3-capture-rollback-failure");
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v1\n",
+    );
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+    assert!(
+        skill_project(
+            root.path(),
+            "model-onboarding",
+            "bind_claude_project_a",
+            Some("copy"),
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let live_file = target_path.join("model-onboarding").join("SKILL.md");
+    fs::write(
+        &live_file,
+        "# model-onboarding\n\ncaptured from live copy\n",
+    )
+    .expect("edit live projection");
+
+    let (capture_output, capture_env) = run_loom_with_env(
+        root.path(),
+        &[
+            ("LOOM_FAULT_INJECT", "skill_capture_after_state_save"),
+            ("LOOM_ROLLBACK_FAULT_INJECT", "restore_source_path"),
+        ],
+        &[
+            "skill",
+            "capture",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+        ],
+    );
+
+    assert!(
+        !capture_output.status.success(),
+        "capture unexpectedly succeeded"
+    );
+    assert_eq!(capture_env["ok"], Value::Bool(false));
+    assert!(
+        rollback_error_steps(&capture_env)
+            .iter()
+            .any(|step| step == "restore_source_path"),
+        "expected rollback error details: {}",
+        capture_env
+    );
+    assert!(
+        capture_env["error"]["details"]["original_error"]["message"]
+            .as_str()
+            .expect("original error message")
+            .contains("skill_capture_after_state_save")
+    );
 }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -30,6 +30,15 @@ fn read_observation_log(root: &std::path::Path, instance_id: &str) -> String {
     .expect("read observation log")
 }
 
+fn rollback_error_steps(env: &Value) -> Vec<String> {
+    env["error"]["details"]["rollback_errors"]
+        .as_array()
+        .expect("rollback errors array")
+        .iter()
+        .filter_map(|error| error["step"].as_str().map(ToString::to_string))
+        .collect()
+}
+
 fn git_output(root: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .arg("-C")
@@ -388,6 +397,58 @@ fn skill_rollback_rolls_back_commits_and_worktree_after_late_audit_failure() {
     assert_eq!(
         git_status_short_for(root.path(), &["skills/model-onboarding", "state/registry"]),
         ""
+    );
+}
+
+#[test]
+fn skill_rollback_reports_registry_layout_restore_failure() {
+    let root = TestDir::new("registry-skill-rollback-restore-failure");
+    write_example_skill(root.path(), "model-onboarding");
+
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+    write_skill(
+        root.path(),
+        "model-onboarding",
+        "# model-onboarding\n\nsource v2\n",
+    );
+    assert!(
+        save_skill(root.path(), "model-onboarding")
+            .0
+            .status
+            .success()
+    );
+
+    let (rollback_output, rollback_env) = run_loom_with_env(
+        root.path(),
+        &[
+            ("LOOM_FAULT_INJECT", "skill_rollback_after_state_commit"),
+            ("LOOM_ROLLBACK_FAULT_INJECT", "restore_registry_layout"),
+        ],
+        &["skill", "rollback", "model-onboarding", "--to", "HEAD~1"],
+    );
+
+    assert!(
+        !rollback_output.status.success(),
+        "rollback unexpectedly succeeded"
+    );
+    assert_eq!(rollback_env["ok"], Value::Bool(false));
+    assert!(
+        rollback_error_steps(&rollback_env)
+            .iter()
+            .any(|step| step == "restore_registry_layout"),
+        "expected rollback error details: {}",
+        rollback_env
+    );
+    assert!(
+        rollback_env["error"]["details"]["original_error"]["message"]
+            .as_str()
+            .expect("original error message")
+            .contains("skill_rollback_after_state_commit")
     );
 }
 
@@ -920,6 +981,72 @@ fn skill_project_rolls_back_projection_after_post_materialize_failure() {
     assert!(
         !projections.contains("model-onboarding"),
         "projection state should roll back"
+    );
+}
+
+#[test]
+fn skill_project_reports_registry_state_rollback_failure() {
+    let root = TestDir::new("v3-skill-project-rollback-failure");
+    write_example_skill(root.path(), "model-onboarding");
+
+    let (save_output, _) = save_skill(root.path(), "model-onboarding");
+    assert!(save_output.status.success(), "save should succeed");
+
+    let target_path = root.path().join("live/claude-project-a");
+    assert!(
+        target_add(root.path(), "claude", &target_path, "managed")
+            .0
+            .status
+            .success()
+    );
+    assert!(
+        binding_add(
+            root.path(),
+            "claude",
+            "default",
+            "path-prefix",
+            "/tmp/project-a",
+            "target_claude_claude_project_a",
+        )
+        .0
+        .status
+        .success()
+    );
+
+    let (project_output, project_env) = run_loom_with_env(
+        root.path(),
+        &[
+            ("LOOM_FAULT_INJECT", "skill_project_after_state_save"),
+            ("LOOM_ROLLBACK_FAULT_INJECT", "restore_registry_state"),
+        ],
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            "bind_claude_project_a",
+            "--method",
+            "copy",
+        ],
+    );
+
+    assert!(
+        !project_output.status.success(),
+        "project unexpectedly succeeded"
+    );
+    assert_eq!(project_env["ok"], Value::Bool(false));
+    assert!(
+        rollback_error_steps(&project_env)
+            .iter()
+            .any(|step| step == "restore_registry_state"),
+        "expected rollback error details: {}",
+        project_env
+    );
+    assert!(
+        project_env["error"]["details"]["original_error"]["message"]
+            .as_str()
+            .expect("original error message")
+            .contains("skill_project_after_state_save")
     );
 }
 


### PR DESCRIPTION
Closes #131

## Summary
- attach rollback failure details to command envelopes instead of discarding restore errors
- collect rollback failures for skill project/capture source, projection, registry state, commit reset, and index restore paths
- collect version release/rollback restore failures for registry layout, source path, commit reset, and index restore paths
- add rollback fault-injection coverage for project, capture, and skill rollback

## Verification
- `cargo fmt --check`
- `cargo test -q --test project skill_project_reports_registry_state_rollback_failure`
- `cargo test -q --test project skill_rollback_reports_registry_layout_restore_failure`
- `cargo test -q --test capture skill_capture_reports_source_restore_rollback_failure`
- `cargo test -q --test project`
- `cargo test -q --test capture`
- `cargo test -q --test write`
- `cargo check`
- `cargo test`
- `git diff --check`
- `make ci`