### PR TITLE
Refresh PostCSS lockfile version

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -2042,9 +2042,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- refresh `panel/package-lock.json` so PostCSS resolves to 8.5.14
- confirm npm audit no longer reports GHSA-qx2v-qp2m-jg93

Closes #105

## Verification
- cd panel && npm ci && npm ls postcss vite --depth=2 && npm audit && npm run typecheck && npm test
- make ci