### PR TITLE
feat(panel): close operation loop

### DIFF
--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -157,6 +157,7 @@ export function PanelApp() {
             onMutation={onMutation}
             onNewTarget={onNewTarget}
             onNewBinding={onNewBinding}
+            onOpenSkills={() => setPage("skills")}
             onViewActivity={onViewActivity}
             onOpenSync={onOpenSync}
             readOnly={readOnly}
@@ -223,6 +224,7 @@ export function PanelApp() {
             mode={live.mode}
             mutationVersion={mutationVersion}
             refreshKey={live.lastUpdated}
+            onMutation={onMutation}
           />
         );
         break;

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
 import { api, ApiError, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
 
 type FilterKey = "all" | "pending" | "ok" | "err";
 type DiagnoseData = NonNullable<OpsHistoryDiagnosePayload["data"]>;
@@ -17,14 +18,18 @@ interface HistoryPageProps {
   mode: PanelDataMode;
   mutationVersion: number;
   refreshKey?: string | null;
+  onMutation?: () => void;
 }
 
-export function HistoryPage({ live, mode, mutationVersion, refreshKey }: HistoryPageProps) {
+export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutation }: HistoryPageProps) {
   const [state, setState] = useState<LoadState>({ kind: "idle" });
   const [diagnose, setDiagnose] = useState<DiagnoseData | null>(null);
+  const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
   const [offset, setOffset] = useState(0);
+  const [repairVersion, setRepairVersion] = useState(0);
+  const repair = useMutation();
 
   useEffect(() => {
     if (!live) {
@@ -35,6 +40,7 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
     const controller = new AbortController();
     setState({ kind: "loading" });
     setDiagnose(null);
+    setDiagnoseError(null);
     Promise.allSettled([
       api.ops({ limit: HISTORY_PAGE_SIZE, offset }, controller.signal),
       api.opsHistoryDiagnose(controller.signal),
@@ -55,12 +61,26 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
       }
       setState({ kind: "ready", payload: res.data });
 
-      if (diagnoseResult.status === "fulfilled" && diagnoseResult.value.data) {
-        setDiagnose(diagnoseResult.value.data);
+      if (diagnoseResult.status === "fulfilled") {
+        if (diagnoseResult.value.data) {
+          setDiagnose(diagnoseResult.value.data);
+        } else if (!diagnoseResult.value.ok) {
+          setDiagnoseError(diagnoseResult.value.error?.message ?? "history diagnose returned ok=false");
+        }
+      } else {
+        const err = diagnoseResult.reason;
+        setDiagnoseError(err instanceof Error ? err.message : String(err));
       }
     });
     return () => controller.abort();
-  }, [live, mutationVersion, refreshKey, offset]);
+  }, [live, mutationVersion, refreshKey, offset, repairVersion]);
+
+  const runRepair = (strategy: "local" | "remote") => {
+    repair.run(`history repair ${strategy}`, () => api.opsHistoryRepair({ strategy }), () => {
+      setRepairVersion((value) => value + 1);
+      onMutation?.();
+    });
+  };
 
   const offlineHint =
     mode === "offline-stale"
@@ -122,6 +142,20 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
           </div>
         </div>
       </div>
+      {(repair.error || repair.success) && (
+        <div
+          style={{
+            padding: "6px 28px",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            borderBottom: "1px solid var(--line)",
+            color: repair.error ? "var(--err)" : "var(--ok)",
+            background: repair.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
+          }}
+        >
+          {repair.error ?? `✓ ${repair.success}`}
+        </div>
+      )}
       <div className="page-body">
         {state.kind === "error" && (
           <div
@@ -138,13 +172,31 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey }: History
           </div>
         )}
         {!live && <div className="empty" style={{ marginBottom: 18 }}>{offlineHint}</div>}
+        {diagnoseError && (
+          <div className="mono" style={{ color: "var(--warn)", fontSize: 11, marginBottom: 12 }}>
+            History diagnose: {diagnoseError}
+          </div>
+        )}
         {diagnose?.local_branch && (
-          <div style={{ display: "flex", gap: 12, padding: "4px 0", marginBottom: 12, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--ink-3)" }}>
+          <div style={{ display: "flex", gap: 12, padding: "4px 0", marginBottom: 12, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--ink-3)", alignItems: "center", flexWrap: "wrap" }}>
             <span>{diagnose.local_segments} segment{diagnose.local_segments === 1 ? "" : "s"}</span>
             {diagnose.remote_tracking && diagnose.ahead > 0 && <span style={{ color: "var(--ok)" }}>↑ {diagnose.ahead} ahead</span>}
             {diagnose.remote_tracking && diagnose.behind > 0 && <span style={{ color: "var(--pending)" }}>↓ {diagnose.behind} behind</span>}
             {diagnose.remote_tracking && diagnose.ahead === 0 && diagnose.behind === 0 && <span>in sync</span>}
-            {diagnose.conflicts.length > 0 && <span style={{ color: "var(--err)" }}>{diagnose.conflicts.length} conflict{diagnose.conflicts.length === 1 ? "" : "s"} — run loom ops history repair</span>}
+            {diagnose.conflicts.length > 0 && (
+              <>
+                <span style={{ color: "var(--err)" }}>
+                  {diagnose.conflicts.length} conflict{diagnose.conflicts.length === 1 ? "" : "s"}
+                </span>
+                <span style={{ color: "var(--ink-2)" }}>{diagnose.conflicts[0]?.path}</span>
+                <button className="btn sm" onClick={() => runRepair("local")} disabled={repair.busy}>
+                  Repair from local
+                </button>
+                <button className="btn sm" onClick={() => runRepair("remote")} disabled={repair.busy}>
+                  Repair from remote
+                </button>
+              </>
+            )}
           </div>
         )}
         <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 18 }}>
@@ -281,7 +333,14 @@ function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
   return (
     <tr>
       <td className="mono dim">{operationDisplayId(op)}</td>
-      <td className="name">{op.intent}</td>
+      <td className="name">
+        {op.intent}
+        {op.last_error && (
+          <div className="mono" style={{ color: "var(--err)", fontSize: 10.5, marginTop: 3 }}>
+            {op.last_error.message}
+          </div>
+        )}
+      </td>
       <td>
         <span className="chip" style={{ color }}>
           {op.last_error ? op.last_error.code : op.status}

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -18,6 +18,7 @@ interface OverviewPageProps {
   onMutation: () => void;
   onNewTarget: () => void;
   onNewBinding: () => void;
+  onOpenSkills: () => void;
   onViewActivity: () => void;
   onOpenSync: () => void;
   readOnly: boolean;
@@ -37,6 +38,7 @@ export function OverviewPage({
   registryRoot,
   onNewTarget,
   onNewBinding,
+  onOpenSkills,
   onViewActivity,
   onOpenSync,
   readOnly,
@@ -57,6 +59,53 @@ export function OverviewPage({
   const writeGuardTone = readOnly ? "warn" : "ok";
   const canAddBinding = !readOnly && targets.length > 0;
   const addBindingTitle = readOnly ? "registry offline" : !canAddBinding ? "add a target first" : undefined;
+  const nextSteps: NextStep[] = [
+    {
+      label: "Add a skill",
+      detail: skills.length === 0 ? "No tracked skills yet." : `${skills.length} tracked skill${skills.length === 1 ? "" : "s"}.`,
+      done: skills.length > 0,
+      action: "Open Skills",
+      onAction: onOpenSkills,
+      disabled: readOnly,
+    },
+    {
+      label: "Add a target",
+      detail: targets.length === 0 ? "No agent directory connected." : `${targets.length} target${targets.length === 1 ? "" : "s"} connected.`,
+      done: targets.length > 0,
+      action: "Add target",
+      onAction: onNewTarget,
+      disabled: readOnly,
+    },
+    {
+      label: "Add a binding",
+      detail: totalRules === 0 ? "No routing rule maps a skill to a target." : `${totalRules} binding rule${totalRules === 1 ? "" : "s"}.`,
+      done: totalRules > 0,
+      action: "Add binding",
+      onAction: onNewBinding,
+      disabled: readOnly || targets.length === 0,
+      title: targets.length === 0 ? "add a target first" : undefined,
+    },
+    {
+      label: "Apply projections",
+      detail: totalProjections === 0 ? "No live projection has been applied." : `${totalProjections} live projection${totalProjections === 1 ? "" : "s"}.`,
+      done: totalProjections > 0,
+      action: "Replay / sync",
+      onAction: onOpenSync,
+      disabled: readOnly || totalRules === 0,
+      title: totalRules === 0 ? "add a binding first" : undefined,
+    },
+    {
+      label: "Clear activity",
+      detail:
+        pendingOps + errOps === 0
+          ? "No pending or failed registry work."
+          : `${pendingOps} pending · ${errOps} failed`,
+      done: pendingOps + errOps === 0,
+      action: errOps > 0 ? "View activity" : "Replay pending",
+      onAction: errOps > 0 ? onViewActivity : onOpenSync,
+      disabled: readOnly,
+    },
+  ];
 
   return (
     <>
@@ -82,22 +131,13 @@ export function OverviewPage({
       <div className="page-body">
         <div className="card" style={{ marginBottom: 16 }}>
           <div className="card-head">
-            <h3>Recommended flow</h3>
+            <h3>Next steps</h3>
             {readOnly && <span className="badge warn">read-only</span>}
           </div>
-          <div className="card-body" style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, fontSize: 12 }}>
-            <div>
-              <div className="section-title" style={{ marginTop: 0 }}>1. Add target</div>
-              <div style={{ color: "var(--ink-2)" }}>Connect an agent directory Loom can manage, observe, or keep external.</div>
-            </div>
-            <div>
-              <div className="section-title" style={{ marginTop: 0 }}>2. Add binding</div>
-              <div style={{ color: "var(--ink-2)" }}>Map a skill to the target with an explicit matcher and projection policy.</div>
-            </div>
-            <div>
-              <div className="section-title" style={{ marginTop: 0 }}>3. Replay / sync</div>
-              <div style={{ color: "var(--ink-2)" }}>Apply pending writes locally, then pull or push registry changes when the remote is in use.</div>
-            </div>
+          <div className="card-body" style={{ display: "grid", gap: 8 }}>
+            {nextSteps.map((step, index) => (
+              <NextStepRow key={step.label} step={step} active={!step.done && nextSteps.findIndex((candidate) => !candidate.done) === index} />
+            ))}
           </div>
         </div>
 
@@ -267,6 +307,46 @@ export function OverviewPage({
         </div>
       </div>
     </>
+  );
+}
+
+interface NextStep {
+  label: string;
+  detail: string;
+  done: boolean;
+  action: string;
+  onAction: () => void;
+  disabled?: boolean;
+  title?: string;
+}
+
+function NextStepRow({ step, active }: { step: NextStep; active: boolean }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "72px minmax(0, 1fr) auto",
+        gap: 12,
+        alignItems: "center",
+        padding: "8px 0",
+        borderBottom: "1px solid var(--line)",
+      }}
+    >
+      <span className={`badge ${step.done ? "ok" : active ? "warn" : ""}`}>
+        {step.done ? "done" : active ? "next" : "waiting"}
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div className="section-title" style={{ margin: 0 }}>
+          {step.label}
+        </div>
+        <div style={{ color: "var(--ink-2)", fontSize: 12 }}>{step.detail}</div>
+      </div>
+      {!step.done && (
+        <button className="btn sm" onClick={step.onAction} disabled={step.disabled} title={step.title}>
+          {step.action}
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/panel/src/pages/panel/PanelOperationLoop.test.tsx
+++ b/panel/src/pages/panel/PanelOperationLoop.test.tsx
@@ -1,0 +1,257 @@
+import { expect, test } from "vitest";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { OverviewPage } from "./OverviewPage";
+import { HistoryPage } from "./HistoryPage";
+import { SyncPage } from "./SyncPage";
+import { api, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import type { Op, Target } from "../../lib/types";
+
+function textOf(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (Array.isArray(value)) return value.map((item) => textOf(item)).join("");
+  if (value && typeof value === "object" && "props" in value) {
+    return textOf((value as { props?: { children?: unknown } }).props?.children);
+  }
+  return "";
+}
+
+function markup(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON());
+}
+
+function buttonByLabel(renderer: ReactTestRenderer, label: string): ReactTestInstance {
+  const button = renderer.root.findAll(
+    (node: ReactTestInstance) => node.type === "button" && textOf(node.props.children).includes(label),
+  )[0];
+  if (!button) throw new Error(`button ${label} not found`);
+  return button;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function makeTarget(): Target {
+  return {
+    id: "target-1",
+    agent: "claude",
+    profile: "home",
+    path: "~/.claude/skills",
+    ownership: "managed",
+    skills: 0,
+    lastSync: "now",
+  };
+}
+
+function makePanelOp(): Op {
+  return {
+    id: "op-pending",
+    status: "pending",
+    kind: "sync-replay",
+    skill: "-",
+    target: "-",
+    method: "copy",
+    time: "now",
+  };
+}
+
+function makeOperation(status: string, ack = false, opId = "op_123", intent = "skill.project"): RegistryOperationRecord {
+  return {
+    op_id: opId,
+    intent,
+    status,
+    ack,
+    payload: {},
+    effects: {},
+    created_at: "2026-04-09T10:05:00Z",
+    updated_at: "2026-04-09T10:05:00Z",
+  };
+}
+
+function opsPayload(operation: RegistryOperationRecord): OpsPayload {
+  return {
+    ok: true,
+    data: {
+      count: 1,
+      loaded_count: 1,
+      offset: 0,
+      limit: 100,
+      has_more: false,
+      operations: [operation],
+      checkpoint: { last_scanned_op_id: operation.op_id ?? undefined },
+    },
+  };
+}
+
+function historyDiagnosePayload(conflictCount = 0): OpsHistoryDiagnosePayload {
+  return {
+    ok: true,
+    data: {
+      local_branch: true,
+      remote_tracking: true,
+      ahead: 0,
+      behind: 0,
+      local_segments: 2,
+      local_archives: 0,
+      remote_segments: 2,
+      remote_archives: 0,
+      local_snapshot: true,
+      remote_snapshot: true,
+      compact_after_segments: 64,
+      retain_recent_segments: 16,
+      retain_archives: 8,
+      conflicts: Array.from({ length: conflictCount }, (_, index) => ({
+        scope: "segment",
+        path: `segments/${index}.jsonl`,
+        local_blob: "local",
+        remote_blob: "remote",
+        local_rename_path: `segments/${index}.local.jsonl`,
+        remote_rename_path: `segments/${index}.remote.jsonl`,
+      })),
+    },
+  };
+}
+
+test("OverviewPage shows actionable next steps for a partial registry", async () => {
+  let openedSkills = 0;
+  let openedSync = 0;
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <OverviewPage
+        skills={[]}
+        targets={[makeTarget()]}
+        ops={[makePanelOp()]}
+        projections={[]}
+        vizMode="loom"
+        setVizMode={() => {}}
+        selectedSkill={null}
+        selectedTarget={null}
+        onSelectSkill={() => {}}
+        onSelectTarget={() => {}}
+        registryRoot="/tmp/loom"
+        onMutation={() => {}}
+        onNewTarget={() => {}}
+        onNewBinding={() => {}}
+        onOpenSkills={() => {
+          openedSkills += 1;
+        }}
+        onViewActivity={() => {}}
+        onOpenSync={() => {
+          openedSync += 1;
+        }}
+        readOnly={false}
+      />,
+    );
+  });
+
+  expect(markup(renderer!).includes("Next steps")).toBe(true);
+  expect(markup(renderer!).includes("No tracked skills yet.")).toBe(true);
+  buttonByLabel(renderer!, "Open Skills").props.onClick();
+  buttonByLabel(renderer!, "Replay pending").props.onClick();
+  expect(openedSkills).toBe(1);
+  expect(openedSync).toBe(1);
+});
+
+test("HistoryPage repairs diagnosed history conflicts from the panel", async () => {
+  const originalOps = api.ops;
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const originalRepair = api.opsHistoryRepair;
+  const repairs: Array<{ strategy: "local" | "remote" }> = [];
+  let mutations = 0;
+  let diagnoseCalls = 0;
+  api.ops = async () => {
+    const operation = {
+      ...makeOperation("failed", false, "op-failed", "sync.pull"),
+      last_error: { code: "history_conflict", message: "loom-history path conflict" },
+    };
+    return opsPayload(operation);
+  };
+  api.opsHistoryDiagnose = async () => {
+    diagnoseCalls += 1;
+    return historyDiagnosePayload(diagnoseCalls === 1 ? 1 : 0);
+  };
+  api.opsHistoryRepair = async (body) => {
+    repairs.push(body);
+    return { ok: true, cmd: "ops.history.repair", request_id: "req-repair", data: { repaired_conflicts: 1 } };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <HistoryPage
+          live={true}
+          mode="live"
+          mutationVersion={0}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+    await flush();
+
+    expect(markup(renderer!).includes("loom-history path conflict")).toBe(true);
+    expect(markup(renderer!).includes("segments/0.jsonl")).toBe(true);
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Repair from remote").props.onClick();
+    });
+    await flush();
+
+    expect(repairs).toEqual([{ strategy: "remote" }]);
+    expect(mutations).toBe(1);
+  } finally {
+    api.ops = originalOps;
+    api.opsHistoryDiagnose = originalDiagnose;
+    api.opsHistoryRepair = originalRepair;
+  }
+});
+
+test("SyncPage surfaces history repair actions", async () => {
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const originalRepair = api.opsHistoryRepair;
+  const repairs: Array<{ strategy: "local" | "remote" }> = [];
+  let mutations = 0;
+  api.opsHistoryDiagnose = async () => historyDiagnosePayload(1);
+  api.opsHistoryRepair = async (body) => {
+    repairs.push(body);
+    return { ok: true, cmd: "ops.history.repair", request_id: "req-repair", data: { repaired_conflicts: 1 } };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <SyncPage
+          remote={{ configured: true, url: "git@example.com:loom.git", ahead: 0, behind: 0, sync_state: "clean" }}
+          pendingCount={0}
+          registryRoot="/tmp/loom"
+          readOnly={false}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+    await flush();
+
+    expect(markup(renderer!).includes("History repair")).toBe(true);
+    expect(markup(renderer!).includes("segments/0.jsonl")).toBe(true);
+
+    await act(async () => {
+      buttonByLabel(renderer!, "Repair from local").props.onClick();
+    });
+    await flush();
+
+    expect(repairs).toEqual([{ strategy: "local" }]);
+    expect(mutations).toBe(1);
+  } finally {
+    api.opsHistoryDiagnose = originalDiagnose;
+    api.opsHistoryRepair = originalRepair;
+  }
+});

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SkillsPage } from "./SkillsPage";
-import type { Binding, Skill } from "../../lib/types";
+import type { Binding, Skill, Target } from "../../lib/types";
 
 vi.mock("../../lib/api/client", () => ({
   api: {
@@ -43,11 +43,11 @@ const mockBinding: Binding = {
   policy: "auto",
 };
 
-function renderPage(overrides: { onMutation?: () => void; bindings?: Binding[] } = {}) {
+function renderPage(overrides: { onMutation?: () => void; bindings?: Binding[]; targets?: Target[] } = {}) {
   return render(
     <SkillsPage
       skills={[mockSkill]}
-      targets={[]}
+      targets={overrides.targets ?? []}
       bindings={overrides.bindings ?? []}
       selectedSkill="skill-1"
       onSelectSkill={() => {}}
@@ -55,6 +55,19 @@ function renderPage(overrides: { onMutation?: () => void; bindings?: Binding[] }
       readOnly={false}
     />,
   );
+}
+
+function makeTarget(overrides: Partial<Target> = {}): Target {
+  return {
+    id: "target-1",
+    agent: "claude",
+    profile: "home",
+    path: "~/.claude/skills",
+    ownership: "managed",
+    skills: 0,
+    lastSync: "now",
+    ...overrides,
+  };
 }
 
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
@@ -90,7 +103,30 @@ describe("SkillsPage — capture action", () => {
     });
   });
 
-  it("disables capture when the skill has no unique binding selector", () => {
+  it("lets users choose which binding to capture when a skill has multiple bindings", async () => {
+    const onMutation = vi.fn();
+    renderPage({
+      targets: [
+        makeTarget(),
+        makeTarget({ id: "target-2", agent: "codex", profile: "work", path: "~/.codex/skills" }),
+      ],
+      bindings: [
+        mockBinding,
+        { ...mockBinding, id: "binding-2", target: "target-2", method: "symlink", policy: "manual" },
+      ],
+      onMutation,
+    });
+
+    fireEvent.change(screen.getByLabelText("Capture binding"), { target: { value: "binding-2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Capture" }));
+
+    await waitFor(() => {
+      expect(api.capture).toHaveBeenCalledWith({ skill: "my-skill", binding: "binding-2" });
+      expect(onMutation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("disables capture when the skill has no projected binding", () => {
     renderPage();
 
     expect(screen.getByRole("button", { name: "Capture" })).toBeDisabled();

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -18,19 +18,32 @@ interface SkillsPageProps {
 export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSelectSkill, onMutation, readOnly }: SkillsPageProps) {
   const [q, setQ] = useState("");
   const [addOpen, setAddOpen] = useState(false);
+  const [captureBindingId, setCaptureBindingId] = useState("");
   const filtered = skills.filter((s) => s.name.includes(q) || s.tag.includes(q));
   const sel = skills.find((s) => s.id === selectedSkill) ?? skills[0];
   const capture = useMutation();
   const selectedSkillBindings = sel ? bindings.filter((b) => b.skill === sel.name) : [];
-  const captureBinding = selectedSkillBindings.length === 1 ? selectedSkillBindings[0] : null;
+  const bindingOptionKey = selectedSkillBindings.map((b) => b.id).join("\u001f");
+  const captureBinding = selectedSkillBindings.find((b) => b.id === captureBindingId) ?? null;
   const captureDisabled = capture.busy || readOnly || !sel || !captureBinding;
   const captureTitle = readOnly
     ? "registry offline"
     : !sel
       ? "select a skill first"
       : !captureBinding
-        ? "capture requires one projected binding"
+        ? "capture requires a projected binding"
         : undefined;
+
+  useEffect(() => {
+    if (selectedSkillBindings.length === 0) {
+      setCaptureBindingId("");
+      return;
+    }
+    setCaptureBindingId((current) =>
+      selectedSkillBindings.some((b) => b.id === current) ? current : selectedSkillBindings[0].id,
+    );
+  }, [bindingOptionKey]);
+
   const emptyMessage: React.ReactNode = readOnly
     ? "Live registry API is offline. Start the panel backend to load real skills."
     : q
@@ -67,6 +80,22 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
             <input placeholder="Filter skills…" value={q} onChange={(e) => setQ(e.target.value)} />
             <kbd>⌘K</kbd>
           </div>
+          {selectedSkillBindings.length > 1 && (
+            <select
+              aria-label="Capture binding"
+              value={captureBindingId}
+              onChange={(event) => setCaptureBindingId(event.target.value)}
+              disabled={readOnly || capture.busy}
+              title="Choose which projected binding to capture from"
+              style={captureSelectStyle}
+            >
+              {selectedSkillBindings.map((binding) => (
+                <option key={binding.id} value={binding.id}>
+                  {formatCaptureBinding(binding, targets)}
+                </option>
+              ))}
+            </select>
+          )}
           <button
             className="btn primary"
             onClick={runCapture}
@@ -226,6 +255,26 @@ function formatSkillTags(skill: Skill): string {
   if (tags.length <= 2) return tags.join(" ");
   return `${tags[0]} +${tags.length - 1}`;
 }
+
+function formatCaptureBinding(binding: Binding, targets: Target[]): string {
+  const target = targets.find((t) => t.id === binding.target);
+  const targetLabel = target ? `${target.agent}/${target.profile}` : binding.target;
+  return `${targetLabel} · ${binding.method} · ${binding.policy}`;
+}
+
+const captureSelectStyle = {
+  height: 32,
+  minWidth: 190,
+  maxWidth: 260,
+  border: "1px solid var(--line)",
+  borderRadius: 6,
+  background: "var(--bg)",
+  color: "var(--ink-0)",
+  padding: "0 8px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  outline: "none",
+};
 
 type DetailTab = "history" | "diff" | "targets";
 

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -2,8 +2,10 @@ import type { RemotePayload } from "../../types";
 import type { FormEvent } from "react";
 import { useEffect, useState } from "react";
 import { GitIcon, PlayIcon, RefreshIcon, SyncIcon } from "../../components/icons/nav_icons";
-import { api } from "../../lib/api/client";
+import { api, type OpsHistoryDiagnosePayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
+
+type DiagnoseData = NonNullable<OpsHistoryDiagnosePayload["data"]>;
 
 interface SyncPageProps {
   remote: RemotePayload | null;
@@ -18,15 +20,53 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
   const pull = useMutation();
   const replay = useMutation();
   const setRemote = useMutation();
+  const historyRepair = useMutation();
   const [remoteUrl, setRemoteUrl] = useState(remote?.url ?? "");
-  const syncBusy = push.busy || pull.busy || replay.busy || setRemote.busy;
+  const [diagnose, setDiagnose] = useState<DiagnoseData | null>(null);
+  const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
+  const [diagnoseLoading, setDiagnoseLoading] = useState(false);
+  const [repairVersion, setRepairVersion] = useState(0);
+  const syncBusy = push.busy || pull.busy || replay.busy || setRemote.busy || historyRepair.busy;
   const configured = remote?.configured === true;
   const state = remote?.sync_state ?? (configured ? "unknown" : "not configured");
   const rootDisplay = registryRoot ? registryRoot.replace(/^\/Users\/[^/]+/, "~") : "—";
+  const conflictCount = diagnose?.conflicts.length ?? 0;
 
   useEffect(() => {
     setRemoteUrl(remote?.url ?? "");
   }, [remote?.url]);
+
+  useEffect(() => {
+    if (readOnly) {
+      setDiagnose(null);
+      setDiagnoseError(null);
+      setDiagnoseLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setDiagnoseError(null);
+    setDiagnoseLoading(true);
+    api.opsHistoryDiagnose(controller.signal)
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        if (res.ok && res.data) {
+          setDiagnose(res.data);
+          return;
+        }
+        setDiagnose(null);
+        setDiagnoseError(res.error?.message ?? "history diagnose returned ok=false");
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setDiagnose(null);
+        setDiagnoseError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setDiagnoseLoading(false);
+      });
+    return () => controller.abort();
+  }, [readOnly, repairVersion]);
 
   const submitRemote = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -37,9 +77,17 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
 
   const banner =
     setRemote.error ?? push.error ?? pull.error ?? replay.error ??
-    setRemote.success ?? push.success ?? pull.success ?? replay.success ?? null;
+    historyRepair.error ??
+    setRemote.success ?? push.success ?? pull.success ?? replay.success ?? historyRepair.success ?? null;
   const bannerType =
-    setRemote.error || push.error || pull.error || replay.error ? "err" : banner ? "ok" : null;
+    setRemote.error || push.error || pull.error || replay.error || historyRepair.error ? "err" : banner ? "ok" : null;
+
+  const runHistoryRepair = (strategy: "local" | "remote") => {
+    historyRepair.run(`history repair ${strategy}`, () => api.opsHistoryRepair({ strategy }), () => {
+      setRepairVersion((value) => value + 1);
+      onMutation();
+    });
+  };
 
   return (
     <>
@@ -136,6 +184,44 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
                 <GitIcon /> {setRemote.busy ? "saving…" : configured ? "Update" : "Set"}
               </button>
             </form>
+          </div>
+        </div>
+
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div className="card-head">
+            <h3>History repair</h3>
+            <span className={`chip ${diagnoseLoading ? "" : diagnoseError || conflictCount > 0 ? "warn" : "ok"}`}>
+              {diagnoseLoading
+                ? "checking"
+                : diagnoseError
+                  ? "diagnose failed"
+                  : conflictCount > 0
+                    ? `${conflictCount} conflict${conflictCount === 1 ? "" : "s"}`
+                    : "clean"}
+            </span>
+          </div>
+          <div className="card-body" style={{ fontSize: 12, color: "var(--ink-1)" }}>
+            {diagnoseLoading ? (
+              <span className="mono" style={{ color: "var(--ink-3)" }}>checking history branch...</span>
+            ) : diagnoseError ? (
+              <div style={{ color: "var(--warn)" }}>{diagnoseError}</div>
+            ) : conflictCount > 0 ? (
+              <>
+                <div className="mono" style={{ color: "var(--ink-2)", marginBottom: 10 }}>
+                  {diagnose?.conflicts[0]?.path}
+                </div>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  <button className="btn" disabled={readOnly || syncBusy} onClick={() => runHistoryRepair("local")}>
+                    Repair from local
+                  </button>
+                  <button className="btn" disabled={readOnly || syncBusy} onClick={() => runHistoryRepair("remote")}>
+                    Repair from remote
+                  </button>
+                </div>
+              </>
+            ) : (
+              "History branch has no path conflicts."
+            )}
           </div>
         </div>
 

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -369,6 +369,7 @@ test("OverviewPage disables add binding until a target exists", async () => {
         onMutation={() => {}}
         onNewTarget={() => {}}
         onNewBinding={() => {}}
+        onOpenSkills={() => {}}
         onViewActivity={() => {}}
         onOpenSync={() => {}}
         readOnly={false}


### PR DESCRIPTION
## Summary
- add a binding selector for Panel skill capture when a skill has multiple bindings
- replace the static Overview flow with an actionable next-step checklist
- surface history diagnose details and local/remote repair actions in History and Sync

Closes #150

## Verification
- make panel-typecheck panel-test panel-build
- git diff --check