### PR TITLE
chore(ci): use cargo-nextest for the test phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Tool Versions
+        run: |
+          rustc --version
+          cargo nextest --version
+          bun --version
+
       - name: Ensure jq
         run: sudo apt-get update && sudo apt-get install -y jq
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,21 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Tool Versions
+        run: |
+          rustc --version
+          cargo nextest --version
+          bun --version
 
       - name: Check tag matches Cargo version
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install-hooks:
 	@echo "pre-commit hook installed (core.hooksPath=.githooks). Disable with 'git config --unset core.hooksPath'."
 
 test:
-	cargo test -q
+	cargo nextest run --no-fail-fast
 
 lint:
 	cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Summary

Closes #146.

Switch `make test` and the CI verify job from `cargo test` to `cargo nextest run`, then align the release verify job so tag releases install the same test runner before `make test`.

## Why

`cargo test` runs each test binary sequentially — binary A finishes before binary B starts. Inside a binary tests are threaded, but inter-binary parallelism is left on the table. Nextest schedules every test on a single global pool.

The first version of this PR updated PR CI but left the release workflow without `cargo-nextest`; that would make tag releases fail at `make test`. This revision fixes that gap and prints Rust/nextest/Bun versions in both workflows for easier run-to-run debugging.

## Measured

On `origin/main` HEAD (`4bfbcb8`), 241 tests:

| Command | Wall time |
|---|---:|
| `cargo test --no-fail-fast` | 113 s |
| `cargo nextest run --no-fail-fast` | 92 s |

Current local verification on this branch:

| Command | Result |
|---|---:|
| `/usr/bin/time -p make test` | 248 passed, 0 skipped; nextest 78.5 s, wall 100.3 s |
| workflow YAML load check | passed for CI + release |
| `git diff --check` | passed |

## Changes

- `Makefile`: `test:` target now calls `cargo nextest run --no-fail-fast`.
- `.github/workflows/ci.yml`: install nextest and print Rust/nextest/Bun versions.
- `.github/workflows/release.yml`: install nextest before `make test` and print Rust/nextest/Bun versions.

## Test plan

- [x] `cargo nextest --version && bun --version && rustc --version`
- [x] `/usr/bin/time -p make test`
- [x] `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/release.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- [x] `git diff --check`
- [ ] GitHub Actions verify job