### PR TITLE
Improve install trust for prebuilt Loom releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -130,6 +133,11 @@ jobs:
           kill "$panel_pid"
           wait "$panel_pid" 2>/dev/null || true
 
+      - name: Attest release archive
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/*.tar.gz
+
       - name: Upload release asset
         uses: actions/upload-artifact@v4
         with:
@@ -154,6 +162,11 @@ jobs:
         run: |
           set -euo pipefail
           cat release-assets/*.sha256 > release-assets/SHA256SUMS
+
+      - name: Attest checksums file
+        uses: actions/attest@v4
+        with:
+          subject-path: release-assets/SHA256SUMS
 
       - name: Publish GitHub release
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,12 @@ exclude = [
 name = "loom"
 path = "src/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.tar.gz"
+bin-dir = "{ name }-{ version }-{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+disabled-strategies = ["quick-install"]
+
 [dependencies]
 anyhow = "1.0.98"
 axum = { version = "0.8.4", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 
 ```bash
 # 1. Install a prebuilt binary with bundled Panel assets
+# Install cargo-binstall once if the subcommand is not available yet
+cargo binstall --version >/dev/null 2>&1 || cargo install cargo-binstall
 cargo binstall skillloom
 
 # or install from the Homebrew tap after its formula PR is merged

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ## Quick Start
 
 ```bash
-# 1. Install
-cargo install skillloom
+# 1. Install a prebuilt binary with bundled Panel assets
+cargo binstall skillloom
 
 # or install from the Homebrew tap after its formula PR is merged
 brew install majiayu000/tap/loom
 
-# or install from source
+# or install from source when you have Rust and Bun available
 git clone https://github.com/majiayu000/loom.git
 cd loom && cargo install --path .
 
@@ -51,6 +51,26 @@ loom init
 # 3. Import/update observed skills once, or keep watching in the foreground
 loom monitor --once
 loom monitor --interval-seconds 30
+```
+
+Prebuilt GitHub Release archives are the recommended install path. They are built
+with Bun in CI, smoke-tested with `loom panel --port 0`, and include the Panel
+frontend inside the `loom` binary. Source installs are useful for development,
+but they need Bun when `panel/dist` is missing or stale.
+
+To verify a downloaded release archive:
+
+```bash
+VERSION=X.Y.Z
+TARGET=aarch64-apple-darwin
+ARCHIVE="skillloom-${VERSION}-${TARGET}.tar.gz"
+
+curl -LO "https://github.com/majiayu000/loom/releases/download/v${VERSION}/${ARCHIVE}"
+curl -LO "https://github.com/majiayu000/loom/releases/download/v${VERSION}/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gh attestation verify "${ARCHIVE}" --repo majiayu000/loom
+tar -xzf "${ARCHIVE}"
+install -m 755 "skillloom-${VERSION}-${TARGET}/loom" "$HOME/.local/bin/loom"
 ```
 
 Loom defaults to `~/.loom-registry`. Pass `--root <dir>` only when you want a different registry.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are released from the latest `main` branch and the latest
+published `vX.Y.Z` release. Older releases may receive a fix only when the
+maintainer can reproduce the issue and the patch applies cleanly without
+changing public behavior.
+
+## Reporting a Vulnerability
+
+Use GitHub's private vulnerability reporting flow for this repository when it is
+available. If the private report button is unavailable, open a public issue that
+only says you have a vulnerability to report and asks for a private contact
+path. Do not include exploit details, secrets, tokens, private paths, or
+proof-of-concept payloads in a public issue.
+
+Please include:
+
+- The affected Loom version or commit.
+- The operating system and install path used.
+- A minimal reproduction that avoids real secrets or private registry content.
+- The impact you observed or expect.
+
+The maintainer will acknowledge valid reports as time permits, coordinate a fix
+on a private branch when needed, and publish release notes after the fix is
+available.
+
+## Dependency and Release Security
+
+- Dependency updates are reviewed through normal pull requests and must pass CI.
+- Release archives are built by GitHub Actions from version tags matching
+  `v*.*.*`.
+- Every release archive is hashed into `SHA256SUMS`.
+- Release archives and `SHA256SUMS` receive GitHub artifact attestations.
+- Prebuilt archives are smoke-tested with `loom --version`, `loom --help`,
+  `loom --json --root "$(mktemp -d)" workspace status`, and
+  `loom --root "$(mktemp -d)" panel --port 0` before publication.
+
+Users should verify downloaded archives with:
+
+```bash
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gh attestation verify "<archive>.tar.gz" --repo majiayu000/loom
+```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,7 +4,8 @@ Loom is distributed as the `skillloom` crate with a `loom` binary.
 
 ## Release Surfaces
 
-- GitHub Release: built from tags matching `v*.*.*`.
+- GitHub Release: built from tags matching `v*.*.*`; archives include bundled
+  Panel assets, SHA256SUMS, and GitHub artifact attestations.
 - crates.io: published when `CARGO_REGISTRY_TOKEN` is configured.
 - Homebrew: opens a `loom` formula PR against `majiayu000/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured.
 
@@ -16,6 +17,11 @@ Configure repository secrets:
 
 - `CARGO_REGISTRY_TOKEN`: crates.io token allowed to publish `skillloom`.
 - `HOMEBREW_TAP_TOKEN`: GitHub token allowed to push branches and open PRs in `majiayu000/homebrew-tap`.
+
+No extra secret is required for release attestations. The release workflow grants
+the GitHub token `id-token`, `attestations`, and `artifact-metadata` write
+permissions so `actions/attest` can publish provenance for archives and
+SHA256SUMS.
 
 ## Release Steps
 
@@ -46,9 +52,28 @@ Configure repository secrets:
 
 ## Install Checks
 
-After the release is published:
+After the release is published, verify the prebuilt archive first:
 
 ```bash
+version=X.Y.Z
+target=aarch64-apple-darwin
+archive="skillloom-${version}-${target}.tar.gz"
+
+curl -LO "https://github.com/majiayu000/loom/releases/download/v${version}/${archive}"
+curl -LO "https://github.com/majiayu000/loom/releases/download/v${version}/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gh attestation verify "${archive}" --repo majiayu000/loom
+tar -xzf "${archive}"
+"skillloom-${version}-${target}/loom" --version
+"skillloom-${version}-${target}/loom" --help
+"skillloom-${version}-${target}/loom" --json --root "$(mktemp -d)" workspace status
+"skillloom-${version}-${target}/loom" --root "$(mktemp -d)" panel --port 0
+```
+
+Then verify package-manager paths:
+
+```bash
+cargo binstall skillloom
 cargo install skillloom
 loom --help
 loom --version


### PR DESCRIPTION
Fixes #149.

## Summary
- Prefer prebuilt install guidance and add release archive checksum/attestation verification steps.
- Add cargo-binstall metadata matching the existing skillloom-{version}-{target}.tar.gz release archive layout.
- Publish GitHub artifact attestations for release archives and SHA256SUMS, and add SECURITY.md.

## Validation
- cargo metadata --no-deps --format-version 1
- git diff --check
- cargo fmt --all --check
- cargo check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'
- cargo test -q
- cargo clippy --all-targets --all-features -- -D warnings