### PR TITLE
Send binding selector for Panel capture

### DIFF
--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SkillsPage } from "./SkillsPage";
-import type { Skill } from "../../lib/types";
+import type { Binding, Skill } from "../../lib/types";
 
 vi.mock("../../lib/api/client", () => ({
   api: {
@@ -34,11 +34,21 @@ const mockSkill: Skill = {
   targets: [],
 };
 
-function renderPage(overrides: { onMutation?: () => void } = {}) {
+const mockBinding: Binding = {
+  id: "binding-1",
+  skill: "my-skill",
+  target: "target-1",
+  matcher: "path_prefix:/repo",
+  method: "copy",
+  policy: "auto",
+};
+
+function renderPage(overrides: { onMutation?: () => void; bindings?: Binding[] } = {}) {
   return render(
     <SkillsPage
       skills={[mockSkill]}
       targets={[]}
+      bindings={overrides.bindings ?? []}
       selectedSkill="skill-1"
       onSelectSkill={() => {}}
       onMutation={overrides.onMutation ?? (() => {})}
@@ -53,6 +63,39 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     ...overrides,
   };
 }
+
+describe("SkillsPage — capture action", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (api.skillHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      data: { skill: "my-skill", count: 0, events: [] },
+    });
+    (api.capture as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      cmd: "skill.capture",
+      request_id: "req-capture",
+    });
+  });
+
+  it("sends a binding selector for a skill with one projected binding", async () => {
+    const onMutation = vi.fn();
+    renderPage({ bindings: [mockBinding], onMutation });
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture" }));
+
+    await waitFor(() => {
+      expect(api.capture).toHaveBeenCalledWith({ skill: "my-skill", binding: "binding-1" });
+      expect(onMutation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("disables capture when the skill has no unique binding selector", () => {
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "Capture" })).toBeDisabled();
+  });
+});
 
 describe("SkillsPage — history tab", () => {
   beforeEach(() => {

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -21,7 +21,16 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
   const filtered = skills.filter((s) => s.name.includes(q) || s.tag.includes(q));
   const sel = skills.find((s) => s.id === selectedSkill) ?? skills[0];
   const capture = useMutation();
-  const captureDisabled = capture.busy || readOnly || !sel;
+  const selectedSkillBindings = sel ? bindings.filter((b) => b.skill === sel.name) : [];
+  const captureBinding = selectedSkillBindings.length === 1 ? selectedSkillBindings[0] : null;
+  const captureDisabled = capture.busy || readOnly || !sel || !captureBinding;
+  const captureTitle = readOnly
+    ? "registry offline"
+    : !sel
+      ? "select a skill first"
+      : !captureBinding
+        ? "capture requires one projected binding"
+        : undefined;
   const emptyMessage: React.ReactNode = readOnly
     ? "Live registry API is offline. Start the panel backend to load real skills."
     : q
@@ -34,11 +43,11 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
       );
 
   const runCapture = () => {
-    if (!sel) return;
+    if (!sel || !captureBinding) return;
     const skillName = sel?.name;
     capture.run(
       `capture ${skillName}`,
-      () => api.capture({ skill: skillName }),
+      () => api.capture({ skill: skillName, binding: captureBinding.id }),
       onMutation,
     );
   };
@@ -62,7 +71,7 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
             className="btn primary"
             onClick={runCapture}
             disabled={captureDisabled}
-            title={readOnly ? "registry offline" : !sel ? "select a skill first" : undefined}
+            title={captureTitle}
           >
             <PlusIcon /> {capture.busy ? "capturing…" : "Capture"}
           </button>


### PR DESCRIPTION
Closes #102

## Summary
- make the Skills page Capture action send `{ skill, binding }` when the selected skill has exactly one binding
- disable the top-level Capture action when there is no unique binding selector instead of sending a backend-rejected payload
- add SkillsPage tests for the valid selector payload and disabled ambiguous state

## Verification
- `cd panel && bun install --frozen-lockfile`
- `cd panel && bun run typecheck`
- `cd panel && bun run test -- SkillsPage`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `git diff --check`
- `make ci`