### PR TITLE
Close Panel operation loop for issue #150

### DIFF
--- a/panel/src/components/panel/forms/SkillAddForm.tsx
+++ b/panel/src/components/panel/forms/SkillAddForm.tsx
@@ -1,0 +1,77 @@
+import { useState, type CSSProperties, type FormEvent } from "react";
+import { api } from "../../../lib/api/client";
+import { useMutation } from "../../../lib/useMutation";
+
+export function SkillAddForm({ onCancel, onSuccess }: { onCancel: () => void; onSuccess: () => void }) {
+  const [source, setSource] = useState("");
+  const [name, setName] = useState("");
+  const add = useMutation();
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmedSource = source.trim();
+    const trimmedName = name.trim();
+    if (!trimmedSource || !trimmedName) return;
+    add.run("skill add", () => api.skillAdd({ source: trimmedSource, name: trimmedName }), onSuccess);
+  };
+
+  return (
+    <form onSubmit={submit} className="card" style={{ padding: 16, marginBottom: 12 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "120px 1fr", gap: 8, alignItems: "center" }}>
+        <label className="hint">source</label>
+        <input
+          value={source}
+          onChange={(event) => setSource(event.target.value)}
+          placeholder="/Users/me/.claude/skills/my-skill"
+          style={formInputStyle}
+          autoFocus
+        />
+        <label className="hint">name</label>
+        <input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="my-skill"
+          style={formInputStyle}
+        />
+      </div>
+      {(add.error || add.success) && <div style={add.error ? errorStyle : okStyle}>{add.error ?? `✓ ${add.success}`}</div>}
+      <div style={{ display: "flex", gap: 8, marginTop: 12, justifyContent: "flex-end" }}>
+        <button type="button" className="btn ghost" onClick={onCancel} disabled={add.busy}>
+          Cancel
+        </button>
+        <button type="submit" className="btn primary" disabled={add.busy || !source.trim() || !name.trim()}>
+          {add.busy ? "adding…" : "skill add"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+const formInputStyle: CSSProperties = {
+  padding: "6px 10px",
+  borderRadius: 6,
+  border: "1px solid var(--line-hi)",
+  background: "var(--bg-2)",
+  color: "var(--ink-0)",
+  fontSize: 12,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const errorStyle: CSSProperties = {
+  marginTop: 10,
+  padding: "6px 10px",
+  color: "var(--err)",
+  background: "rgba(216,90,90,0.08)",
+  border: "1px solid rgba(216,90,90,0.3)",
+  borderRadius: 6,
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+};
+
+const okStyle: CSSProperties = {
+  ...errorStyle,
+  color: "var(--ok)",
+  background: "rgba(111,183,138,0.08)",
+  border: "1px solid rgba(111,183,138,0.3)",
+};

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -132,6 +132,7 @@ export function PanelApp() {
   };
   const onNewTarget = () => setPage("targets");
   const onNewBinding = () => setPage("bindings");
+  const onOpenSkills = () => setPage("skills");
   const onOpenSync = () => setPage("sync");
   const onViewActivity = () => setPage("ops");
 
@@ -157,6 +158,7 @@ export function PanelApp() {
             onMutation={onMutation}
             onNewTarget={onNewTarget}
             onNewBinding={onNewBinding}
+            onOpenSkills={onOpenSkills}
             onViewActivity={onViewActivity}
             onOpenSync={onOpenSync}
             readOnly={readOnly}
@@ -223,6 +225,8 @@ export function PanelApp() {
             mode={live.mode}
             mutationVersion={mutationVersion}
             refreshKey={live.lastUpdated}
+            onMutation={onMutation}
+            readOnly={readOnly}
           />
         );
         break;

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -224,6 +224,7 @@ export function PanelApp() {
             live={live.live}
             mode={live.mode}
             mutationVersion={mutationVersion}
+            pendingCount={live.pendingCount}
             refreshKey={live.lastUpdated}
             onMutation={onMutation}
             readOnly={readOnly}

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -17,6 +17,7 @@ interface HistoryPageProps {
   live: boolean;
   mode: PanelDataMode;
   mutationVersion: number;
+  pendingCount?: number;
   refreshKey?: string | null;
   onMutation?: () => void;
   readOnly?: boolean;
@@ -26,6 +27,7 @@ export function HistoryPage({
   live,
   mode,
   mutationVersion,
+  pendingCount,
   refreshKey,
   onMutation = () => {},
   readOnly = !live,
@@ -116,8 +118,9 @@ export function HistoryPage({
       : null;
   const actionBusy = replay.busy || repairLocal.busy || repairRemote.busy;
   const conflictCount = diagnose?.conflicts.length ?? 0;
+  const replayPendingCount = pendingCount ?? counts.pending;
   const canRepair = live && !readOnly && conflictCount > 0 && !actionBusy;
-  const canReplay = live && !readOnly && counts.pending > 0 && !actionBusy;
+  const canReplay = live && !readOnly && replayPendingCount > 0 && !actionBusy;
   const banner =
     replay.error ??
     repairLocal.error ??
@@ -162,12 +165,12 @@ export function HistoryPage({
             title={
               readOnly
                 ? "registry offline"
-                : counts.pending === 0
+                : replayPendingCount === 0
                 ? "no pending operations to replay"
                 : "replay pending registry operations"
             }
           >
-            {replay.busy ? "Replaying..." : `Replay pending (${counts.pending})`}
+            {replay.busy ? "Replaying..." : `Replay pending (${replayPendingCount})`}
           </button>
           <button
             className="btn ghost"

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
 import { api, ApiError, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
 
 type FilterKey = "all" | "pending" | "ok" | "err";
 type DiagnoseData = NonNullable<OpsHistoryDiagnosePayload["data"]>;
@@ -17,14 +18,26 @@ interface HistoryPageProps {
   mode: PanelDataMode;
   mutationVersion: number;
   refreshKey?: string | null;
+  onMutation?: () => void;
+  readOnly?: boolean;
 }
 
-export function HistoryPage({ live, mode, mutationVersion, refreshKey }: HistoryPageProps) {
+export function HistoryPage({
+  live,
+  mode,
+  mutationVersion,
+  refreshKey,
+  onMutation = () => {},
+  readOnly = !live,
+}: HistoryPageProps) {
   const [state, setState] = useState<LoadState>({ kind: "idle" });
   const [diagnose, setDiagnose] = useState<DiagnoseData | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
   const [offset, setOffset] = useState(0);
+  const replay = useMutation();
+  const repairLocal = useMutation();
+  const repairRemote = useMutation();
 
   useEffect(() => {
     if (!live) {
@@ -101,6 +114,28 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
       : payload
       ? `${payload.loaded_count} recorded change${payload.loaded_count === 1 ? "" : "s"} loaded.`
       : null;
+  const actionBusy = replay.busy || repairLocal.busy || repairRemote.busy;
+  const conflictCount = diagnose?.conflicts.length ?? 0;
+  const canRepair = live && !readOnly && conflictCount > 0 && !actionBusy;
+  const canReplay = live && !readOnly && counts.pending > 0 && !actionBusy;
+  const banner =
+    replay.error ??
+    repairLocal.error ??
+    repairRemote.error ??
+    replay.success ??
+    repairLocal.success ??
+    repairRemote.success ??
+    null;
+  const bannerType = replay.error || repairLocal.error || repairRemote.error ? "err" : banner ? "ok" : null;
+
+  const runRepair = (strategy: "local" | "remote") => {
+    const mutation = strategy === "local" ? repairLocal : repairRemote;
+    mutation.run(
+      `history repair ${strategy}`,
+      () => api.opsHistoryRepair({ strategy }),
+      onMutation,
+    );
+  };
 
   return (
     <>
@@ -120,9 +155,65 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
               onChange={(e) => setQuery(e.target.value)}
             />
           </div>
+          <button
+            className="btn ghost"
+            disabled={!canReplay}
+            onClick={() => replay.run("sync replay", api.syncReplay, onMutation)}
+            title={
+              readOnly
+                ? "registry offline"
+                : counts.pending === 0
+                ? "no pending operations to replay"
+                : "replay pending registry operations"
+            }
+          >
+            {replay.busy ? "Replaying..." : `Replay pending (${counts.pending})`}
+          </button>
+          <button
+            className="btn ghost"
+            disabled={!canRepair}
+            onClick={() => runRepair("local")}
+            title={
+              readOnly
+                ? "registry offline"
+                : conflictCount === 0
+                ? "no history conflicts detected"
+                : "repair conflicts by keeping local history"
+            }
+          >
+            {repairLocal.busy ? "Repairing..." : "Repair local"}
+          </button>
+          <button
+            className="btn ghost"
+            disabled={!canRepair}
+            onClick={() => runRepair("remote")}
+            title={
+              readOnly
+                ? "registry offline"
+                : conflictCount === 0
+                ? "no history conflicts detected"
+                : "repair conflicts by keeping remote history"
+            }
+          >
+            {repairRemote.busy ? "Repairing..." : "Repair remote"}
+          </button>
         </div>
       </div>
       <div className="page-body">
+        {banner && (
+          <div
+            style={{
+              padding: "6px 28px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              borderBottom: "1px solid var(--line)",
+              color: bannerType === "err" ? "var(--err)" : "var(--ok)",
+              background: bannerType === "err" ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
+            }}
+          >
+            {bannerType === "err" ? banner : `✓ ${banner}`}
+          </div>
+        )}
         {state.kind === "error" && (
           <div
             style={{
@@ -144,7 +235,42 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
             {diagnose.remote_tracking && diagnose.ahead > 0 && <span style={{ color: "var(--ok)" }}>↑ {diagnose.ahead} ahead</span>}
             {diagnose.remote_tracking && diagnose.behind > 0 && <span style={{ color: "var(--pending)" }}>↓ {diagnose.behind} behind</span>}
             {diagnose.remote_tracking && diagnose.ahead === 0 && diagnose.behind === 0 && <span>in sync</span>}
-            {diagnose.conflicts.length > 0 && <span style={{ color: "var(--err)" }}>{diagnose.conflicts.length} conflict{diagnose.conflicts.length === 1 ? "" : "s"} — run loom ops history repair</span>}
+            {diagnose.conflicts.length > 0 && <span style={{ color: "var(--err)" }}>{diagnose.conflicts.length} conflict{diagnose.conflicts.length === 1 ? "" : "s"}</span>}
+          </div>
+        )}
+        {diagnose && diagnose.conflicts.length > 0 && (
+          <div
+            className="card"
+            style={{
+              marginBottom: 16,
+              borderColor: "rgba(216,90,90,0.35)",
+              background: "rgba(216,90,90,0.06)",
+            }}
+          >
+            <div className="card-head">
+              <h3>History conflicts</h3>
+              <span className="badge err">{diagnose.conflicts.length}</span>
+            </div>
+            <div className="card-body" style={{ display: "grid", gap: 8 }}>
+              {diagnose.conflicts.slice(0, 4).map((conflict) => (
+                <div key={`${conflict.scope}:${conflict.path}`} style={{ fontSize: 12 }}>
+                  <div className="mono" style={{ color: "var(--ink-0)" }}>
+                    {conflict.scope} · {conflict.path}
+                  </div>
+                  <div className="mono" style={{ color: "var(--ink-3)", fontSize: 11, marginTop: 2 }}>
+                    local {shortBlob(conflict.local_blob)} · remote {shortBlob(conflict.remote_blob)}
+                  </div>
+                </div>
+              ))}
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+                <button className="btn ghost danger" disabled={!canRepair} onClick={() => runRepair("local")}>
+                  Keep local history
+                </button>
+                <button className="btn ghost danger" disabled={!canRepair} onClick={() => runRepair("remote")}>
+                  Keep remote history
+                </button>
+              </div>
+            </div>
           </div>
         )}
         <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 18 }}>
@@ -207,6 +333,7 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
                 <th>Intent</th>
                 <th>Status</th>
                 <th>ack</th>
+                <th>Details</th>
                 <th>Created</th>
                 <th>Updated</th>
               </tr>
@@ -214,14 +341,14 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
             <tbody>
               {state.kind === "loading" && (
                 <tr>
-                  <td colSpan={6} className="mono" style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
+                  <td colSpan={7} className="mono" style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
                     loading…
                   </td>
                 </tr>
               )}
               {state.kind === "ready" && filtered.length === 0 && (
                 <tr>
-                  <td colSpan={6} style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
+                  <td colSpan={7} style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
                     {operations.length === 0
                       ? "No activity recorded yet — every CLI or Panel change will show up here."
                       : "No activity matches the current filter."}
@@ -288,6 +415,9 @@ function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
         </span>
       </td>
       <td className="mono dim">{op.ack ? "✓" : "—"}</td>
+      <td className="mono dim" style={{ maxWidth: 280, whiteSpace: "normal", lineHeight: 1.35 }}>
+        {operationDetail(op)}
+      </td>
       <td className="mono dim" style={{ fontSize: 10.5 }}>
         {op.created_at}
       </td>
@@ -296,6 +426,19 @@ function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
       </td>
     </tr>
   );
+}
+
+function operationDetail(op: RegistryOperationRecord): string {
+  if (op.last_error) return op.last_error.message;
+  if (bucket(op) === "pending") return "Waiting for replay or retry.";
+  if (op.method || op.skill || op.target || op.binding) {
+    return [op.skill, op.binding ?? op.target, op.method].filter(Boolean).join(" · ");
+  }
+  return "Recorded.";
+}
+
+function shortBlob(blob: string): string {
+  return blob.length > 12 ? blob.slice(0, 12) : blob;
 }
 
 function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -18,6 +18,7 @@ interface OverviewPageProps {
   onMutation: () => void;
   onNewTarget: () => void;
   onNewBinding: () => void;
+  onOpenSkills: () => void;
   onViewActivity: () => void;
   onOpenSync: () => void;
   readOnly: boolean;
@@ -37,6 +38,7 @@ export function OverviewPage({
   registryRoot,
   onNewTarget,
   onNewBinding,
+  onOpenSkills,
   onViewActivity,
   onOpenSync,
   readOnly,
@@ -57,6 +59,20 @@ export function OverviewPage({
   const writeGuardTone = readOnly ? "warn" : "ok";
   const canAddBinding = !readOnly && targets.length > 0;
   const addBindingTitle = readOnly ? "registry offline" : !canAddBinding ? "add a target first" : undefined;
+  const nextSteps = buildNextSteps({
+    readOnly,
+    skillsCount: skills.length,
+    targetsCount: targets.length,
+    bindingsCount: totalRules,
+    projectionsCount: totalProjections,
+    pendingOps,
+    errOps,
+    onNewTarget,
+    onNewBinding,
+    onOpenSkills,
+    onOpenSync,
+    onViewActivity,
+  });
 
   return (
     <>
@@ -82,22 +98,33 @@ export function OverviewPage({
       <div className="page-body">
         <div className="card" style={{ marginBottom: 16 }}>
           <div className="card-head">
-            <h3>Recommended flow</h3>
+            <h3>Next steps</h3>
             {readOnly && <span className="badge warn">read-only</span>}
           </div>
-          <div className="card-body" style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, fontSize: 12 }}>
-            <div>
-              <div className="section-title" style={{ marginTop: 0 }}>1. Add target</div>
-              <div style={{ color: "var(--ink-2)" }}>Connect an agent directory Loom can manage, observe, or keep external.</div>
-            </div>
-            <div>
-              <div className="section-title" style={{ marginTop: 0 }}>2. Add binding</div>
-              <div style={{ color: "var(--ink-2)" }}>Map a skill to the target with an explicit matcher and projection policy.</div>
-            </div>
-            <div>
-              <div className="section-title" style={{ marginTop: 0 }}>3. Replay / sync</div>
-              <div style={{ color: "var(--ink-2)" }}>Apply pending writes locally, then pull or push registry changes when the remote is in use.</div>
-            </div>
+          <div className="card-body" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12, fontSize: 12 }}>
+            {nextSteps.map((step, index) => (
+              <div
+                key={step.title}
+                style={{
+                  border: "1px solid var(--line-soft)",
+                  borderRadius: 6,
+                  padding: 12,
+                  background: step.done ? "transparent" : "var(--bg-2)",
+                  minWidth: 0,
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                  <span className={`badge ${step.done ? "ok" : step.tone ?? "pending"}`}>{step.done ? "done" : index + 1}</span>
+                  <div style={{ color: "var(--ink-0)", fontWeight: 600 }}>{step.title}</div>
+                </div>
+                <div style={{ color: "var(--ink-2)", lineHeight: 1.45 }}>{step.body}</div>
+                {step.action && (
+                  <button className="btn sm" onClick={step.action.onClick} disabled={step.action.disabled} style={{ marginTop: 10 }}>
+                    {step.action.label}
+                  </button>
+                )}
+              </div>
+            ))}
           </div>
         </div>
 
@@ -268,6 +295,122 @@ export function OverviewPage({
       </div>
     </>
   );
+}
+
+interface NextStepInput {
+  readOnly: boolean;
+  skillsCount: number;
+  targetsCount: number;
+  bindingsCount: number;
+  projectionsCount: number;
+  pendingOps: number;
+  errOps: number;
+  onNewTarget: () => void;
+  onNewBinding: () => void;
+  onOpenSkills: () => void;
+  onOpenSync: () => void;
+  onViewActivity: () => void;
+}
+
+interface NextStep {
+  title: string;
+  body: string;
+  done?: boolean;
+  tone?: "pending" | "err" | "warn";
+  action?: { label: string; onClick: () => void; disabled?: boolean };
+}
+
+function buildNextSteps(input: NextStepInput): NextStep[] {
+  if (input.readOnly) {
+    return [
+      {
+        title: "Reconnect panel API",
+        body: "Live registry data is unavailable, so write actions are disabled.",
+        tone: "warn",
+      },
+    ];
+  }
+
+  const steps: NextStep[] = [];
+  if (input.targetsCount === 0) {
+    steps.push({
+      title: "Add first target",
+      body: "Connect an agent skills directory before binding or projecting skills.",
+      action: { label: "Add target", onClick: input.onNewTarget },
+    });
+  } else {
+    steps.push({
+      title: "Target connected",
+      body: `${input.targetsCount} target${input.targetsCount === 1 ? "" : "s"} registered.`,
+      done: true,
+    });
+  }
+
+  if (input.skillsCount === 0) {
+    steps.push({
+      title: "Add or import skills",
+      body: "Register source skills so Loom can project them into targets.",
+      action: { label: "Open Skills", onClick: input.onOpenSkills },
+    });
+  } else {
+    steps.push({
+      title: "Skills available",
+      body: `${input.skillsCount} skill${input.skillsCount === 1 ? "" : "s"} available for projection.`,
+      done: true,
+    });
+  }
+
+  if (input.bindingsCount === 0) {
+    steps.push({
+      title: "Create binding rules",
+      body: "Bind skills to targets with an explicit matcher and projection method.",
+      action: {
+        label: "Add binding",
+        onClick: input.onNewBinding,
+        disabled: input.targetsCount === 0,
+      },
+    });
+  } else {
+    steps.push({
+      title: "Bindings configured",
+      body: `${input.bindingsCount} binding rule${input.bindingsCount === 1 ? "" : "s"} configured.`,
+      done: true,
+    });
+  }
+
+  if (input.pendingOps > 0) {
+    steps.push({
+      title: "Replay pending writes",
+      body: `${input.pendingOps} operation${input.pendingOps === 1 ? "" : "s"} waiting for replay.`,
+      action: { label: "Open Sync", onClick: input.onOpenSync },
+      tone: "pending",
+    });
+  }
+  if (input.errOps > 0) {
+    steps.push({
+      title: "Inspect failed operations",
+      body: `${input.errOps} operation${input.errOps === 1 ? "" : "s"} need attention.`,
+      action: { label: "View Activity", onClick: input.onViewActivity },
+      tone: "err",
+    });
+  }
+  if (input.projectionsCount === 0 && input.skillsCount > 0 && input.bindingsCount > 0) {
+    steps.push({
+      title: "Project skills",
+      body: "Bindings exist but no projections have been realized yet.",
+      action: { label: "Open Skills", onClick: input.onOpenSkills },
+    });
+  }
+
+  if (steps.every((step) => step.done) && input.projectionsCount > 0) {
+    steps.push({
+      title: "Operation loop complete",
+      body: `${input.projectionsCount} projection${input.projectionsCount === 1 ? "" : "s"} active and no pending recovery work.`,
+      done: true,
+    });
+  }
+
+  return steps;
 }
 
 interface KpiProps {

--- a/panel/src/pages/panel/SkillTargetsTab.tsx
+++ b/panel/src/pages/panel/SkillTargetsTab.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import { AgentAvatar } from "../../components/panel/AgentAvatar";
+import { api } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
+import type { Binding, Target } from "../../lib/types";
+
+export function SkillTargetsTab({
+  skillName,
+  bindings,
+  targets,
+  projectedTargetIds,
+  onMutation,
+  readOnly,
+}: {
+  skillName: string;
+  bindings: Binding[];
+  targets: Target[];
+  projectedTargetIds: string[];
+  onMutation: () => void;
+  readOnly: boolean;
+}) {
+  const targetObjs = targets.filter((target) => projectedTargetIds.includes(target.id));
+  return (
+    <>
+      <ProjectSkillForm
+        skillName={skillName}
+        bindings={bindings}
+        targets={targets}
+        onMutation={onMutation}
+        readOnly={readOnly}
+      />
+      <TargetsTab targets={targetObjs} />
+    </>
+  );
+}
+
+function ProjectSkillForm({
+  skillName,
+  bindings,
+  targets,
+  onMutation,
+  readOnly,
+}: {
+  skillName: string;
+  bindings: Binding[];
+  targets: Target[];
+  onMutation: () => void;
+  readOnly: boolean;
+}) {
+  const [bindingId, setBindingId] = useState(bindings[0]?.id ?? "");
+  const [method, setMethod] = useState<"symlink" | "copy" | "materialize">("symlink");
+  const project = useMutation();
+  const bindingKey = bindings.map((binding) => binding.id).join("\0");
+
+  useEffect(() => {
+    setBindingId((current) => {
+      if (bindings.some((binding) => binding.id === current)) return current;
+      return bindings[0]?.id ?? "";
+    });
+    // Recompute only when the selectable binding set changes, not on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bindingKey]);
+
+  const runProject = () => {
+    if (!bindingId) return;
+    project.run("skill project", () => api.project({ skill: skillName, binding: bindingId, method }), onMutation);
+  };
+
+  return (
+    <div className="card" style={{ padding: 12, marginBottom: 12 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 130px auto", gap: 8 }}>
+        <select value={bindingId} onChange={(event) => setBindingId(event.target.value)} style={formInputStyle} disabled={readOnly}>
+          {bindings.length === 0 && <option value="">(no bindings)</option>}
+          {bindings.map((binding) => {
+            const target = targets.find((item) => item.id === binding.target);
+            return (
+              <option key={binding.id} value={binding.id}>
+                {binding.id} · {target ? `${target.agent}/${target.profile}` : binding.target}
+              </option>
+            );
+          })}
+        </select>
+        <select
+          value={method}
+          onChange={(event) => setMethod(event.target.value as "symlink" | "copy" | "materialize")}
+          style={formInputStyle}
+          disabled={readOnly}
+        >
+          <option value="symlink">symlink</option>
+          <option value="copy">copy</option>
+          <option value="materialize">materialize</option>
+        </select>
+        <button className="btn primary" onClick={runProject} disabled={readOnly || project.busy || !bindingId}>
+          {project.busy ? "projecting…" : "Project"}
+        </button>
+      </div>
+      {(project.error || project.success) && <div style={project.error ? errorStyle : okStyle}>{project.error ?? `✓ ${project.success}`}</div>}
+    </div>
+  );
+}
+
+function TargetsTab({ targets }: { targets: Target[] }) {
+  if (targets.length === 0) {
+    return <div className="empty" style={{ padding: "18px 4px" }}>This skill is not projected to any target.</div>;
+  }
+
+  return (
+    <div>
+      {targets.map((target) => (
+        <div
+          key={target.id}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "10px 12px",
+            borderBottom: "1px solid var(--line-soft)",
+          }}
+        >
+          <AgentAvatar agent={target.agent} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 12.5, color: "var(--ink-0)" }}>
+              {target.agent}/{target.profile}
+            </div>
+            <div className="mono" style={{ fontSize: 10.5, color: "var(--ink-3)" }}>
+              {target.path}
+            </div>
+          </div>
+          <span className={`chip ${target.ownership}`}>
+            <span className="dot" />
+            {target.ownership}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const formInputStyle: CSSProperties = {
+  padding: "6px 10px",
+  borderRadius: 6,
+  border: "1px solid var(--line-hi)",
+  background: "var(--bg-2)",
+  color: "var(--ink-0)",
+  fontSize: 12,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const errorStyle: CSSProperties = {
+  marginTop: 10,
+  padding: "6px 10px",
+  color: "var(--err)",
+  background: "rgba(216,90,90,0.08)",
+  border: "1px solid rgba(216,90,90,0.3)",
+  borderRadius: 6,
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+};
+
+const okStyle: CSSProperties = {
+  ...errorStyle,
+  color: "var(--ok)",
+  background: "rgba(111,183,138,0.08)",
+  border: "1px solid rgba(111,183,138,0.3)",
+};

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -43,6 +43,15 @@ const mockBinding: Binding = {
   policy: "auto",
 };
 
+const secondMockBinding: Binding = {
+  id: "binding-2",
+  skill: "my-skill",
+  target: "target-2",
+  matcher: "path_prefix:/repo/team",
+  method: "materialize",
+  policy: "manual",
+};
+
 function renderPage(overrides: { onMutation?: () => void; bindings?: Binding[] } = {}) {
   return render(
     <SkillsPage
@@ -90,7 +99,20 @@ describe("SkillsPage — capture action", () => {
     });
   });
 
-  it("disables capture when the skill has no unique binding selector", () => {
+  it("lets users choose which binding to capture from", async () => {
+    renderPage({ bindings: [mockBinding, secondMockBinding] });
+
+    fireEvent.change(screen.getByLabelText("Capture binding"), {
+      target: { value: "binding-2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Capture" }));
+
+    await waitFor(() => {
+      expect(api.capture).toHaveBeenCalledWith({ skill: "my-skill", binding: "binding-2" });
+    });
+  });
+
+  it("disables capture when the skill has no projected binding selector", () => {
     renderPage();
 
     expect(screen.getByRole("button", { name: "Capture" })).toBeDisabled();

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import type { Binding, Skill, Target } from "../../lib/types";
-import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon, SearchIcon } from "../../components/icons/nav_icons";
+import { SkillAddForm } from "../../components/panel/forms/SkillAddForm";
 import { api, type SkillDiffFile, type RegistryObservationEvent } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
+import { SkillTargetsTab } from "./SkillTargetsTab";
 
 interface SkillsPageProps {
   skills: Skill[];
@@ -18,18 +19,20 @@ interface SkillsPageProps {
 export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSelectSkill, onMutation, readOnly }: SkillsPageProps) {
   const [q, setQ] = useState("");
   const [addOpen, setAddOpen] = useState(false);
+  const [captureBindingId, setCaptureBindingId] = useState("");
   const filtered = skills.filter((s) => s.name.includes(q) || s.tag.includes(q));
   const sel = skills.find((s) => s.id === selectedSkill) ?? skills[0];
   const capture = useMutation();
   const selectedSkillBindings = sel ? bindings.filter((b) => b.skill === sel.name) : [];
-  const captureBinding = selectedSkillBindings.length === 1 ? selectedSkillBindings[0] : null;
+  const selectedSkillBindingKey = `${sel?.name ?? ""}\0${selectedSkillBindings.map((binding) => binding.id).join("\0")}`;
+  const captureBinding = selectedSkillBindings.find((binding) => binding.id === captureBindingId) ?? null;
   const captureDisabled = capture.busy || readOnly || !sel || !captureBinding;
   const captureTitle = readOnly
     ? "registry offline"
     : !sel
       ? "select a skill first"
       : !captureBinding
-        ? "capture requires one projected binding"
+        ? "capture requires a projected binding"
         : undefined;
   const emptyMessage: React.ReactNode = readOnly
     ? "Live registry API is offline. Start the panel backend to load real skills."
@@ -41,6 +44,15 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
           <code className="mono">loom skill add &lt;source&gt; --name &lt;name&gt;</code>.
         </>
       );
+
+  useEffect(() => {
+    setCaptureBindingId((current) => {
+      if (selectedSkillBindings.some((binding) => binding.id === current)) return current;
+      return selectedSkillBindings[0]?.id ?? "";
+    });
+    // Recompute only when the selectable binding set changes, not on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSkillBindingKey]);
 
   const runCapture = () => {
     if (!sel || !captureBinding) return;
@@ -67,6 +79,27 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
             <input placeholder="Filter skills…" value={q} onChange={(e) => setQ(e.target.value)} />
             <kbd>⌘K</kbd>
           </div>
+          <select
+            aria-label="Capture binding"
+            value={captureBindingId}
+            onChange={(event) => setCaptureBindingId(event.target.value)}
+            disabled={readOnly || !sel || selectedSkillBindings.length === 0}
+            title={
+              readOnly
+                ? "registry offline"
+                : selectedSkillBindings.length === 0
+                ? "capture requires a projected binding"
+                : "select binding to capture from"
+            }
+            style={captureSelectStyle}
+          >
+            {selectedSkillBindings.length === 0 && <option value="">no binding</option>}
+            {selectedSkillBindings.map((binding) => (
+              <option key={binding.id} value={binding.id}>
+                {captureBindingLabel(binding, targets)}
+              </option>
+            ))}
+          </select>
           <button
             className="btn primary"
             onClick={runCapture}
@@ -166,46 +199,6 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
   );
 }
 
-function SkillAddForm({ onCancel, onSuccess }: { onCancel: () => void; onSuccess: () => void }) {
-  const [source, setSource] = useState("");
-  const [name, setName] = useState("");
-  const add = useMutation();
-
-  const submit = (event: React.FormEvent) => {
-    event.preventDefault();
-    const trimmedSource = source.trim();
-    const trimmedName = name.trim();
-    if (!trimmedSource || !trimmedName) return;
-    add.run("skill add", () => api.skillAdd({ source: trimmedSource, name: trimmedName }), onSuccess);
-  };
-
-  return (
-    <form onSubmit={submit} className="card" style={{ padding: 16, marginBottom: 12 }}>
-      <div style={{ display: "grid", gridTemplateColumns: "120px 1fr", gap: 8, alignItems: "center" }}>
-        <label className="hint">source</label>
-        <input
-          value={source}
-          onChange={(event) => setSource(event.target.value)}
-          placeholder="/Users/me/.claude/skills/my-skill"
-          style={formInputStyle}
-          autoFocus
-        />
-        <label className="hint">name</label>
-        <input value={name} onChange={(event) => setName(event.target.value)} placeholder="my-skill" style={formInputStyle} />
-      </div>
-      {(add.error || add.success) && <div style={add.error ? errorStyle : okStyle}>{add.error ?? `✓ ${add.success}`}</div>}
-      <div style={{ display: "flex", gap: 8, marginTop: 12, justifyContent: "flex-end" }}>
-        <button type="button" className="btn ghost" onClick={onCancel} disabled={add.busy}>
-          Cancel
-        </button>
-        <button type="submit" className="btn primary" disabled={add.busy || !source.trim() || !name.trim()}>
-          {add.busy ? "adding…" : "skill add"}
-        </button>
-      </div>
-    </form>
-  );
-}
-
 function summarizePolicy(skillBindings: Binding[]): string {
   if (skillBindings.length === 0) return "— (no bindings)";
   const counts = skillBindings.reduce<Record<string, number>>((acc, b) => {
@@ -225,6 +218,12 @@ function formatSkillTags(skill: Skill): string {
   if (tags.length === 0) return "—";
   if (tags.length <= 2) return tags.join(" ");
   return `${tags[0]} +${tags.length - 1}`;
+}
+
+function captureBindingLabel(binding: Binding, targets: Target[]): string {
+  const target = targets.find((item) => item.id === binding.target);
+  const targetLabel = target ? `${target.agent}/${target.profile}` : binding.target;
+  return `${binding.id} · ${targetLabel} · ${binding.method}`;
 }
 
 type DetailTab = "history" | "diff" | "targets";
@@ -298,10 +297,6 @@ function SkillDetail({
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [historyEvents, setHistoryEvents] = useState<LifecycleEvent[]>([]);
 
-  const targetObjs = skill.targets
-    .map((tid) => targets.find((t) => t.id === tid))
-    .filter((t): t is Target => t !== undefined);
-
   const skillBindings = bindings.filter((b) => b.skill === skill.name);
   const policyLabel = summarizePolicy(skillBindings);
 
@@ -354,7 +349,7 @@ function SkillDetail({
           Diff
         </button>
         <button className={tab === "targets" ? "active" : ""} onClick={() => setTab("targets")}>
-          Targets ({targetObjs.length})
+          Targets ({skill.targets.length})
         </button>
       </div>
 
@@ -375,16 +370,14 @@ function SkillDetail({
       )}
       {tab === "diff" && <SkillDiff skillName={skill.name} />}
       {tab === "targets" && (
-        <>
-          <ProjectSkillForm
-            skillName={skill.name}
-            bindings={bindings}
-            targets={targets}
-            onMutation={onMutation}
-            readOnly={readOnly}
-          />
-          <TargetsTab targets={targetObjs} />
-        </>
+        <SkillTargetsTab
+          skillName={skill.name}
+          bindings={skillBindings}
+          targets={targets}
+          projectedTargetIds={skill.targets}
+          onMutation={onMutation}
+          readOnly={readOnly}
+        />
       )}
     </div>
   );
@@ -681,98 +674,6 @@ function SkillDiff({ skillName }: { skillName: string }) {
   );
 }
 
-function ProjectSkillForm({
-  skillName,
-  bindings,
-  targets,
-  onMutation,
-  readOnly,
-}: {
-  skillName: string;
-  bindings: Binding[];
-  targets: Target[];
-  onMutation: () => void;
-  readOnly: boolean;
-}) {
-  const [bindingId, setBindingId] = useState(bindings[0]?.id ?? "");
-  const [method, setMethod] = useState<"symlink" | "copy" | "materialize">("symlink");
-  const project = useMutation();
-
-  const runProject = () => {
-    if (!bindingId) return;
-    project.run("skill project", () => api.project({ skill: skillName, binding: bindingId, method }), onMutation);
-  };
-
-  return (
-    <div className="card" style={{ padding: 12, marginBottom: 12 }}>
-      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 130px auto", gap: 8 }}>
-        <select value={bindingId} onChange={(event) => setBindingId(event.target.value)} style={formInputStyle} disabled={readOnly}>
-          {bindings.length === 0 && <option value="">(no bindings)</option>}
-          {bindings.map((binding) => {
-            const target = targets.find((item) => item.id === binding.target);
-            return (
-              <option key={binding.id} value={binding.id}>
-                {binding.id} · {target ? `${target.agent}/${target.profile}` : binding.target}
-              </option>
-            );
-          })}
-        </select>
-        <select
-          value={method}
-          onChange={(event) => setMethod(event.target.value as "symlink" | "copy" | "materialize")}
-          style={formInputStyle}
-          disabled={readOnly}
-        >
-          <option value="symlink">symlink</option>
-          <option value="copy">copy</option>
-          <option value="materialize">materialize</option>
-        </select>
-        <button className="btn primary" onClick={runProject} disabled={readOnly || project.busy || !bindingId}>
-          {project.busy ? "projecting…" : "Project"}
-        </button>
-      </div>
-      {(project.error || project.success) && <div style={project.error ? errorStyle : okStyle}>{project.error ?? `✓ ${project.success}`}</div>}
-    </div>
-  );
-}
-
-function TargetsTab({ targets }: { targets: Target[] }) {
-  if (targets.length === 0) {
-    return <div className="empty" style={{ padding: "18px 4px" }}>This skill is not projected to any target.</div>;
-  }
-
-  return (
-    <div>
-      {targets.map((t) => (
-        <div
-          key={t.id}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            padding: "10px 12px",
-            borderBottom: "1px solid var(--line-soft)",
-          }}
-        >
-          <AgentAvatar agent={t.agent} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 12.5, color: "var(--ink-0)" }}>
-              {t.agent}/{t.profile}
-            </div>
-            <div className="mono" style={{ fontSize: 10.5, color: "var(--ink-3)" }}>
-              {t.path}
-            </div>
-          </div>
-          <span className={`chip ${t.ownership}`}>
-            <span className="dot" />
-            {t.ownership}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 const formInputStyle: React.CSSProperties = {
   padding: "6px 10px",
   borderRadius: 6,
@@ -782,6 +683,12 @@ const formInputStyle: React.CSSProperties = {
   fontSize: 12,
   fontFamily: "var(--font-mono)",
   minWidth: 0,
+};
+
+const captureSelectStyle: React.CSSProperties = {
+  ...formInputStyle,
+  width: 220,
+  height: 32,
 };
 
 const fullWidthButtonStyle: React.CSSProperties = {

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -338,6 +338,7 @@ test("OverviewPage disables add binding until a target exists", async () => {
         onMutation={() => {}}
         onNewTarget={() => {}}
         onNewBinding={() => {}}
+        onOpenSkills={() => {}}
         onViewActivity={() => {}}
         onOpenSync={() => {}}
         readOnly={false}
@@ -348,6 +349,8 @@ test("OverviewPage disables add binding until a target exists", async () => {
   const addBinding = buttonByLabel(renderer!, "Add binding");
   expect(addBinding.props.disabled).toBe(true);
   expect(addBinding.props.title).toBe("add a target first");
+  expect(markup(renderer!).includes("Add first target")).toBe(true);
+  expect(markup(renderer!).includes("Add or import skills")).toBe(true);
 });
 
 test("BindingAddForm submits the canonical matcher kind", async () => {
@@ -666,6 +669,166 @@ test("HistoryPage refetches when the shared live refresh key changes", async () 
     expect(markup(renderer!).includes("op-old")).toBe(false);
   } finally {
     api.ops = originalOps;
+  }
+});
+
+test("HistoryPage shows failed operation details", async () => {
+  const originalOps = api.ops;
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const failed = {
+    ...makeOperation("failed", false, "op-failed", "skill.project"),
+    last_error: { code: "PROJECT_FAILED", message: "target path missing" },
+  };
+  api.ops = async () => opsPayload(failed);
+  api.opsHistoryDiagnose = async () => ({
+    ok: true,
+    data: {
+      local_branch: true,
+      remote_tracking: false,
+      ahead: 0,
+      behind: 0,
+      local_segments: 1,
+      local_archives: 0,
+      remote_segments: 0,
+      remote_archives: 0,
+      local_snapshot: true,
+      remote_snapshot: false,
+      compact_after_segments: 50,
+      retain_recent_segments: 10,
+      retain_archives: 3,
+      conflicts: [],
+    },
+  });
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<HistoryPage live={true} mode="live" mutationVersion={0} />);
+    });
+    await flush();
+
+    expect(markup(renderer!).includes("PROJECT_FAILED")).toBe(true);
+    expect(markup(renderer!).includes("target path missing")).toBe(true);
+  } finally {
+    api.ops = originalOps;
+    api.opsHistoryDiagnose = originalDiagnose;
+  }
+});
+
+test("HistoryPage can replay pending operations", async () => {
+  const originalOps = api.ops;
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const originalReplay = api.syncReplay;
+  let mutations = 0;
+  let replayCalls = 0;
+  api.ops = async () => opsPayload(makeOperation("pending", false, "op-pending", "sync.replay"));
+  api.opsHistoryDiagnose = async () => ({ ok: true, data: undefined });
+  api.syncReplay = async () => {
+    replayCalls += 1;
+    return { ok: true, cmd: "sync.replay", request_id: "req-replay" };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <HistoryPage
+          live={true}
+          mode="live"
+          mutationVersion={0}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+    await flush();
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Replay pending").props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(replayCalls).toBe(1);
+    expect(mutations).toBe(1);
+  } finally {
+    api.ops = originalOps;
+    api.opsHistoryDiagnose = originalDiagnose;
+    api.syncReplay = originalReplay;
+  }
+});
+
+test("HistoryPage exposes repair actions for diagnosed conflicts", async () => {
+  const originalOps = api.ops;
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const originalRepair = api.opsHistoryRepair;
+  const repairs: Array<{ strategy: "local" | "remote" }> = [];
+  let mutations = 0;
+  api.ops = async () => opsPayload(makeOperation("succeeded", true, "op-ok", "sync.push"));
+  api.opsHistoryDiagnose = async () => ({
+    ok: true,
+    data: {
+      local_branch: true,
+      remote_tracking: true,
+      ahead: 1,
+      behind: 1,
+      local_segments: 3,
+      local_archives: 0,
+      remote_segments: 3,
+      remote_archives: 0,
+      local_snapshot: true,
+      remote_snapshot: true,
+      compact_after_segments: 50,
+      retain_recent_segments: 10,
+      retain_archives: 3,
+      conflicts: [
+        {
+          scope: "segment",
+          path: "state/v3/ops/001.jsonl",
+          local_blob: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          remote_blob: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          local_rename_path: "state/v3/ops/001.local.jsonl",
+          remote_rename_path: "state/v3/ops/001.remote.jsonl",
+        },
+      ],
+    },
+  });
+  api.opsHistoryRepair = async (body) => {
+    repairs.push(body);
+    return { ok: true, cmd: "ops.history.repair", request_id: "req-repair" };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <HistoryPage
+          live={true}
+          mode="live"
+          mutationVersion={0}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+    await flush();
+
+    expect(markup(renderer!).includes("state/v3/ops/001.jsonl")).toBe(true);
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Repair local").props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(repairs).toEqual([{ strategy: "local" }]);
+    expect(mutations).toBe(1);
+  } finally {
+    api.ops = originalOps;
+    api.opsHistoryDiagnose = originalDiagnose;
+    api.opsHistoryRepair = originalRepair;
   }
 });
 

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -759,6 +759,61 @@ test("HistoryPage can replay pending operations", async () => {
   }
 });
 
+test("HistoryPage can replay pending operations outside the visible page", async () => {
+  const originalOps = api.ops;
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const originalReplay = api.syncReplay;
+  let replayCalls = 0;
+  api.ops = async () => ({
+    ok: true,
+    data: {
+      count: 101,
+      loaded_count: 1,
+      offset: 100,
+      limit: 100,
+      has_more: false,
+      operations: [makeOperation("succeeded", true, "op-older", "sync.push")],
+      checkpoint: { last_scanned_op_id: "op-older" },
+    },
+  });
+  api.opsHistoryDiagnose = async () => ({ ok: true, data: undefined });
+  api.syncReplay = async () => {
+    replayCalls += 1;
+    return { ok: true, cmd: "sync.replay", request_id: "req-replay" };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <HistoryPage
+          live={true}
+          mode="live"
+          mutationVersion={0}
+          pendingCount={2}
+        />,
+      );
+    });
+    await flush();
+
+    const replayButton = buttonByLabel(renderer!, "Replay pending");
+    expect(replayButton.props.disabled).toBe(false);
+    expect(textOf(replayButton.props.children)).toContain("Replay pending (2)");
+
+    await act(async () => {
+      replayButton.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(replayCalls).toBe(1);
+  } finally {
+    api.ops = originalOps;
+    api.opsHistoryDiagnose = originalDiagnose;
+    api.syncReplay = originalReplay;
+  }
+});
+
 test("HistoryPage exposes repair actions for diagnosed conflicts", async () => {
   const originalOps = api.ops;
   const originalDiagnose = api.opsHistoryDiagnose;


### PR DESCRIPTION
## Summary
- add a capture binding selector on the Skills page for multi-binding workflows
- add state-based Overview next steps for empty and partially configured registries
- add History replay/repair controls plus failed-operation and conflict details
- split Skills page form/target controls into focused components

Closes #150

## Validation
- make panel-typecheck
- make panel-test
- make panel-build