### PR TITLE
Expose snapshot audit through V1 ops

### DIFF
--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -192,7 +192,7 @@ export function adaptPendingOp(op: PendingOp, index: number): Op {
 
 export function adaptRegistryOperation(op: RegistryOperationRecord): Op {
   return {
-    id: op.op_id,
+    id: op.op_id ?? op.audit_id ?? op.request_id ?? `${op.intent}-${op.updated_at}`,
     status: operationStatus(op),
     kind: op.intent,
     skill: op.skill ?? op.intent,

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -11,7 +11,9 @@ import type { RegistryRule } from "../../generated/RegistryRule";
 import type { RegistryTarget } from "../../generated/RegistryTarget";
 
 export interface RegistryOperationRecord {
-  op_id: string;
+  op_id: string | null;
+  audit_id?: string | null;
+  source?: string;
   intent: string;
   status: string;
   ack: boolean;

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -76,7 +76,7 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
       if (filter !== "all" && bucket(op) !== filter) return false;
       if (!needle) return true;
       return (
-        op.op_id.toLowerCase().includes(needle) ||
+        operationDisplayId(op).toLowerCase().includes(needle) ||
         op.intent.toLowerCase().includes(needle) ||
         (op.last_error?.message ?? "").toLowerCase().includes(needle)
       );
@@ -229,7 +229,7 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
                 </tr>
               )}
               {filtered.map((op) => (
-                <OpHistoryRow key={op.op_id} op={op} />
+                <OpHistoryRow key={operationDisplayId(op)} op={op} />
               ))}
             </tbody>
           </table>
@@ -271,12 +271,16 @@ export function bucket(op: RegistryOperationRecord): "pending" | "ok" | "err" {
   return op.ack ? "ok" : "pending";
 }
 
+function operationDisplayId(op: RegistryOperationRecord): string {
+  return op.op_id ?? op.audit_id ?? op.request_id ?? `${op.intent}-${op.updated_at}`;
+}
+
 function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
   const kind = bucket(op);
   const color = kind === "err" ? "var(--err)" : kind === "pending" ? "var(--pending)" : "var(--ok)";
   return (
     <tr>
-      <td className="mono dim">{op.op_id}</td>
+      <td className="mono dim">{operationDisplayId(op)}</td>
       <td className="name">{op.intent}</td>
       <td>
         <span className="chip" style={{ color }}>

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -233,7 +233,7 @@ function opsPayload(operation: RegistryOperationRecord): OpsPayload {
       limit: 100,
       has_more: false,
       operations: [operation],
-      checkpoint: { last_scanned_op_id: operation.op_id },
+      checkpoint: { last_scanned_op_id: operation.op_id ?? undefined },
     },
   };
 }

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -1478,6 +1478,31 @@ impl App {
         let tag = format!("snapshot/{}/{}-{}", args.skill, ts, short);
         gitops::create_annotated_tag(&self.ctx, &tag, &format!("snapshot {}", args.skill))
             .map_err(map_git)?;
+        if let Err(err) = gitops::append_history_audit_event(
+            &self.ctx,
+            "skill.snapshot",
+            json!({"skill": args.skill, "tag": tag.clone()}),
+            request_id,
+        ) {
+            let mut failure = map_git(err);
+            let rollback_output = gitops::run_git_allow_failure(&self.ctx, &["tag", "-d", &tag]);
+            let mut rollback_errors = Vec::new();
+            match rollback_output {
+                Ok(output) if output.status.success() => {}
+                Ok(output) => rollback_errors.push(json!({
+                    "step": "delete_snapshot_tag",
+                    "message": String::from_utf8_lossy(&output.stderr).trim().to_string()
+                })),
+                Err(err) => rollback_errors.push(json!({
+                    "step": "delete_snapshot_tag",
+                    "message": err.to_string()
+                })),
+            }
+            if !rollback_errors.is_empty() {
+                failure.details = json!({ "rollback_errors": rollback_errors });
+            }
+            return Err(failure);
+        }
 
         let mut meta = Meta::default();
         maybe_autosync_or_queue(

--- a/src/gitops/history.rs
+++ b/src/gitops/history.rs
@@ -2,15 +2,18 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
+use chrono::Utc;
 use serde::Serialize;
+use serde_json::json;
 
 use crate::state::AppContext;
+use crate::types::PendingOp;
 
 use super::{
     HISTORY_BRANCH, HISTORY_BRANCH_REF, HISTORY_COMPACT_AFTER_SEGMENTS, HISTORY_RETAIN_ARCHIVES,
     HISTORY_RETAIN_RECENT_SEGMENTS, ORIGIN_HISTORY_BRANCH_REF, ahead_behind_refs,
-    ensure_local_identity, hash_object_file, remote_exists, remote_tracking_history_exists,
-    repo_is_initialized,
+    ensure_local_identity, hash_object_bytes, hash_object_file, read_blob, remote_exists,
+    remote_tracking_history_exists, repo_is_initialized,
 };
 
 use super::history_impl::{
@@ -122,6 +125,79 @@ pub fn history_status(ctx: &AppContext) -> Result<HistoryStatusReport> {
         retain_archives: HISTORY_RETAIN_ARCHIVES,
         conflicts,
     })
+}
+
+pub fn history_journal_bodies(ctx: &AppContext) -> Result<Vec<(String, String)>> {
+    if !repo_is_initialized(ctx)? {
+        return Ok(Vec::new());
+    }
+    let Some(local) = load_history_branch_state(ctx, HISTORY_BRANCH_REF)? else {
+        return Ok(Vec::new());
+    };
+
+    let mut bodies = Vec::with_capacity(local.archives.len() + local.segments.len());
+    for (path, blob) in local.archives.iter().chain(local.segments.iter()) {
+        bodies.push((path.clone(), read_blob(ctx, blob)?));
+    }
+    Ok(bodies)
+}
+
+pub fn append_history_audit_event(
+    ctx: &AppContext,
+    command: &str,
+    details: serde_json::Value,
+    request_id: &str,
+) -> Result<String> {
+    ensure_local_identity(ctx)?;
+
+    let op = PendingOp::new(command, details, request_id.to_string());
+    let op_id = op.stable_id();
+    let event_id = uuid::Uuid::new_v4().to_string();
+    let at = Utc::now();
+    let raw = serde_json::to_string(&json!({
+        "event": "audited",
+        "event_id": event_id,
+        "at": at,
+        "op": op,
+    }))? + "\n";
+    let segment_blob = hash_object_bytes(ctx, raw.as_bytes())?;
+    let segment_ref_path = format!(
+        "pending_ops_history/00001-{}.jsonl",
+        event_id.replace('-', "")
+    );
+
+    let base = load_history_branch_state(ctx, HISTORY_BRANCH_REF)?;
+    let mut archives = base
+        .as_ref()
+        .map_or_else(BTreeMap::new, |state| state.archives.clone());
+    let mut segments = base
+        .as_ref()
+        .map_or_else(BTreeMap::new, |state| state.segments.clone());
+    segments.insert(segment_ref_path, segment_blob);
+
+    let retention = apply_history_retention(ctx, &mut archives, &mut segments)?;
+    let snapshot_blob = synthesize_history_snapshot_blob(ctx, &archives, &segments)?;
+    let composed = ComposedHistoryState {
+        archives,
+        segments,
+        snapshot_blob,
+        retention,
+    };
+    let new_tree = build_tree_from_entries(ctx, &history_tree_entries(&composed))?;
+    let parents = base
+        .as_ref()
+        .map(|state| vec![state.commit.as_str()])
+        .unwrap_or_default();
+    let commit = create_commit_tree(
+        ctx,
+        &new_tree,
+        &parents,
+        &format!("Audit operation {}", command),
+    )?;
+    let expected_old = base.as_ref().map(|state| state.commit.as_str());
+    update_ref(ctx, HISTORY_BRANCH_REF, &commit, expected_old)?;
+
+    Ok(op_id)
 }
 
 pub fn repair_history_branch(

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -8,6 +8,7 @@ use axum::{
     extract::{ConnectInfo, Path as AxumPath, Query, State},
     http::{HeaderMap, StatusCode},
 };
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -21,7 +22,7 @@ use crate::commands::{
 };
 use crate::envelope::Envelope;
 use crate::gitops;
-use crate::state::resolve_agent_skill_dirs;
+use crate::state::{OpsAuditOperation, resolve_agent_skill_dirs};
 use crate::state_model::{RegistryOperationRecord, RegistrySnapshot, RegistryStatePaths};
 use crate::types::ErrorCode;
 
@@ -171,51 +172,153 @@ pub(super) async fn v1_registry_ops(
 ) -> (StatusCode, Json<serde_json::Value>) {
     match load_registry_snapshot(&state.ctx, "registry.ops") {
         Ok(snapshot) => {
-            let total = snapshot.operations.len();
+            let audit_report = match state.ctx.read_ops_audit_report() {
+                Ok(report) => report,
+                Err(err) => {
+                    let request_id = uuid::Uuid::new_v4().to_string();
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!(Envelope::err(
+                            "registry.ops",
+                            request_id,
+                            ErrorCode::IoError,
+                            err.to_string(),
+                            json!({})
+                        ))),
+                    );
+                }
+            };
             let limit = query
                 .limit
                 .unwrap_or(DEFAULT_OPS_PAGE_SIZE)
                 .clamp(1, MAX_OPS_PAGE_SIZE);
             let offset = query.offset.unwrap_or(0);
-            let end = total.saturating_sub(offset);
-            let start = end.saturating_sub(limit);
-            let operations = snapshot.operations[start..end]
+            let registry_count = snapshot.operations.len();
+            let mut rows = snapshot
+                .operations
                 .iter()
-                .rev()
-                .map(|op| {
-                    let summary = operation_summary(op);
-                    json!({
-                        "op_id": op.op_id,
-                        "intent": op.intent,
-                        "status": op.status,
-                        "ack": op.ack,
-                        "request_id": summary.request_id,
-                        "skill": summary.skill,
-                        "target": summary.target,
-                        "binding": summary.binding,
-                        "method": summary.method,
-                        "last_error": op.last_error,
-                        "created_at": op.created_at,
-                        "updated_at": op.updated_at,
-                    })
-                })
+                .map(registry_operation_activity_row)
+                .collect::<Vec<_>>();
+            let audited_snapshot_tags = audit_report
+                .operations
+                .iter()
+                .filter(|op| op.command == "skill.snapshot")
+                .filter_map(|op| json_string_field(&op.details, &["tag"]))
+                .collect::<BTreeSet<_>>();
+            for op in &audit_report.operations {
+                if op.command == "snapshot"
+                    && json_string_field(&op.details, &["tag"])
+                        .is_some_and(|tag| audited_snapshot_tags.contains(&tag))
+                {
+                    continue;
+                }
+                rows.push(audit_operation_activity_row(op));
+            }
+            rows.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| right.1.cmp(&left.1)));
+            let total = rows.len();
+            let operations = rows
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(_, _, row)| row)
                 .collect::<Vec<_>>();
 
-            panel_v1_ok(
-                "registry.ops",
-                json!({
-                    "state_model": "registry",
-                    "count": total,
-                    "loaded_count": operations.len(),
-                    "offset": offset,
-                    "limit": limit,
-                    "has_more": start > 0,
-                    "operations": operations,
-                    "checkpoint": snapshot.checkpoint,
-                }),
+            (
+                StatusCode::OK,
+                Json(json!(Envelope::ok(
+                    "registry.ops",
+                    uuid::Uuid::new_v4().to_string(),
+                    json!({
+                        "state_model": "registry",
+                        "count": total,
+                        "registry_count": registry_count,
+                        "audit_count": audit_report.operations.len(),
+                        "loaded_count": operations.len(),
+                        "offset": offset,
+                        "limit": limit,
+                        "has_more": offset + operations.len() < total,
+                        "operations": operations,
+                        "checkpoint": snapshot.checkpoint,
+                    }),
+                    crate::envelope::Meta {
+                        warnings: audit_report.warnings,
+                        ..crate::envelope::Meta::default()
+                    }
+                ))),
             )
         }
         Err(err) => panel_v1_registry_error(err),
+    }
+}
+
+fn registry_operation_activity_row(
+    op: &RegistryOperationRecord,
+) -> (DateTime<Utc>, String, serde_json::Value) {
+    let summary = operation_summary(op);
+    (
+        op.updated_at,
+        op.op_id.clone(),
+        json!({
+            "op_id": op.op_id,
+            "audit_id": null,
+            "source": "registry",
+            "intent": op.intent,
+            "status": op.status,
+            "ack": op.ack,
+            "request_id": summary.request_id,
+            "skill": summary.skill,
+            "target": summary.target,
+            "binding": summary.binding,
+            "method": summary.method,
+            "last_error": op.last_error,
+            "created_at": op.created_at,
+            "updated_at": op.updated_at,
+        }),
+    )
+}
+
+fn audit_operation_activity_row(
+    op: &OpsAuditOperation,
+) -> (DateTime<Utc>, String, serde_json::Value) {
+    let intent = audit_operation_intent(op);
+    let summary = audit_operation_summary(op);
+    let ack = matches!(op.status.as_str(), "acked" | "purged" | "succeeded");
+    (
+        op.updated_at,
+        op.op_id.clone(),
+        json!({
+            "op_id": null,
+            "audit_id": op.op_id,
+            "source": op.source,
+            "intent": intent,
+            "status": op.status,
+            "ack": ack,
+            "request_id": op.request_id,
+            "skill": summary.skill,
+            "target": summary.target,
+            "binding": summary.binding,
+            "method": summary.method,
+            "last_error": null,
+            "created_at": op.created_at,
+            "updated_at": op.updated_at,
+        }),
+    )
+}
+
+fn audit_operation_intent(op: &OpsAuditOperation) -> String {
+    match op.command.as_str() {
+        "snapshot" => "skill.snapshot".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn audit_operation_summary(op: &OpsAuditOperation) -> OperationSummary {
+    OperationSummary {
+        request_id: Some(op.request_id.clone()),
+        skill: json_string_field(&op.details, &["skill_id", "skill"]),
+        target: json_string_field(&op.details, &["target_id", "target"]),
+        binding: json_string_field(&op.details, &["binding_id", "binding"]),
+        method: json_string_field(&op.details, &["method"]),
     }
 }
 

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -14,7 +14,27 @@ use axum::{
 };
 use chrono::Duration as ChrDuration;
 use serde_json::{Value, json};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::Path,
+    process::Command,
+};
+
+fn git_ok(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
 
 #[test]
 fn registry_ops_returns_bounded_newest_first_rows() {
@@ -113,6 +133,54 @@ async fn v1_registry_ops_returns_activity_summary_fields() {
     assert_eq!(op["request_id"], json!("req-1"));
     assert!(op.get("payload").is_none());
     assert!(op.get("effects").is_none());
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
+async fn v1_registry_ops_includes_snapshot_history_audit_without_registry_op_id() {
+    let (root, state) = make_test_state();
+    git_ok(&root, &["init"]);
+    let paths = RegistryStatePaths::from_app_context(state.ctx.as_ref());
+    paths.ensure_layout().expect("ensure registry layout");
+    crate::gitops::append_history_audit_event(
+        state.ctx.as_ref(),
+        "skill.snapshot",
+        json!({
+            "skill": "demo-skill",
+            "tag": "snapshot/demo-skill/20260518T000000Z-deadbee"
+        }),
+        "req-snapshot",
+    )
+    .expect("append history audit");
+
+    let (status, Json(payload)) = v1_registry_ops(
+        Query(OpsQuery {
+            limit: Some(10),
+            offset: Some(0),
+        }),
+        State(state),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["data"]["registry_count"], json!(0));
+    assert_eq!(payload["data"]["audit_count"], json!(1));
+    let op = &payload["data"]["operations"][0];
+    assert_eq!(op["op_id"], Value::Null);
+    assert!(op["audit_id"].as_str().is_some());
+    assert_eq!(op["source"], json!("loom_history"));
+    assert_eq!(op["intent"], json!("skill.snapshot"));
+    assert_eq!(op["status"], json!("succeeded"));
+    assert_eq!(op["request_id"], json!("req-snapshot"));
+    assert_eq!(op["skill"], json!("demo-skill"));
+    assert!(
+        std::fs::read_to_string(paths.operations_file)
+            .expect("read registry ops")
+            .trim()
+            .is_empty(),
+        "snapshot audit must not be written as a registry operation"
+    );
 
     cleanup_root(root);
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2,7 +2,8 @@ mod lock;
 mod ops;
 
 pub use ops::{
-    remove_path_if_exists, summarize_history_body, synthesize_snapshot_raw_from_segment_bodies,
+    OpsAuditOperation, remove_path_if_exists, summarize_history_body,
+    synthesize_snapshot_raw_from_segment_bodies,
 };
 
 use lock::{LockMetadata, try_reap_stale_lock};

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::gitops;
 use crate::types::PendingOp;
@@ -23,6 +24,11 @@ enum OpJournalEvent {
         at: DateTime<Utc>,
         op: PendingOp,
     },
+    Audited {
+        event_id: String,
+        at: DateTime<Utc>,
+        op: PendingOp,
+    },
     Removed {
         event_id: String,
         at: DateTime<Utc>,
@@ -34,13 +40,15 @@ enum OpJournalEvent {
 impl OpJournalEvent {
     fn event_id(&self) -> &str {
         match self {
-            Self::Queued { event_id, .. } | Self::Removed { event_id, .. } => event_id,
+            Self::Queued { event_id, .. }
+            | Self::Audited { event_id, .. }
+            | Self::Removed { event_id, .. } => event_id,
         }
     }
 
     fn at(&self) -> DateTime<Utc> {
         match self {
-            Self::Queued { at, .. } | Self::Removed { at, .. } => *at,
+            Self::Queued { at, .. } | Self::Audited { at, .. } | Self::Removed { at, .. } => *at,
         }
     }
 }
@@ -66,6 +74,24 @@ struct OpsReadModel {
     warnings: Vec<String>,
     journal_events: usize,
     history_events: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OpsAuditOperation {
+    pub op_id: String,
+    pub request_id: String,
+    pub command: String,
+    pub status: String,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub details: Value,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OpsAuditReport {
+    pub operations: Vec<OpsAuditOperation>,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +128,103 @@ impl AppContext {
             warnings: model.warnings,
             journal_events: model.journal_events,
             history_events: model.history_events,
+        })
+    }
+
+    pub fn read_ops_audit_report(&self) -> Result<OpsAuditReport> {
+        let mut events = Vec::new();
+        let mut seen_event_ids = BTreeSet::new();
+        let mut warnings = Vec::new();
+
+        collect_audit_events_from_file(
+            &self.pending_ops_file,
+            "pending_ops",
+            &mut seen_event_ids,
+            &mut events,
+            &mut warnings,
+        )?;
+        collect_audit_events_from_dir(
+            &self.pending_ops_history_dir,
+            "pending_ops_history",
+            &mut seen_event_ids,
+            &mut events,
+            &mut warnings,
+        )?;
+        match gitops::history_journal_bodies(self) {
+            Ok(bodies) => {
+                for (path, body) in bodies {
+                    collect_audit_events_from_body(
+                        &path,
+                        "loom_history",
+                        &body,
+                        &mut seen_event_ids,
+                        &mut events,
+                        &mut warnings,
+                    );
+                }
+            }
+            Err(err) => warnings.push(format!("failed to read loom-history branch: {}", err)),
+        }
+
+        events.sort_by(|left, right| {
+            left.at
+                .cmp(&right.at)
+                .then_with(|| left.event_id.cmp(&right.event_id))
+        });
+
+        let mut operations = BTreeMap::new();
+        for event in events {
+            match event.event {
+                OpJournalEvent::Queued { mut op, .. } => {
+                    if op.op_id.is_none() {
+                        op.op_id = Some(op.stable_id());
+                    }
+                    let op_id = op.stable_id();
+                    operations.insert(
+                        op_id.clone(),
+                        OpsAuditOperation {
+                            op_id,
+                            request_id: op.request_id,
+                            command: op.command,
+                            status: "pending".to_string(),
+                            source: event.source,
+                            created_at: op.created_at,
+                            updated_at: event.at,
+                            details: op.details,
+                        },
+                    );
+                }
+                OpJournalEvent::Audited { mut op, .. } => {
+                    if op.op_id.is_none() {
+                        op.op_id = Some(op.stable_id());
+                    }
+                    let op_id = op.stable_id();
+                    operations.insert(
+                        op_id.clone(),
+                        OpsAuditOperation {
+                            op_id,
+                            request_id: op.request_id,
+                            command: op.command,
+                            status: "succeeded".to_string(),
+                            source: event.source,
+                            created_at: op.created_at,
+                            updated_at: event.at,
+                            details: op.details,
+                        },
+                    );
+                }
+                OpJournalEvent::Removed { op_id, reason, .. } => {
+                    if let Some(op) = operations.get_mut(&op_id) {
+                        op.status = reason;
+                        op.updated_at = event.at;
+                    }
+                }
+            }
+        }
+
+        Ok(OpsAuditReport {
+            operations: operations.into_values().collect(),
+            warnings,
         })
     }
 
@@ -298,6 +421,101 @@ impl AppContext {
     }
 }
 
+struct ParsedAuditEvent {
+    event_id: String,
+    at: DateTime<Utc>,
+    source: String,
+    event: OpJournalEvent,
+}
+
+fn collect_audit_events_from_dir(
+    dir: &Path,
+    source: &str,
+    seen_event_ids: &mut BTreeSet<String>,
+    events: &mut Vec<ParsedAuditEvent>,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to read {}", dir.display()));
+        }
+    };
+
+    let mut files = entries
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().map(|ty| ty.is_file()).unwrap_or(false))
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    files.sort();
+
+    for file in files {
+        collect_audit_events_from_file(&file, source, seen_event_ids, events, warnings)?;
+    }
+    Ok(())
+}
+
+fn collect_audit_events_from_file(
+    path: &Path,
+    source: &str,
+    seen_event_ids: &mut BTreeSet<String>,
+    events: &mut Vec<ParsedAuditEvent>,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let body = match fs::read_to_string(path) {
+        Ok(body) => body,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+    collect_audit_events_from_body(
+        &path.display().to_string(),
+        source,
+        &body,
+        seen_event_ids,
+        events,
+        warnings,
+    );
+    Ok(())
+}
+
+fn collect_audit_events_from_body(
+    label: &str,
+    source: &str,
+    body: &str,
+    seen_event_ids: &mut BTreeSet<String>,
+    events: &mut Vec<ParsedAuditEvent>,
+    warnings: &mut Vec<String>,
+) {
+    for (line_no, line) in body.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match parse_journal_line(trimmed) {
+            Ok(event) => {
+                let event_id = event.event_id().to_string();
+                if seen_event_ids.insert(event_id.clone()) {
+                    events.push(ParsedAuditEvent {
+                        event_id,
+                        at: event.at(),
+                        source: source.to_string(),
+                        event,
+                    });
+                }
+            }
+            Err(err) => warnings.push(format!(
+                "skipped malformed operation audit event at {}:{}: {}",
+                label,
+                line_no + 1,
+                err
+            )),
+        }
+    }
+}
+
 pub fn synthesize_snapshot_raw_from_segment_bodies(segment_bodies: &[String]) -> Result<String> {
     let mut seen_event_ids = BTreeSet::new();
     let mut ordered_events = Vec::new();
@@ -425,6 +643,7 @@ fn apply_journal_event(active_ops: &mut BTreeMap<String, PendingOp>, event: OpJo
             }
             active_ops.insert(op.stable_id(), op);
         }
+        OpJournalEvent::Audited { .. } => {}
         OpJournalEvent::Removed { op_id, .. } => {
             active_ops.remove(&op_id);
         }

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -585,6 +585,39 @@ fn snapshot_pushes_annotated_tag_to_remote() {
         "--format=%(objecttype) %(refname:strip=2)",
     ]);
     assert!(refs.lines().any(|line| line == format!("tag {}", tag)));
+    assert!(
+        run_git([
+            "--git-dir",
+            remote.to_str().unwrap(),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/heads/loom-history",
+        ])
+        .status
+        .success(),
+        "snapshot should push lifecycle audit to loom-history"
+    );
+    let history_files = git_ok([
+        "--git-dir",
+        remote.to_str().unwrap(),
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "loom-history",
+    ]);
+    let segment_path = history_files
+        .lines()
+        .find(|line| line.starts_with("pending_ops_history/"))
+        .expect("snapshot audit segment");
+    let segment_raw = git_ok([
+        "--git-dir",
+        remote.to_str().unwrap(),
+        "show",
+        &format!("loom-history:{segment_path}"),
+    ]);
+    assert!(segment_raw.contains("\"event\":\"audited\""));
+    assert!(segment_raw.contains("\"command\":\"skill.snapshot\""));
 
     let pending = run_loom_ok(root.path(), &["ops", "list"]);
     assert_eq!(pending["data"]["count"], 0);
@@ -778,21 +811,32 @@ fn ops_compaction_mirrors_history_into_local_git_branch() {
             .lines()
             .any(|line| line == "pending_ops_snapshot.json")
     );
-    let segment_path = files
+    let segment_paths = files
         .lines()
-        .find(|line| line.starts_with("pending_ops_history/"))
-        .expect("history segment in loom-history branch");
+        .filter(|line| line.starts_with("pending_ops_history/"))
+        .collect::<Vec<_>>();
+    assert!(
+        !segment_paths.is_empty(),
+        "history segment in loom-history branch"
+    );
     let snapshot_raw = git_ok_in(
         root.path(),
         &["show", "loom-history:pending_ops_snapshot.json"],
     );
     let snapshot: Value = serde_json::from_str(&snapshot_raw).expect("parse history snapshot");
     assert!(snapshot["history_events"].as_u64().unwrap() >= 16);
-    let segment_raw = git_ok_in(
-        root.path(),
-        &["show", &format!("loom-history:{segment_path}")],
-    );
-    assert!(segment_raw.lines().count() >= 16);
+    let segment_event_count = segment_paths
+        .iter()
+        .map(|segment_path| {
+            git_ok_in(
+                root.path(),
+                &["show", &format!("loom-history:{segment_path}")],
+            )
+            .lines()
+            .count()
+        })
+        .sum::<usize>();
+    assert!(segment_event_count >= 16);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- write `skill.snapshot` lifecycle audit events directly to the conflict-free `loom-history` branch
- keep snapshots out of registry `operations.jsonl` and keep `meta.op_id` empty for snapshot responses
- make `/api/v1/ops` union registry operations with pending/history audit events without fake registry op ids
- update Panel activity typing/rendering for nullable `op_id` audit rows

Closes #119

## Verification
- cargo test -q --test write skill_snapshot_without_registry_operation_does_not_return_op_id
- cargo test -q panel::tests::handlers::v1_registry_ops_includes_snapshot_history_audit_without_registry_op_id
- cargo test -q --test reliability snapshot_pushes_annotated_tag_to_remote
- cargo test -q --test reliability snapshot
- cargo test -q --test reliability sync_
- cargo test -q --test reliability
- cd panel && bun run typecheck
- cd panel && bun run test
- cargo check
- cargo test
- git diff --check
- make ci