### PR TITLE
docs: improve install trust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /panel
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -140,6 +143,11 @@ jobs:
           fi
           kill "$panel_pid"
           wait "$panel_pid" 2>/dev/null || true
+
+      - name: Attest release archive
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/*.tar.gz
 
       - name: Upload release asset
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ## Quick Start
 
 ```bash
-# 1. Install
-cargo install skillloom
+# 1. Install a prebuilt release archive (recommended)
+# Pick one target: aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu
+VERSION="0.1.0" # replace with the latest release version
+TARGET="aarch64-apple-darwin"
+BASE_URL="https://github.com/majiayu000/loom/releases/download/v${VERSION}"
+curl -LO "${BASE_URL}/skillloom-${VERSION}-${TARGET}.tar.gz"
+curl -LO "${BASE_URL}/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+tar -xzf "skillloom-${VERSION}-${TARGET}.tar.gz"
+sudo install "skillloom-${VERSION}-${TARGET}/loom" /usr/local/bin/loom
 
 # or install from the Homebrew tap after its formula PR is merged
 brew install majiayu000/tap/loom
 
-# or install from source
+# or build from source
 git clone https://github.com/majiayu000/loom.git
 cd loom && cargo install --path .
 
@@ -95,6 +103,8 @@ loom panel        # -> http://localhost:43117
 ```
 
 `loom panel` now serves a frontend bundled into the Rust binary at build time, so it works even when `--root` points at a separate registry directory. If panel assets are unavailable in your build, reinstall from a checkout with `bun` available so Loom can package the frontend during compile.
+
+Release archives are the preferred install path because their binaries are built with the Panel frontend already bundled and smoke-tested. To verify a downloaded archive, use the release `SHA256SUMS` file as shown above; if you use GitHub CLI, you can also verify provenance with `gh attestation verify skillloom-${VERSION}-${TARGET}.tar.gz --repo majiayu000/loom`.
 
 Prefer a guided walkthrough? Run `./scripts/demo.sh` for a scripted end-to-end tour (init → target add → status → panel hint) against a throwaway registry. `./scripts/e2e-agent-flow.sh` runs the four real integration scenarios used in CI.
 
@@ -200,6 +210,7 @@ Quick decision: **edits from the agent side → `capture`; edits inside the regi
 - State-changing registry commands commit `state/registry` to Git, and `sync push` has a safety commit before pushing.
 - Hard write guard: if `--root` points to the Loom tool repo itself, write operations are rejected. Use an independent skill registry repo for mutable operations.
 - English is the primary documentation language. [中文完整指南](docs/LOOM_COMPLETE_GUIDE_ZH.md).
+- Release and install trust notes live in [Releasing Loom](docs/RELEASING.md) and [Security Policy](SECURITY.md).
 - V1 planning lives in [Loom V1 Core Spec](docs/LOOM_V1_CORE_SPEC.md).
 
 ## Command Surface

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Loom is early-stage software. Security fixes target the latest release and `main`.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for suspected vulnerabilities. Use GitHub private vulnerability reporting for this repository, or email the maintainer listed on the GitHub profile with enough detail to reproduce the issue.
+
+Include:
+
+- affected version or commit
+- operating system and install method
+- exact command or Panel route involved
+- expected impact and any safe proof of concept
+
+We will acknowledge reports as quickly as practical, triage severity, and publish a fix or advisory when needed.
+
+## Dependency and Release Trust
+
+- Rust dependencies are locked in `Cargo.lock`; Panel dependencies are locked in `panel/bun.lock` and `panel/package-lock.json`.
+- Dependabot tracks Cargo, Panel npm, and GitHub Actions updates.
+- Release archives are built by GitHub Actions from version tags, smoke-tested, checksummed in `SHA256SUMS`, and attested with GitHub artifact attestations.
+- Users should prefer release archives or Homebrew over source installs when they need a guaranteed bundled Panel.
+
+## Secrets
+
+Loom must not commit API tokens, private keys, registry credentials, or generated secret material. Use environment variables or GitHub repository secrets for release automation.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,11 +4,18 @@ Loom is distributed as the `skillloom` crate with a `loom` binary.
 
 ## Release Surfaces
 
-- GitHub Release: built from tags matching `v*.*.*`.
+- GitHub Release: built from tags matching `v*.*.*`; each archive includes the `loom` binary plus README/LICENSE.
 - crates.io: published when `CARGO_REGISTRY_TOKEN` is configured.
 - Homebrew: opens a `loom` formula PR against `majiayu000/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured.
 
-The Homebrew formula installs the `loom` binary from GitHub Release archives. The crate name remains `skillloom` because `loom` is already used by an unrelated crates.io package.
+GitHub Release archives are the preferred install path. They are built with the Panel frontend bundled into the Rust binary and smoke-tested before upload. The release workflow publishes:
+
+- `skillloom-<version>-aarch64-apple-darwin.tar.gz`
+- `skillloom-<version>-x86_64-apple-darwin.tar.gz`
+- `skillloom-<version>-x86_64-unknown-linux-gnu.tar.gz`
+- `SHA256SUMS`
+
+The release workflow also creates GitHub artifact attestations for the `.tar.gz` archives. The Homebrew formula installs the `loom` binary from GitHub Release archives. The crate name remains `skillloom` because `loom` is already used by an unrelated crates.io package.
 
 ## One-Time Setup
 
@@ -49,9 +56,28 @@ Configure repository secrets:
 After the release is published:
 
 ```bash
-cargo install skillloom
-loom --help
-loom --version
+tag=vX.Y.Z
+version="${tag#v}"
+target=aarch64-apple-darwin
+archive="skillloom-${version}-${target}.tar.gz"
+
+gh release download "$tag" --repo majiayu000/loom --pattern "$archive" --pattern SHA256SUMS
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gh attestation verify "$archive" --repo majiayu000/loom
+
+tmp="$(mktemp -d)"
+tar -C "$tmp" -xzf "$archive"
+bin="$tmp/skillloom-${version}-${target}/loom"
+"$bin" --version
+"$bin" --help >/dev/null
+root="$(mktemp -d)"
+"$bin" --json --root "$root" workspace status >/dev/null
+"$bin" --root "$root" panel --port 0 >/tmp/loom-panel-smoke.log 2>&1 &
+panel_pid="$!"
+sleep 1
+kill -0 "$panel_pid"
+kill "$panel_pid"
+wait "$panel_pid" 2>/dev/null || true
 ```
 
 After the Homebrew PR is merged:
@@ -61,3 +87,9 @@ brew install majiayu000/tap/loom
 loom --help
 loom --version
 ```
+
+`cargo install skillloom` remains supported as a source-build path, but it is not the recommended first install path for users who want a guaranteed bundled Panel. Source builds need the Panel frontend inputs and `bun` available during compile time; otherwise the CLI can build without embedded Panel assets.
+
+## Future Install Surfaces
+
+Only add `cargo-binstall` metadata after a tagged GitHub Release has been downloaded and verified with the archive layout above. The metadata must point at `skillloom-<version>-<target>.tar.gz` and install the nested `loom` binary from `skillloom-<version>-<target>/loom`.


### PR DESCRIPTION
## Summary
- make prebuilt release archives the recommended install path in README and release docs
- document checksum and GitHub attestation verification for release archives
- add SECURITY.md plus Dependabot update policy
- attest release archives from the release workflow with actions/attest

Closes #149

## Verification
- ruby YAML parse for .github/workflows/release.yml and .github/dependabot.yml
- actionlint .github/workflows/release.yml
- cargo check --locked
- git diff --check