### PR TITLE
Canonicalize target paths before duplicate checks

### DIFF
--- a/src/commands/target_cmds.rs
+++ b/src/commands/target_cmds.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use chrono::Utc;
@@ -91,6 +91,16 @@ impl App {
                 }
             }
         }
+        let normalized_target_path = target_path
+            .canonicalize()
+            .with_context(|| {
+                format!(
+                    "failed to canonicalize target path '{}'",
+                    target_path.display()
+                )
+            })
+            .map_err(map_io)?;
+        let normalized_path = normalized_target_path.to_string_lossy().into_owned();
 
         let paths = self.ensure_registry_layout()?;
         let mut targets = paths.load_targets().map_err(map_registry_state)?;
@@ -100,7 +110,8 @@ impl App {
             .targets
             .iter()
             .find(|target| {
-                target.agent == agent_kind_as_str(args.agent) && target.path == args.path
+                target.agent == agent_kind_as_str(args.agent)
+                    && target_path_matches(&target.path, &normalized_target_path)
             })
             .cloned()
         {
@@ -116,11 +127,13 @@ impl App {
             return Ok((json!({"target": existing, "noop": true}), Meta::default()));
         }
 
-        let target_id = unique_target_id(&targets, args);
+        let mut target_args = args.clone();
+        target_args.path.clone_from(&normalized_path);
+        let target_id = unique_target_id(&targets, &target_args);
         let target = RegistryProjectionTarget {
             target_id: target_id.clone(),
             agent: agent_kind_as_str(args.agent).to_string(),
-            path: args.path.clone(),
+            path: normalized_path,
             ownership: target_ownership_as_str(args.ownership).to_string(),
             capabilities: target_capabilities(args.ownership),
             created_at: Some(Utc::now()),
@@ -281,4 +294,12 @@ impl App {
             meta,
         ))
     }
+}
+
+fn target_path_matches(stored_path: &str, normalized_target_path: &Path) -> bool {
+    let stored = PathBuf::from(stored_path);
+    stored.as_path() == normalized_target_path
+        || stored
+            .canonicalize()
+            .is_ok_and(|canonical| canonical == normalized_target_path)
 }

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -49,6 +49,11 @@ fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
         live_projection.exists(),
         "projection should exist before remove"
     );
+    let live_projection_dir = live_projection
+        .parent()
+        .expect("live projection parent")
+        .canonicalize()
+        .expect("canonicalize live projection parent");
 
     let (output, env) = run_loom(
         root.path(),
@@ -71,7 +76,7 @@ fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
     );
     assert_eq!(
         env["data"]["orphaned_paths"][0],
-        Value::String(root.path().join("live/claude-a/demo").display().to_string())
+        Value::String(live_projection_dir.display().to_string())
     );
     assert!(
         env["meta"]["warnings"]
@@ -102,7 +107,7 @@ fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
     );
     assert_eq!(
         orphan_list_env["data"]["orphaned_paths"][0],
-        Value::String(root.path().join("live/claude-a/demo").display().to_string())
+        Value::String(live_projection_dir.display().to_string())
     );
     assert_eq!(
         orphan_list_env["data"]["projections"][0]["live_path_exists"],

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -264,6 +264,56 @@ fn target_add_is_idempotent_for_same_agent_and_path() {
 }
 
 #[test]
+fn target_add_is_idempotent_for_equivalent_directory_path() {
+    let root = TestDir::new("registry-target-add-equivalent-path");
+    let target_path = root.path().join("live/codex-workbench");
+    let (first_output, first_env) = target_add(root.path(), "codex", &target_path, "managed");
+    assert!(first_output.status.success(), "first add should succeed");
+
+    let equivalent_path = target_path.join(".");
+    let (second_output, second_env) = target_add(root.path(), "codex", &equivalent_path, "managed");
+    assert!(second_output.status.success(), "second add should succeed");
+    assert_eq!(second_env["data"]["noop"], Value::Bool(true));
+
+    let canonical_path = target_path
+        .canonicalize()
+        .expect("canonicalize managed target")
+        .to_string_lossy()
+        .into_owned();
+    assert_eq!(
+        first_env["data"]["target"]["path"],
+        Value::from(canonical_path)
+    );
+
+    let (list_output, list_env) = run_loom(root.path(), &["target", "list"]);
+    assert!(list_output.status.success(), "target list should succeed");
+    assert_eq!(list_env["data"]["count"], Value::from(1));
+}
+
+#[cfg(unix)]
+#[test]
+fn target_add_is_idempotent_for_symlinked_directory_path() {
+    use std::os::unix::fs::symlink;
+
+    let root = TestDir::new("registry-target-add-symlink-path");
+    let target_path = root.path().join("live/codex-workbench");
+    let link_path = root.path().join("live/codex-link");
+    fs::create_dir_all(&target_path).expect("create observed target");
+    symlink(&target_path, &link_path).expect("create target symlink");
+
+    let (first_output, _) = target_add(root.path(), "codex", &target_path, "observed");
+    assert!(first_output.status.success(), "first add should succeed");
+
+    let (second_output, second_env) = target_add(root.path(), "codex", &link_path, "observed");
+    assert!(second_output.status.success(), "second add should succeed");
+    assert_eq!(second_env["data"]["noop"], Value::Bool(true));
+
+    let (list_output, list_env) = run_loom(root.path(), &["target", "list"]);
+    assert!(list_output.status.success(), "target list should succeed");
+    assert_eq!(list_env["data"]["count"], Value::from(1));
+}
+
+#[test]
 fn workspace_binding_add_rolls_back_bindings_after_operation_log_failure() {
     let root = TestDir::new("registry-binding-add-oplog-rollback");
     let target_path = root.path().join("live/claude-project-a");


### PR DESCRIPTION
## Summary
- canonicalize target add paths before duplicate detection, ID generation, and persistence
- treat existing stored paths as equivalent when they canonicalize to the same directory
- add regressions for /./ paths and symlinked target directories

Closes #104

## Verification
- cargo test -q --test write target_add_is_idempotent_for_equivalent_directory_path
- cargo test -q --test write target_add_is_idempotent_for_symlinked_directory_path
- cargo test -q --test remove binding_remove_cascades_metadata_and_leaves_live_projection_in_place
- cargo check
- git diff --check
- cargo test
- make ci