### PR TITLE
test: silence stdout pollution in concurrent init and write tests

### DIFF
--- a/tests/workspace_init.rs
+++ b/tests/workspace_init.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use common::{TestDir, run_loom, run_loom_with_env};
 use serde_json::Value;
@@ -93,31 +93,41 @@ fn workspace_init_scan_existing_concurrent_inits_leave_consistent_state() {
     let home_str = fake_home.path().to_string_lossy().into_owned();
     let root_str = root.path().to_string_lossy().into_owned();
 
-    let mut child1 = Command::new(env!("CARGO_BIN_EXE_loom"))
+    let child1 = Command::new(env!("CARGO_BIN_EXE_loom"))
         .arg("--json")
         .arg("--root")
         .arg(&root_str)
         .args(["workspace", "init", "--scan-existing"])
         .env("HOME", &home_str)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("spawn first loom process");
 
-    let mut child2 = Command::new(env!("CARGO_BIN_EXE_loom"))
+    let child2 = Command::new(env!("CARGO_BIN_EXE_loom"))
         .arg("--json")
         .arg("--root")
         .arg(&root_str)
         .args(["workspace", "init", "--scan-existing"])
         .env("HOME", &home_str)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("spawn second loom process");
 
-    let s1 = child1.wait().expect("wait for first process");
-    let s2 = child2.wait().expect("wait for second process");
+    let out1 = child1
+        .wait_with_output()
+        .expect("wait for first process");
+    let out2 = child2
+        .wait_with_output()
+        .expect("wait for second process");
 
     // At least one must succeed; the other may get LOCK_BUSY.
     assert!(
-        s1.success() || s2.success(),
-        "neither concurrent init succeeded"
+        out1.status.success() || out2.status.success(),
+        "neither concurrent init succeeded: stderr1={} stderr2={}",
+        String::from_utf8_lossy(&out1.stderr),
+        String::from_utf8_lossy(&out2.stderr)
     );
 
     // State must be consistent regardless of which process won the race.

--- a/tests/workspace_init.rs
+++ b/tests/workspace_init.rs
@@ -115,12 +115,8 @@ fn workspace_init_scan_existing_concurrent_inits_leave_consistent_state() {
         .spawn()
         .expect("spawn second loom process");
 
-    let out1 = child1
-        .wait_with_output()
-        .expect("wait for first process");
-    let out2 = child2
-        .wait_with_output()
-        .expect("wait for second process");
+    let out1 = child1.wait_with_output().expect("wait for first process");
+    let out2 = child2.wait_with_output().expect("wait for second process");
 
     // At least one must succeed; the other may get LOCK_BUSY.
     assert!(

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use common::actions::{binding_add, target_add, target_add_with_default_ownership};
 use serde_json::Value;
@@ -29,12 +29,16 @@ fn git_ok(root: &Path, args: &[&str]) -> String {
 }
 
 fn git_status(root: &Path, args: &[&str]) -> bool {
+    // Suppress stderr; callers intentionally probe for missing paths
+    // (e.g. `cat-file -e HEAD:...`) where git logs "fatal: ..." on a clean miss.
     Command::new("git")
         .arg("-C")
         .arg(root)
         .arg("-c")
         .arg("commit.gpgsign=false")
         .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()
         .expect("run git")
         .success()


### PR DESCRIPTION
## Summary

- `tests/workspace_init.rs`: capture stdout/stderr from the two `spawn()` children in `workspace_init_scan_existing_concurrent_inits_leave_consistent_state` so envelope JSON does not leak into the test runner output, and surface stderr in the failure message instead.
- `tests/write.rs`: silence git stderr in the `git_status()` probe used when the target path does not yet exist.

The `[profile.release]` portion of the original local commit already landed via a separate PR; this PR ships only the test stdout fixes.

## Test plan

- [x] \`cargo test --test workspace_init\` (3 passed)
- [x] \`cargo test --test write\` (16 passed)