### PR TITLE
feat(skill): add `loom skill verify` and document the threat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ The chain `add → capture → save → snapshot → release → rollback` is th
 | `loom skill release` | Tag the skill at a semantic version | You're publishing a stable revision teammates can pull (`v1.2.0`) | Source (semver tag) |
 | `loom skill rollback` | Reset the source to an earlier revision (with `recovery_ref`) | A capture or save introduced bad state — undo it without losing the recovery point | Source (history) |
 | `loom skill diff` | Compare two revisions of a skill source | Inspect what changed between any two refs (commit, snapshot, release tag) | Source (read-only) |
+| `loom skill verify` | Detect uncommitted drift in a skill source | Confirm the working tree under `skills/<name>` matches the last commit; flag external edits that bypassed `save` | Source (read-only) |
 
-Quick decision: **edits from the agent side → `capture`; edits inside the registry repo → `save`; anchor → `snapshot`; public version → `release`; undo → `rollback`.**
+Quick decision: **edits from the agent side → `capture`; edits inside the registry repo → `save`; anchor → `snapshot`; public version → `release`; undo → `rollback`; integrity audit → `verify`.**
 
 ## Comparison
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Policy
+
+This document describes Loom's threat model, the boundaries Loom enforces, and
+how to report vulnerabilities.
+
+## Supported Versions
+
+Security fixes target the latest `main` branch. Released versions on
+crates.io may receive backports at the maintainer's discretion; older minor
+versions are not guaranteed to receive patches.
+
+## Trust Model
+
+Loom is a local-first tool. The default trust boundaries are:
+
+| Surface | Trust assumption |
+|---|---|
+| The user running `loom` | Fully trusted; can read and modify the registry. |
+| Files under `--root` (default `~/.loom-registry`) | Trusted as written by Loom or the user. |
+| Files under registered target paths (`~/.claude/skills`, `~/.codex/skills`, …) | Trusted to be readable by Loom; writes only happen when ownership is `managed`. |
+| Other processes on the host | Treated as untrusted; Loom does not defend against a co-resident attacker with write access to the registry. |
+| Remote registries pulled via `sync` | Trusted only after manual review of the upstream commit and remote URL. |
+
+Loom does not currently sign commits or verify upstream commit signatures.
+See [Roadmap](#roadmap) for future work.
+
+## Enforcement Surfaces
+
+Loom enforces the following invariants today:
+
+### Hard write guard
+The CLI refuses to write to a `--root` directory that matches the Loom tool
+repository checkout (see `ensure_write_repo_ready`). This prevents accidental
+writes that would mutate the development copy of Loom itself.
+
+### Ownership tiers
+Every registered target carries an explicit ownership tier:
+
+- `managed` — Loom is the only writer.
+- `observed` — Loom only reads; capture flows pull edits back into the registry.
+- `external` — Loom does not touch the directory.
+
+Skill projections under `observed` and `external` targets are guaranteed not
+to be overwritten by `skill project` operations.
+
+### Read / write command split
+Read commands (`workspace status`, `workspace doctor`, `target list`,
+`target show`, `sync status`, `skill verify`) never append to the audit log
+or the registry operation history. Write commands write durable audit events
+through the registry operations pipeline.
+
+### Audit log
+Write commands record a `RegistryOperationRecord` under
+`state/registry/ops/operations.jsonl` with the operation intent, payload,
+effects, and timestamps. The history branch (`refs/heads/loom-history`)
+mirrors these events through git, which gives every audited mutation a
+verifiable commit ancestor.
+
+### Skill source integrity check
+`loom skill verify <name>` compares the working tree under
+`skills/<name>` against the last `loom skill save` commit and reports any
+modified, staged, or untracked files. It is the local integrity primitive
+for detecting edits that bypassed `skill save`. The check is read-only and
+does not modify state.
+
+## Limitations Known At This Time
+
+- Loom does not cryptographically sign commits. An attacker who can write to
+  the registry directly can rewrite history.
+- Loom does not validate skill contents (no script sandboxing, no static
+  analysis). Projecting a skill into an agent directory makes its contents
+  available to that agent verbatim.
+- Loom does not verify SSH or HTTPS endpoints beyond what the configured
+  git client validates. Skills pulled via `sync pull` inherit the trust
+  level of the upstream registry.
+- Projection methods `symlink` and `materialize` follow symlinks during
+  capture. A malicious agent directory could in principle redirect a
+  capture into a different filesystem location. Restrict the `--root`
+  parent directory's ACLs accordingly.
+
+## Roadmap
+
+Tracked, but not yet implemented:
+
+- Optional Ed25519 signing of `skill save` / `skill release` commits, with
+  a per-registry trusted-keys file.
+- `skill verify --at <ref>` to compare the working tree against an
+  arbitrary historical revision rather than the most recent save commit.
+- Cross-registry signature verification during `sync pull` and `replay`.
+
+## Reporting a Vulnerability
+
+Report security issues privately:
+
+1. Open a [GitHub Security Advisory](https://github.com/majiayu000/loom/security/advisories/new)
+   on this repository (preferred — encrypted, allows coordinated disclosure).
+2. If you cannot use Security Advisories, email the maintainer listed in
+   `Cargo.toml` with a description of the issue and a minimal reproduction.
+
+Please **do not** open public GitHub issues for security reports.
+
+Expected response times:
+
+- Acknowledgement: within 7 days.
+- Initial assessment: within 14 days.
+- Fix or detailed remediation plan: within 30 days for issues classified as
+  high or critical; longer for lower-severity issues.
+
+Coordinated disclosure is preferred; the maintainer will work with reporters
+to align on a disclosure timeline.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,8 @@ pub enum SkillCommand {
     Rollback(RollbackArgs),
     #[command(about = "Diff two revisions of a skill source")]
     Diff(DiffArgs),
+    #[command(about = "Verify a skill source has no uncommitted drift")]
+    Verify(SkillOnlyArgs),
     #[command(about = "Continuously import and update skills from observed targets")]
     MonitorObserved(MonitorObservedArgs),
     #[command(about = "Run one import pass over observed targets and exit")]

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -125,6 +125,7 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
             SkillCommand::Release(_) => "skill.release",
             SkillCommand::Rollback(_) => "skill.rollback",
             SkillCommand::Diff(_) => "skill.diff",
+            SkillCommand::Verify(_) => "skill.verify",
             SkillCommand::Orphan {
                 command: SkillOrphanCommand::List,
             } => "skill.orphan.list",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod fs_probe;
 mod helpers;
 mod projections;
 mod skill_cmds;
+mod skill_verify;
 mod sync_cmds;
 mod target_cmds;
 mod version_cmds;
@@ -175,6 +176,7 @@ impl App {
                 SkillCommand::Release(args) => self.cmd_release(args, &request_id),
                 SkillCommand::Rollback(args) => self.cmd_rollback(args, &request_id),
                 SkillCommand::Diff(args) => self.cmd_diff(args),
+                SkillCommand::Verify(args) => self.cmd_verify(args),
                 SkillCommand::Orphan {
                     command: SkillOrphanCommand::List,
                 } => self.cmd_skill_orphan_list(),

--- a/src/commands/skill_verify.rs
+++ b/src/commands/skill_verify.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use serde_json::json;
+
+use crate::cli::SkillOnlyArgs;
+use crate::envelope::Meta;
+use crate::gitops::{run_git, run_git_allow_failure};
+use crate::state::AppContext;
+use crate::types::ErrorCode;
+
+use super::helpers::{map_arg, map_git, validate_skill_name};
+use super::{App, CommandFailure};
+
+impl App {
+    pub fn cmd_verify(
+        &self,
+        args: &SkillOnlyArgs,
+    ) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
+        validate_skill_name(&args.skill).map_err(map_arg)?;
+        let skill_rel = format!("skills/{}", args.skill);
+        let skill_path = self.ctx.root.join(&skill_rel);
+        if !skill_path.exists() {
+            return Err(CommandFailure::new(
+                ErrorCode::SkillNotFound,
+                format!("skill '{}' not found", args.skill),
+            ));
+        }
+
+        let head_tree_oid = head_tree_oid_for_path(&self.ctx, &skill_rel).map_err(map_git)?;
+        let last_save_commit = last_commit_for_path(&self.ctx, &skill_rel).map_err(map_git)?;
+        let drifted_paths = drifted_paths_under(&self.ctx, &skill_rel).map_err(map_git)?;
+        let matches = drifted_paths.is_empty() && head_tree_oid.is_some();
+
+        Ok((
+            json!({
+                "skill": args.skill,
+                "matches": matches,
+                "head_tree_oid": head_tree_oid,
+                "last_save_commit": last_save_commit,
+                "drifted_paths": drifted_paths,
+            }),
+            Meta::default(),
+        ))
+    }
+}
+
+fn head_tree_oid_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> {
+    let output = run_git_allow_failure(ctx, &["rev-parse", &format!("HEAD:{path}")])?;
+    if output.status.success() {
+        let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if oid.is_empty() { Ok(None) } else { Ok(Some(oid)) }
+    } else {
+        Ok(None)
+    }
+}
+
+fn last_commit_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> {
+    let stdout = run_git(ctx, &["log", "-1", "--format=%H", "--", path])?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(trimmed.to_string()))
+    }
+}
+
+fn drifted_paths_under(ctx: &AppContext, prefix: &str) -> Result<Vec<String>> {
+    // run_git trims the entire stdout, which mangles porcelain's fixed-offset
+    // status prefix. Use --name-only outputs that contain only paths, so the
+    // result is stable under the trim.
+    let mut paths: Vec<String> = Vec::new();
+    let tracked = run_git(ctx, &["diff", "--name-only", "HEAD", "--", prefix])?;
+    for line in tracked.lines() {
+        let p = line.trim();
+        if !p.is_empty() && !paths.iter().any(|x| x == p) {
+            paths.push(p.to_string());
+        }
+    }
+    let staged = run_git(ctx, &["diff", "--name-only", "--cached", "--", prefix])?;
+    for line in staged.lines() {
+        let p = line.trim();
+        if !p.is_empty() && !paths.iter().any(|x| x == p) {
+            paths.push(p.to_string());
+        }
+    }
+    let untracked = run_git(
+        ctx,
+        &[
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "--",
+            prefix,
+        ],
+    )?;
+    for line in untracked.lines() {
+        let p = line.trim();
+        if !p.is_empty() && !paths.iter().any(|x| x == p) {
+            paths.push(p.to_string());
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}

--- a/tests/skill_verify.rs
+++ b/tests/skill_verify.rs
@@ -1,0 +1,107 @@
+mod common;
+
+use std::fs;
+
+use common::actions::save_skill;
+use common::{TestDir, run_loom, write_skill};
+use serde_json::Value;
+
+#[test]
+fn skill_verify_matches_after_save() {
+    let root = TestDir::new("skill-verify-match");
+    write_skill(root.path(), "demo", "# demo\n\nbody v1\n");
+    assert!(save_skill(root.path(), "demo").0.status.success());
+
+    let (output, env) = run_loom(root.path(), &["skill", "verify", "demo"]);
+    assert!(output.status.success(), "verify should succeed");
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert_eq!(env["data"]["skill"], Value::String("demo".to_string()));
+    assert_eq!(env["data"]["matches"], Value::Bool(true));
+    assert_eq!(
+        env["data"]["drifted_paths"].as_array().map(Vec::len),
+        Some(0)
+    );
+    assert!(
+        env["data"]["head_tree_oid"].is_string(),
+        "head_tree_oid must be populated after save"
+    );
+    assert!(
+        env["data"]["last_save_commit"].is_string(),
+        "last_save_commit must be populated after save"
+    );
+}
+
+#[test]
+fn skill_verify_detects_drift_after_external_edit() {
+    let root = TestDir::new("skill-verify-drift");
+    write_skill(root.path(), "demo", "# demo\n\nbody v1\n");
+    assert!(save_skill(root.path(), "demo").0.status.success());
+
+    // External edit that bypasses `skill save`.
+    fs::write(
+        root.path().join("skills/demo/SKILL.md"),
+        "# demo\n\nbody v2 (drifted)\n",
+    )
+    .expect("overwrite skill body");
+
+    let (output, env) = run_loom(root.path(), &["skill", "verify", "demo"]);
+    assert!(output.status.success(), "verify should still succeed");
+    assert_eq!(env["data"]["matches"], Value::Bool(false));
+    let drifted = env["data"]["drifted_paths"]
+        .as_array()
+        .expect("drifted_paths array");
+    assert_eq!(
+        drifted.len(),
+        1,
+        "exactly one modified path expected, got {drifted:?}"
+    );
+    let drift_entry = drifted[0].as_str().expect("drift path string");
+    assert!(
+        drift_entry.contains("skills/demo/SKILL.md"),
+        "expected drifted entry to reference SKILL.md, got {drift_entry}"
+    );
+}
+
+#[test]
+fn skill_verify_detects_untracked_file_drift() {
+    let root = TestDir::new("skill-verify-untracked");
+    write_skill(root.path(), "demo", "# demo\n\nbody v1\n");
+    assert!(save_skill(root.path(), "demo").0.status.success());
+
+    // New file dropped into the skill directory without a save.
+    fs::write(
+        root.path().join("skills/demo/NOTES.md"),
+        "side notes not yet committed\n",
+    )
+    .expect("write untracked note");
+
+    let (output, env) = run_loom(root.path(), &["skill", "verify", "demo"]);
+    assert!(output.status.success());
+    assert_eq!(env["data"]["matches"], Value::Bool(false));
+    let drifted = env["data"]["drifted_paths"]
+        .as_array()
+        .expect("drifted_paths array");
+    assert!(
+        drifted
+            .iter()
+            .any(|p| p.as_str().unwrap_or("").contains("NOTES.md")),
+        "expected untracked NOTES.md to appear, got {drifted:?}"
+    );
+}
+
+#[test]
+fn skill_verify_reports_skill_not_found() {
+    let root = TestDir::new("skill-verify-missing");
+    let (output, env) = run_loom(root.path(), &["skill", "verify", "ghost"]);
+    assert!(
+        !output.status.success(),
+        "verify on missing skill should fail"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        env["error"]["code"].as_str(),
+        Some("SKILL_NOT_FOUND"),
+        "unexpected error: {:?}",
+        env["error"]
+    );
+}


### PR DESCRIPTION
## Summary

- New read-only CLI `loom skill verify <name>` detects when the working tree under `skills/<name>` has drifted from the last `skill save` commit. The envelope reports `matches`, `head_tree_oid`, `last_save_commit`, and a list of `drifted_paths` (modified, staged, and untracked entries).
- Implementation lives in a new module `src/commands/skill_verify.rs` rather than `skill_cmds.rs` to avoid further inflating that file past its current 1754-line size.
- Drift detection uses `git diff --name-only HEAD`, `git diff --name-only --cached`, and `git ls-files --others --exclude-standard`. `git status --porcelain` was avoided because `run_git` trims stdout, which corrupts porcelain's fixed-offset status prefix.
- New `SECURITY.md` documents the trust model, the enforcement surfaces today (hard write guard, ownership tiers, read/write command split, audit log, skill source integrity check), known limitations (no commit signing, no content scanning, capture symlink caveats), a short roadmap (optional Ed25519 signing, `verify --at <ref>`), and the vulnerability reporting process via GitHub Security Advisories.
- README's skill lifecycle table gains a `verify` row and the quick-decision line is extended to cover integrity audits.

## Test plan

- [x] `cargo test --test skill_verify` (4 new tests passed: clean post-save match, modified tracked file detected, untracked file detected, missing skill returns `SKILL_NOT_FOUND`)
- [x] `cargo test` full suite (252 passed / 0 failed)
- [x] `cargo check`