### PR TITLE
feat(agent): add preflight dry-run planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Quick decision: **edits from the agent side → `capture`; edits inside the regi
 
 - Multi-directory behavior is explicit via `target add`; no implicit directory inference.
 - Agent automation should use explicit `--root`, `--json`, selectors such as `binding_id` / `target_id`, and branch on `ok` + `error.code`.
+- Agents can call `loom agent preflight --agent <agent> --workspace <path> --skill <skill>` before writing, and can add `--dry-run` to high-risk writes to get a no-mutation plan.
 - `--json` wraps both command execution errors and argument parsing failures in the same envelope. `loom panel` is the local HTTP UI server and does not return a command envelope.
 - Read commands such as `workspace status`, `workspace doctor`, `target list`, and `sync status` do not mutate registry state, Git refs, the Git index, live target directories, or the pending queue. They do write durable command audit events under `state/events/commands.jsonl`.
 - Registry metadata lives under `state/registry`; Loom does not use release-style labels for internal state names.
@@ -234,24 +235,28 @@ loom workspace binding remove <binding-id>
 loom workspace remote set <git-url>
 loom workspace remote status
 
+loom agent preflight --agent <agent> --workspace <path> [--skill <skill>] [--method <symlink|copy|materialize>]
+
 loom target add --agent <agent> --path <abs-path> [--ownership <managed|observed|external>]
 loom target list
 loom target show <target-id>
 loom target remove <target-id>
 
 loom skill add <path|git-url> --name <skill>
-loom skill project <skill> --binding <binding-id> [--target <target-id>] [--method <symlink|copy|materialize>]
-loom skill capture [<skill>] [--binding <binding-id>] [--instance <instance-id>] [--message <msg>]
+loom skill project <skill> --binding <binding-id> [--target <target-id>] [--method <symlink|copy|materialize>] [--dry-run]
+loom skill capture [<skill>] [--binding <binding-id>] [--instance <instance-id>] [--message <msg>] [--dry-run]
 loom skill save <skill> [--message <msg>]
 loom skill snapshot <skill>
 loom skill release <skill> <version>
-loom skill rollback <skill> [--to <ref> | --steps <n>]
+loom skill rollback <skill> [--to <ref> | --steps <n>] [--dry-run]
 loom skill diff <skill> <from> <to>
 loom skill import-observed [--target <target-id>]
 loom skill monitor-observed [--target <target-id>] [--once] [--interval-seconds <seconds>]
+loom skill orphan list
+loom skill orphan clean [--delete-live-paths] [--dry-run]
 
 loom sync status
-loom sync push
+loom sync push [--dry-run]
 loom sync pull
 loom sync replay
 

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -61,17 +61,21 @@ loom --json --root "$REGISTRY_ROOT" skill monitor-observed --once
 ## 4. 日常操作建议（Agent）
 
 1. 读取状态：`loom --json --root <registry_root> workspace status`
-2. 保存变更：`loom --json --root <registry_root> skill save <skill>`
-3. 关键节点快照：`loom --json --root <registry_root> skill snapshot <skill>`
-4. 发布版本：`loom --json --root <registry_root> skill release <skill> vX.Y.Z`
-5. 差异检查：`loom --json --root <registry_root> skill diff <skill> <from> <to>`
-6. 远端同步：`loom --json --root <registry_root> sync push` / `sync pull`
+2. 写入前规划：`loom --json --root <registry_root> agent preflight --agent <agent> --workspace "$PWD" --skill <skill>`
+3. 高风险写入预演：在 `skill project` / `skill capture` / `skill rollback` / `skill orphan clean` / `sync push` 后加 `--dry-run`
+4. 保存变更：`loom --json --root <registry_root> skill save <skill>`
+5. 关键节点快照：`loom --json --root <registry_root> skill snapshot <skill>`
+6. 发布版本：`loom --json --root <registry_root> skill release <skill> vX.Y.Z`
+7. 差异检查：`loom --json --root <registry_root> skill diff <skill> <from> <to>`
+8. 远端同步：`loom --json --root <registry_root> sync push` / `sync pull`
 
 ## 5. 安全护栏
 
 - 未经明确授权，不要默认使用 `--force` 覆盖同名 skill。
 - 优先 symlink 模式；只有环境不支持时再使用 `--method copy`。
 - `meta.warnings` 不为空时，视为“成功但有风险”，需写入运行日志。
+- `agent preflight` 和 `--dry-run` 返回 `ok=true` 不代表可以直接写入；必须同时检查 `data.safe_to_run=true`。
+- `--dry-run` 只允许写 command audit，不应改变 registry ops、pending queue、Git refs/index 或 live target 内容。
 - `sync_state=LOCAL_ONLY` 或 `PENDING_PUSH` 时，不应宣称“远端已同步”。
 - 读命令（如 `workspace status`、`workspace doctor`、`target list`）不会修改 registry state、Git refs/index、live target 目录或 pending queue；它们会写入 durable command event。registry 写操作审计以 `meta.op_id` / `/api/v1/ops` 为准。
 
@@ -97,7 +101,11 @@ loom --json --root "$ROOT" skill monitor-observed --once
 # 2) 日常保存
 loom --json --root "$ROOT" skill save "$SKILL"
 
-# 3) 同步
+# 3) 写入前规划
+loom --json --root "$ROOT" agent preflight --agent codex --workspace "$PWD" --skill "$SKILL"
+loom --json --root "$ROOT" sync push --dry-run
+
+# 4) 同步
 loom --json --root "$ROOT" sync push
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,11 @@ pub enum Command {
         #[command(subcommand)]
         command: OpsCommand,
     },
+    #[command(about = "Plan safe agent automation before mutating state")]
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
     #[command(about = "Serve the local registry control panel")]
     Panel(PanelArgs),
 }
@@ -158,6 +163,10 @@ pub struct OrphanCleanArgs {
     /// Also delete validated live projection directories.
     #[arg(long)]
     pub delete_live_paths: bool,
+
+    /// Show the cleanup plan without modifying registry state or live files.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
@@ -181,6 +190,31 @@ pub enum OpsHistoryCommand {
     Diagnose,
     #[command(about = "Repair operation-history divergence")]
     Repair(HistoryRepairArgs),
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize)]
+pub enum AgentCommand {
+    #[command(about = "Resolve selectors and risks for an agent workspace")]
+    Preflight(AgentPreflightArgs),
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct AgentPreflightArgs {
+    /// Agent kind asking for the plan.
+    #[arg(long, value_enum)]
+    pub agent: AgentKind,
+
+    /// Workspace path the agent is operating in.
+    #[arg(long)]
+    pub workspace: PathBuf,
+
+    /// Optional skill to resolve project/capture selectors for.
+    #[arg(long)]
+    pub skill: Option<String>,
+
+    /// Desired projection method for a new project operation.
+    #[arg(long, value_enum, default_value_t = ProjectionMethod::Symlink)]
+    pub method: ProjectionMethod,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
@@ -222,6 +256,10 @@ pub struct ProjectArgs {
     /// Projection strategy used for the live agent directory.
     #[arg(long, value_enum, default_value_t = ProjectionMethod::Symlink)]
     pub method: ProjectionMethod,
+
+    /// Show the projection plan without writing registry state or target files.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
@@ -240,6 +278,10 @@ pub struct CaptureArgs {
     /// Git commit message for the captured source revision.
     #[arg(long)]
     pub message: Option<String>,
+
+    /// Show the capture plan without writing registry state or source files.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
@@ -297,6 +339,10 @@ pub struct RollbackArgs {
     /// Number of source commits to roll back when --to is not provided.
     #[arg(long)]
     pub steps: Option<u32>,
+
+    /// Show the rollback plan without changing Git refs, source files, or registry state.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]
@@ -388,11 +434,18 @@ pub enum SyncCommand {
     #[command(about = "Show Git sync state")]
     Status,
     #[command(about = "Push registry state and operation history")]
-    Push,
+    Push(SyncPushArgs),
     #[command(about = "Pull registry state and operation history")]
     Pull,
     #[command(about = "Replay pending operations")]
     Replay,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct SyncPushArgs {
+    /// Show the push plan without committing, pushing, or clearing pending ops.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(

--- a/src/commands/agent_cmds.rs
+++ b/src/commands/agent_cmds.rs
@@ -1,0 +1,670 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+
+use super::helpers::{
+    agent_kind_as_str, map_arg, map_git, map_io, map_registry_state, projection_method_as_str,
+    resolve_capture_projection, validate_skill_name,
+};
+use super::{App, CommandFailure};
+use crate::cli::{AgentPreflightArgs, CaptureArgs, OrphanCleanArgs, ProjectArgs, RollbackArgs};
+use crate::envelope::Meta;
+use crate::gitops;
+use crate::state_model::{RegistryProjectionInstance, RegistrySnapshot, RegistryStatePaths};
+
+impl App {
+    pub fn cmd_agent_preflight(
+        &self,
+        args: &AgentPreflightArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        if let Some(skill) = args.skill.as_deref() {
+            validate_skill_name(skill).map_err(map_arg)?;
+        }
+        let snapshot = self.require_registry_snapshot()?;
+        let agent = agent_kind_as_str(args.agent);
+        let workspace = normalize_path(&args.workspace);
+        let mut risks = Vec::new();
+        let mut matches = Vec::new();
+
+        for binding in snapshot.bindings.bindings.iter().filter(|binding| {
+            binding.active
+                && binding.agent == agent
+                && workspace_matches(
+                    &binding.workspace_matcher.kind,
+                    &binding.workspace_matcher.value,
+                    &workspace,
+                )
+        }) {
+            let method = args
+                .skill
+                .as_deref()
+                .and_then(|skill| {
+                    snapshot
+                        .rules
+                        .rules
+                        .iter()
+                        .find(|rule| {
+                            rule.binding_id == binding.binding_id && rule.skill_id == skill
+                        })
+                        .map(|rule| rule.method.clone())
+                })
+                .unwrap_or_else(|| projection_method_as_str(args.method).to_string());
+            let target = snapshot.target(&binding.default_target_id);
+            if let Some(target) = target {
+                push_target_risks(
+                    &mut risks,
+                    &snapshot,
+                    &binding.binding_id,
+                    &target.target_id,
+                    &method,
+                );
+            } else {
+                risks.push(risk(
+                    "error",
+                    "TARGET_NOT_FOUND",
+                    format!(
+                        "binding '{}' points at missing target '{}'",
+                        binding.binding_id, binding.default_target_id
+                    ),
+                ));
+            }
+            matches.push(json!({
+                "binding_id": binding.binding_id,
+                "agent": binding.agent,
+                "profile": binding.profile_id,
+                "matcher": binding.workspace_matcher,
+                "target_id": binding.default_target_id,
+                "target": target,
+                "method": method,
+                "existing_projection": args.skill.as_deref().and_then(|skill| {
+                    snapshot.projections.projections.iter().find(|projection| {
+                        projection.skill_id == skill
+                            && projection.binding_id.as_deref() == Some(binding.binding_id.as_str())
+                    })
+                }),
+            }));
+        }
+
+        match matches.len() {
+            0 => risks.push(risk(
+                "error",
+                "NO_MATCHING_BINDING",
+                format!(
+                    "no active '{}' binding matches workspace '{}'",
+                    agent,
+                    workspace.display()
+                ),
+            )),
+            1 => {}
+            count => risks.push(risk(
+                "error",
+                "AMBIGUOUS_BINDING",
+                format!(
+                    "{} active '{}' bindings match workspace '{}'; refine workspace binding matchers or use the returned binding_id with the write command",
+                    count,
+                    agent,
+                    workspace.display()
+                ),
+            )),
+        }
+
+        if let Some(skill) = args.skill.as_deref()
+            && !self.ctx.skill_path(skill).exists()
+        {
+            risks.push(risk(
+                "error",
+                "SKILL_NOT_FOUND",
+                format!("skill '{}' not found", skill),
+            ));
+        }
+
+        let required_selectors = if matches.len() == 1 {
+            let binding_id = matches[0]["binding_id"].as_str().unwrap_or_default();
+            json!({
+                "skill": args.skill,
+                "binding_id": binding_id,
+                "target_id": matches[0]["target_id"],
+                "method": matches[0]["method"],
+            })
+        } else {
+            json!({
+                "skill": args.skill,
+                "binding_id": null,
+                "target_id": null,
+                "method": projection_method_as_str(args.method),
+            })
+        };
+        let next_commands =
+            build_preflight_next_commands(&self.ctx.root, args, &required_selectors);
+
+        Ok((
+            json!({
+                "dry_run": true,
+                "operation": "agent.preflight",
+                "safe_to_run": is_safe(&risks),
+                "status": status_for(&risks, matches.len()),
+                "workspace": workspace.display().to_string(),
+                "agent": agent,
+                "required_selectors": required_selectors,
+                "target_paths": target_paths(&matches),
+                "matches": matches,
+                "risks": risks,
+                "next_commands": next_commands,
+            }),
+            Meta::default(),
+        ))
+    }
+
+    pub fn cmd_project_plan(
+        &self,
+        args: &ProjectArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        validate_skill_name(&args.skill).map_err(map_arg)?;
+        let snapshot = self.require_registry_snapshot()?;
+        let mut risks = Vec::new();
+
+        if !self.ctx.skill_path(&args.skill).exists() {
+            risks.push(risk(
+                "error",
+                "SKILL_NOT_FOUND",
+                format!("skill '{}' not found", args.skill),
+            ));
+        }
+
+        let binding = snapshot.binding(&args.binding);
+        let mut target_id = args.target.clone();
+        if let Some(binding) = binding {
+            if target_id.is_none() {
+                target_id = Some(binding.default_target_id.clone());
+            }
+        } else {
+            risks.push(risk(
+                "error",
+                "BINDING_NOT_FOUND",
+                format!("binding '{}' not found", args.binding),
+            ));
+        }
+
+        let target = target_id.as_deref().and_then(|id| snapshot.target(id));
+        if let Some(target) = target {
+            if let Some(binding) = binding
+                && target.agent != binding.agent
+            {
+                risks.push(risk(
+                    "error",
+                    "TARGET_AGENT_MISMATCH",
+                    format!(
+                        "binding '{}' is for agent '{}' but target '{}' is for agent '{}'",
+                        binding.binding_id, binding.agent, target.target_id, target.agent
+                    ),
+                ));
+            }
+            push_target_risks(
+                &mut risks,
+                &snapshot,
+                binding
+                    .map(|b| b.binding_id.as_str())
+                    .unwrap_or(args.binding.as_str()),
+                &target.target_id,
+                projection_method_as_str(args.method),
+            );
+        } else if let Some(target_id) = target_id.as_deref() {
+            risks.push(risk(
+                "error",
+                "TARGET_NOT_FOUND",
+                format!("target '{}' not found", target_id),
+            ));
+        }
+
+        let materialized_path = target.map(|target| PathBuf::from(&target.path).join(&args.skill));
+        if let Some(path) = materialized_path.as_ref()
+            && path.exists()
+        {
+            risks.push(risk(
+                "warning",
+                "REPLACE_EXISTING_PROJECTION",
+                format!(
+                    "projection path '{}' already exists and would be replaced",
+                    path.display()
+                ),
+            ));
+        }
+
+        Ok((
+            json!({
+                "dry_run": true,
+                "operation": "skill.project",
+                "safe_to_run": is_safe(&risks),
+                "status": status_for(&risks, usize::from(binding.is_some())),
+                "required_selectors": {
+                    "skill": args.skill,
+                    "binding_id": args.binding,
+                    "target_id": target_id,
+                    "method": projection_method_as_str(args.method),
+                },
+                "target_paths": materialized_path.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+                "will_mutate": ["live_target", "registry_state", "registry_ops", "git_history"],
+                "risks": risks,
+                "next_commands": [format!(
+                    "loom --json --root {} skill project {} --binding {} --method {}",
+                    shell_arg(&self.ctx.root),
+                    shell_arg(&args.skill),
+                    shell_arg(&args.binding),
+                    projection_method_as_str(args.method)
+                )],
+            }),
+            Meta::default(),
+        ))
+    }
+
+    pub fn cmd_capture_plan(
+        &self,
+        args: &CaptureArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        let snapshot = self.require_registry_snapshot()?;
+        let mut risks = Vec::new();
+        let projection = match resolve_capture_projection(&snapshot, args) {
+            Ok(projection) => Some(projection),
+            Err(err) => {
+                risks.push(risk("error", err.code.as_str(), err.message));
+                None
+            }
+        };
+
+        if let Some(projection) = projection.as_ref() {
+            if !self.ctx.skill_path(&projection.skill_id).exists() {
+                risks.push(risk(
+                    "error",
+                    "SKILL_NOT_FOUND",
+                    format!("skill '{}' not found", projection.skill_id),
+                ));
+            }
+            let live_path = Path::new(&projection.materialized_path);
+            if !live_path.exists() {
+                risks.push(risk(
+                    "error",
+                    "LIVE_PATH_MISSING",
+                    format!("projection path '{}' does not exist", live_path.display()),
+                ));
+            }
+            if projection.method != "symlink" {
+                risks.push(risk(
+                    "warning",
+                    "SOURCE_REPLACE",
+                    format!(
+                        "capture from '{}' would replace the registry source copy",
+                        projection.instance_id
+                    ),
+                ));
+            }
+        }
+        let target_paths = projection
+            .iter()
+            .map(|p| p.materialized_path.clone())
+            .collect::<Vec<_>>();
+
+        Ok((
+            json!({
+                "dry_run": true,
+                "operation": "skill.capture",
+                "safe_to_run": is_safe(&risks),
+                "status": status_for(&risks, usize::from(projection.is_some())),
+                "required_selectors": {
+                    "skill": args.skill,
+                    "binding_id": args.binding,
+                    "instance_id": args.instance,
+                },
+                "projection": projection,
+                "target_paths": target_paths,
+                "will_mutate": ["skill_source", "registry_state", "registry_ops", "git_history"],
+                "risks": risks,
+            }),
+            Meta::default(),
+        ))
+    }
+
+    pub fn cmd_rollback_plan(
+        &self,
+        args: &RollbackArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        validate_skill_name(&args.skill).map_err(map_arg)?;
+        let mut risks = Vec::new();
+        if args.to.is_some() && args.steps.is_some() {
+            risks.push(risk(
+                "error",
+                "ARG_INVALID",
+                "--to and --steps are mutually exclusive",
+            ));
+        }
+        if !self.ctx.skill_path(&args.skill).exists() {
+            risks.push(risk(
+                "error",
+                "SKILL_NOT_FOUND",
+                format!("skill '{}' not found", args.skill),
+            ));
+        }
+        let reference = match (&args.to, args.steps) {
+            (Some(r), _) => r.clone(),
+            (None, Some(n)) => format!("HEAD~{}", n),
+            (None, None) => "HEAD~1".to_string(),
+        };
+        let resolved = match gitops::resolve_ref(&self.ctx, &reference) {
+            Ok(rev) => Some(rev),
+            Err(err) => {
+                risks.push(risk(
+                    "error",
+                    "GIT_ERROR",
+                    format!("failed to resolve '{}': {}", reference, err),
+                ));
+                None
+            }
+        };
+        let stale_projection_ids = rollback_stale_projection_ids(&self.ctx, &args.skill)?;
+        if !stale_projection_ids.is_empty() {
+            risks.push(risk(
+                "warning",
+                "STALE_LIVE_PROJECTIONS",
+                format!(
+                    "rollback does not update non-symlink live projections: {}",
+                    stale_projection_ids.join(", ")
+                ),
+            ));
+        }
+
+        Ok((
+            json!({
+                "dry_run": true,
+                "operation": "skill.rollback",
+                "safe_to_run": is_safe(&risks),
+                "status": status_for(&risks, usize::from(resolved.is_some())),
+                "required_selectors": {
+                    "skill": args.skill,
+                    "reference": reference,
+                },
+                "resolved_ref": resolved,
+                "will_mutate": ["skill_source", "git_history", "git_tags", "registry_ops"],
+                "will_create_recovery_ref": true,
+                "stale_projection_ids": stale_projection_ids,
+                "risks": risks,
+            }),
+            Meta::default(),
+        ))
+    }
+
+    pub fn cmd_skill_orphan_clean_plan(
+        &self,
+        args: &OrphanCleanArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        let snapshot = self.require_registry_snapshot()?;
+        let projections = snapshot
+            .projections
+            .projections
+            .iter()
+            .filter(|projection| is_orphan_projection(projection))
+            .collect::<Vec<_>>();
+        let mut risks = Vec::new();
+        let mut live_paths_to_delete = Vec::new();
+        for projection in &projections {
+            if args.delete_live_paths && Path::new(&projection.materialized_path).exists() {
+                live_paths_to_delete.push(projection.materialized_path.clone());
+            }
+        }
+        if !live_paths_to_delete.is_empty() {
+            risks.push(risk(
+                "warning",
+                "LIVE_DELETE",
+                format!(
+                    "{} live orphan path(s) would be deleted",
+                    live_paths_to_delete.len()
+                ),
+            ));
+        }
+
+        Ok((
+            json!({
+                "dry_run": true,
+                "operation": "skill.orphan.clean",
+                "safe_to_run": is_safe(&risks),
+                "status": status_for(&risks, projections.len()),
+                "delete_live_paths": args.delete_live_paths,
+                "cleaned_projection_ids": projections.iter().map(|p| p.instance_id.clone()).collect::<Vec<_>>(),
+                "live_paths_to_delete": live_paths_to_delete,
+                "will_mutate": if args.delete_live_paths {
+                    json!(["registry_state", "registry_ops", "live_target"])
+                } else {
+                    json!(["registry_state", "registry_ops"])
+                },
+                "risks": risks,
+            }),
+            Meta::default(),
+        ))
+    }
+
+    pub fn cmd_sync_push_plan(&self) -> std::result::Result<(Value, Meta), CommandFailure> {
+        let pending_report = self.ctx.read_pending_report().map_err(map_io)?;
+        let mut risks = Vec::new();
+        let remote_configured = gitops::remote_exists(&self.ctx);
+        let tracking_ref = if remote_configured {
+            gitops::remote_tracking_main_exists(&self.ctx).map_err(map_git)?
+        } else {
+            false
+        };
+        let mut ahead = None;
+        let mut behind = None;
+        if tracking_ref {
+            let (a, b) = gitops::ahead_behind_main(&self.ctx).map_err(map_git)?;
+            ahead = Some(a);
+            behind = Some(b);
+            if b > 0 {
+                risks.push(risk(
+                    "error",
+                    "REMOTE_DIVERGED",
+                    "local branch is behind origin/main",
+                ));
+            }
+        }
+        if !remote_configured {
+            risks.push(risk(
+                "error",
+                "REMOTE_NOT_CONFIGURED",
+                "remote origin not configured",
+            ));
+        }
+        risks.push(risk(
+            "warning",
+            "REMOTE_STATUS_NOT_FETCHED",
+            "dry-run does not fetch remote refs; result is based on local tracking refs",
+        ));
+
+        Ok((
+            json!({
+                "dry_run": true,
+                "operation": "sync.push",
+                "safe_to_run": is_safe(&risks),
+                "status": status_for(&risks, usize::from(remote_configured)),
+                "remote_configured": remote_configured,
+                "tracking_ref": tracking_ref,
+                "ahead": ahead,
+                "behind": behind,
+                "pending_ops": pending_report.ops.len(),
+                "will_mutate": ["git_history", "remote", "pending_queue"],
+                "risks": risks,
+            }),
+            Meta {
+                warnings: pending_report.warnings,
+                ..Meta::default()
+            },
+        ))
+    }
+}
+
+fn push_target_risks(
+    risks: &mut Vec<Value>,
+    snapshot: &RegistrySnapshot,
+    binding_id: &str,
+    target_id: &str,
+    method: &str,
+) {
+    let Some(target) = snapshot.target(target_id) else {
+        risks.push(risk(
+            "error",
+            "TARGET_NOT_FOUND",
+            format!("target '{}' not found", target_id),
+        ));
+        return;
+    };
+    if target.ownership != "managed" {
+        risks.push(risk(
+            "error",
+            "TARGET_NOT_MANAGED",
+            format!(
+                "target '{}' has ownership '{}' and cannot be written",
+                target.target_id, target.ownership
+            ),
+        ));
+    }
+    if let Some(binding) = snapshot.binding(binding_id)
+        && target.agent != binding.agent
+    {
+        risks.push(risk(
+            "error",
+            "TARGET_AGENT_MISMATCH",
+            format!(
+                "binding '{}' is for agent '{}' but target '{}' is for agent '{}'",
+                binding.binding_id, binding.agent, target.target_id, target.agent
+            ),
+        ));
+    }
+    match method {
+        "symlink" if !target.capabilities.symlink => risks.push(risk(
+            "error",
+            "PROJECTION_METHOD_UNSUPPORTED",
+            format!(
+                "target '{}' does not support symlink projections",
+                target.target_id
+            ),
+        )),
+        "copy" | "materialize" if !target.capabilities.copy => risks.push(risk(
+            "error",
+            "PROJECTION_METHOD_UNSUPPORTED",
+            format!(
+                "target '{}' does not support copy/materialize projections",
+                target.target_id
+            ),
+        )),
+        _ => {}
+    }
+}
+
+fn rollback_stale_projection_ids(
+    ctx: &crate::state::AppContext,
+    skill: &str,
+) -> std::result::Result<Vec<String>, CommandFailure> {
+    let paths = RegistryStatePaths::from_app_context(ctx);
+    let Some(snapshot) = paths.maybe_load_snapshot().map_err(map_registry_state)? else {
+        return Ok(Vec::new());
+    };
+    Ok(snapshot
+        .projections
+        .projections
+        .iter()
+        .filter(|projection| projection.skill_id == skill && projection.method != "symlink")
+        .map(|projection| projection.instance_id.clone())
+        .collect())
+}
+
+fn build_preflight_next_commands(
+    root: &Path,
+    args: &AgentPreflightArgs,
+    selectors: &Value,
+) -> Vec<String> {
+    let Some(skill) = args.skill.as_deref() else {
+        return Vec::new();
+    };
+    let Some(binding_id) = selectors["binding_id"].as_str() else {
+        return Vec::new();
+    };
+    let method = selectors["method"]
+        .as_str()
+        .unwrap_or_else(|| projection_method_as_str(args.method));
+    vec![format!(
+        "loom --json --root {} skill project {} --binding {} --method {}",
+        shell_arg(root),
+        shell_arg(skill),
+        shell_arg(binding_id),
+        method
+    )]
+}
+
+fn target_paths(matches: &[Value]) -> Vec<String> {
+    matches
+        .iter()
+        .filter_map(|entry| entry["target"]["path"].as_str().map(ToString::to_string))
+        .collect()
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    absolute.canonicalize().unwrap_or(absolute)
+}
+
+fn workspace_matches(kind: &str, value: &str, workspace: &Path) -> bool {
+    match kind {
+        "path_prefix" => workspace.starts_with(normalize_path(Path::new(value))),
+        "exact_path" => workspace == normalize_path(Path::new(value)),
+        "name" => workspace.file_name().and_then(|name| name.to_str()) == Some(value),
+        _ => false,
+    }
+}
+
+fn is_orphan_projection(projection: &RegistryProjectionInstance) -> bool {
+    projection.binding_id.is_none() && projection.health == "orphaned"
+}
+
+fn is_safe(risks: &[Value]) -> bool {
+    !risks
+        .iter()
+        .any(|risk| risk["severity"].as_str() == Some("error"))
+}
+
+fn status_for(risks: &[Value], match_count: usize) -> &'static str {
+    if !is_safe(risks) {
+        return "blocked";
+    }
+    if match_count == 0 {
+        return "no-op";
+    }
+    if risks
+        .iter()
+        .any(|risk| risk["severity"].as_str() == Some("warning"))
+    {
+        return "ready_with_warnings";
+    }
+    "ready"
+}
+
+fn risk(severity: &'static str, code: impl Into<String>, message: impl Into<String>) -> Value {
+    json!({
+        "severity": severity,
+        "code": code.into(),
+        "message": message.into(),
+    })
+}
+
+fn shell_arg(value: impl AsRef<Path>) -> String {
+    let raw = value.as_ref().display().to_string();
+    if raw
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
+    {
+        raw
+    } else {
+        format!("'{}'", raw.replace('\'', "'\\''"))
+    }
+}

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -4,8 +4,8 @@ use anyhow::{Result, anyhow};
 use uuid::Uuid;
 
 use crate::cli::{
-    AgentKind, BindingAddArgs, Command, OpsCommand, OpsHistoryCommand, ProjectionMethod,
-    SkillCommand, SkillOrphanCommand, SyncCommand, TargetAddArgs, TargetCommand,
+    AgentCommand, AgentKind, BindingAddArgs, Command, OpsCommand, OpsHistoryCommand,
+    ProjectionMethod, SkillCommand, SkillOrphanCommand, SyncCommand, TargetAddArgs, TargetCommand,
     WorkspaceBindingCommand, WorkspaceCommand, WorkspaceMatcherKind,
 };
 use crate::state::AppContext;
@@ -134,7 +134,7 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
         },
         Command::Sync { command } => match command {
             SyncCommand::Status => "sync.status",
-            SyncCommand::Push => "sync.push",
+            SyncCommand::Push(_) => "sync.push",
             SyncCommand::Pull => "sync.pull",
             SyncCommand::Replay => "sync.replay",
         },
@@ -146,6 +146,9 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
                 OpsHistoryCommand::Diagnose => "ops.history.diagnose",
                 OpsHistoryCommand::Repair(_) => "ops.history.repair",
             },
+        },
+        Command::Agent { command } => match command {
+            AgentCommand::Preflight(_) => "agent.preflight",
         },
         Command::Panel(_) => "panel",
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod agent_cmds;
 mod event_store;
 mod file_ops;
 mod fs_probe;
@@ -14,8 +15,9 @@ use serde_json::json;
 use uuid::Uuid;
 
 use crate::cli::{
-    Cli, Command, OpsCommand, OpsHistoryCommand, RemoteCommand, SkillCommand, SkillOrphanCommand,
-    SyncCommand, TargetCommand, WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs,
+    AgentCommand, Cli, Command, OpsCommand, OpsHistoryCommand, RemoteCommand, SkillCommand,
+    SkillOrphanCommand, SyncCommand, TargetCommand, WorkspaceBindingCommand, WorkspaceCommand,
+    WorkspaceInitArgs,
 };
 use crate::envelope::{Envelope, Meta};
 use crate::state::AppContext;
@@ -168,11 +170,14 @@ impl App {
                 SkillCommand::Add(args) => self.cmd_add(args, &request_id),
                 SkillCommand::ImportObserved(args) => self.cmd_import_observed(args, &request_id),
                 SkillCommand::MonitorObserved(args) => self.cmd_monitor_observed(args, &request_id),
+                SkillCommand::Project(args) if args.dry_run => self.cmd_project_plan(args),
                 SkillCommand::Project(args) => self.cmd_project(args, &request_id),
+                SkillCommand::Capture(args) if args.dry_run => self.cmd_capture_plan(args),
                 SkillCommand::Capture(args) => self.cmd_capture(args, &request_id),
                 SkillCommand::Save(args) => self.cmd_save(args, &request_id),
                 SkillCommand::Snapshot(args) => self.cmd_snapshot(args, &request_id),
                 SkillCommand::Release(args) => self.cmd_release(args, &request_id),
+                SkillCommand::Rollback(args) if args.dry_run => self.cmd_rollback_plan(args),
                 SkillCommand::Rollback(args) => self.cmd_rollback(args, &request_id),
                 SkillCommand::Diff(args) => self.cmd_diff(args),
                 SkillCommand::Orphan {
@@ -180,10 +185,16 @@ impl App {
                 } => self.cmd_skill_orphan_list(),
                 SkillCommand::Orphan {
                     command: SkillOrphanCommand::Clean(args),
+                } if args.dry_run => self.cmd_skill_orphan_clean_plan(args),
+                SkillCommand::Orphan {
+                    command: SkillOrphanCommand::Clean(args),
                 } => self.cmd_skill_orphan_clean(args, &request_id),
             },
             Command::Sync { command } => self.cmd_sync(command),
             Command::Ops { command } => self.cmd_ops(command),
+            Command::Agent { command } => match command {
+                AgentCommand::Preflight(args) => self.cmd_agent_preflight(args),
+            },
             Command::Panel(_) => Ok((json!({"message": "panel handled in main"}), Meta::default())),
         };
 
@@ -336,6 +347,7 @@ fn command_requires_durable_audit(command: &Command) -> bool {
             OpsCommand::Retry | OpsCommand::Purge => true,
             OpsCommand::History { command } => !matches!(command, OpsHistoryCommand::Diagnose),
         },
+        Command::Agent { .. } => false,
         Command::Panel(_) => false,
     }
 }

--- a/src/commands/sync_cmds.rs
+++ b/src/commands/sync_cmds.rs
@@ -21,7 +21,8 @@ impl App {
                 let (remote, meta) = remote_status_payload(&self.ctx)?;
                 Ok((json!({"remote": remote}), meta))
             }
-            SyncCommand::Push => {
+            SyncCommand::Push(args) if args.dry_run => self.cmd_sync_push_plan(),
+            SyncCommand::Push(_) => {
                 let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
                 self.ensure_write_repo_ready()?;
                 let res = sync_push_internal(&self.ctx)?;

--- a/src/commands/workspace_cmds/orphan.rs
+++ b/src/commands/workspace_cmds/orphan.rs
@@ -346,7 +346,10 @@ mod orphan_tests {
     }
 
     fn orphan_clean_args(delete_live_paths: bool) -> crate::cli::OrphanCleanArgs {
-        crate::cli::OrphanCleanArgs { delete_live_paths }
+        crate::cli::OrphanCleanArgs {
+            delete_live_paths,
+            dry_run: false,
+        }
     }
 
     fn setup_with_binding_and_projection(

--- a/src/panel/handlers.rs
+++ b/src/panel/handlers.rs
@@ -1062,6 +1062,7 @@ pub(super) async fn registry_project(
                 binding: req.binding,
                 target: req.target,
                 method: req.method.unwrap_or(ProjectionMethod::Symlink),
+                dry_run: false,
             }),
         },
     )
@@ -1175,6 +1176,7 @@ pub(super) async fn registry_skill_rollback(
                 skill: skill_name,
                 to: req.to,
                 steps: req.steps,
+                dry_run: false,
             }),
         },
     )
@@ -1199,6 +1201,7 @@ pub(super) async fn registry_capture(
                 binding: req.binding,
                 instance: req.instance,
                 message: req.message,
+                dry_run: false,
             }),
         },
     )
@@ -1222,6 +1225,7 @@ pub(super) async fn registry_orphan_clean(
             command: crate::cli::SkillCommand::Orphan {
                 command: SkillOrphanCommand::Clean(OrphanCleanArgs {
                     delete_live_paths: req.delete_live_paths,
+                    dry_run: false,
                 }),
             },
         },
@@ -1326,7 +1330,7 @@ pub(super) async fn sync_push(
         "sync.push",
         StatusCode::OK,
         Command::Sync {
-            command: SyncCommand::Push,
+            command: SyncCommand::Push(crate::cli::SyncPushArgs { dry_run: false }),
         },
     )
 }

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -290,6 +290,7 @@ fn run_panel_command_returns_non_2xx_for_logical_failures_across_mutations() {
                     binding: "missing-binding".to_string(),
                     target: None,
                     method: ProjectionMethod::Symlink,
+                    dry_run: false,
                 }),
             },
         ),
@@ -302,6 +303,7 @@ fn run_panel_command_returns_non_2xx_for_logical_failures_across_mutations() {
                     binding: None,
                     instance: None,
                     message: None,
+                    dry_run: false,
                 }),
             },
         ),
@@ -342,6 +344,7 @@ fn run_panel_command_returns_non_2xx_for_logical_failures_across_mutations() {
                     skill: "missing-skill".to_string(),
                     to: Some("HEAD~1".to_string()),
                     steps: None,
+                    dry_run: false,
                 }),
             },
         ),
@@ -349,7 +352,7 @@ fn run_panel_command_returns_non_2xx_for_logical_failures_across_mutations() {
             "sync.push",
             StatusCode::OK,
             Command::Sync {
-                command: SyncCommand::Push,
+                command: SyncCommand::Push(crate::cli::SyncPushArgs { dry_run: false }),
             },
         ),
         (

--- a/tests/agent_preflight.rs
+++ b/tests/agent_preflight.rs
@@ -1,0 +1,249 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+mod common;
+
+use common::actions::{binding_add, save_skill, target_add};
+use common::{TestDir, run_loom, write_skill};
+
+fn write_example_skill(root: &Path, skill: &str) {
+    write_skill(root, skill, &format!("# {}\n\nexample skill\n", skill));
+}
+
+fn read_text(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+fn operations_log(root: &Path) -> String {
+    read_text(&root.join("state/registry/ops/operations.jsonl"))
+}
+
+fn pending_log(root: &Path) -> String {
+    read_text(&root.join("state/pending_ops.jsonl"))
+}
+
+fn setup_binding(root: &Path, ownership: &str, workspace: &Path) -> String {
+    write_example_skill(root, "model-onboarding");
+    let (save_output, _) = save_skill(root, "model-onboarding");
+    assert!(save_output.status.success(), "save should succeed");
+
+    let target_path = root.join("live/claude-project-a");
+    fs::create_dir_all(&target_path).expect("target path");
+    let (target_output, target_env) = target_add(root, "claude", &target_path, ownership);
+    assert!(target_output.status.success(), "target add should succeed");
+    let target_id = target_env["data"]["target"]["target_id"]
+        .as_str()
+        .expect("target id");
+
+    let workspace = workspace.to_string_lossy().into_owned();
+    let (binding_output, binding_env) = binding_add(
+        root,
+        "claude",
+        "default",
+        "path-prefix",
+        &workspace,
+        target_id,
+    );
+    assert!(
+        binding_output.status.success(),
+        "binding add failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&binding_output.stderr),
+        String::from_utf8_lossy(&binding_output.stdout)
+    );
+    binding_env["data"]["binding"]["binding_id"]
+        .as_str()
+        .expect("binding id")
+        .to_string()
+}
+
+#[test]
+fn agent_preflight_resolves_selectors_without_registry_operation() {
+    let root = TestDir::new("agent-preflight-ready");
+    let workspace = root.path().join("work/project-a");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let binding_id = setup_binding(root.path(), "managed", &workspace);
+    let operations_before = operations_log(root.path());
+
+    let workspace_arg = workspace.to_string_lossy().into_owned();
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "agent",
+            "preflight",
+            "--agent",
+            "claude",
+            "--workspace",
+            &workspace_arg,
+            "--skill",
+            "model-onboarding",
+        ],
+    );
+
+    assert!(output.status.success(), "preflight should succeed");
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert_eq!(env["data"]["safe_to_run"], Value::Bool(true));
+    assert_eq!(
+        env["data"]["required_selectors"]["binding_id"],
+        Value::String(binding_id)
+    );
+    assert!(
+        env["data"]["next_commands"][0]
+            .as_str()
+            .expect("next command")
+            .contains("skill project model-onboarding")
+    );
+    assert_eq!(operations_log(root.path()), operations_before);
+}
+
+#[test]
+fn agent_preflight_reports_ambiguous_workspace_binding() {
+    let root = TestDir::new("agent-preflight-ambiguous");
+    let workspace = root.path().join("work/project-a");
+    fs::create_dir_all(&workspace).expect("workspace");
+    setup_binding(root.path(), "managed", &workspace);
+
+    let second_target = root.path().join("live/claude-project-b");
+    let (target_output, target_env) = target_add(root.path(), "claude", &second_target, "managed");
+    assert!(
+        target_output.status.success(),
+        "second target add should succeed"
+    );
+    let target_id = target_env["data"]["target"]["target_id"]
+        .as_str()
+        .expect("target id");
+    let workspace_arg = workspace.to_string_lossy().into_owned();
+    let (binding_output, _) = binding_add(
+        root.path(),
+        "claude",
+        "second",
+        "path-prefix",
+        &workspace_arg,
+        target_id,
+    );
+    assert!(
+        binding_output.status.success(),
+        "second binding add should succeed"
+    );
+
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "agent",
+            "preflight",
+            "--agent",
+            "claude",
+            "--workspace",
+            &workspace_arg,
+            "--skill",
+            "model-onboarding",
+        ],
+    );
+
+    assert!(output.status.success(), "preflight should return a plan");
+    assert_eq!(env["data"]["safe_to_run"], Value::Bool(false));
+    assert_eq!(
+        env["data"]["risks"][0]["code"],
+        Value::String("AMBIGUOUS_BINDING".to_string())
+    );
+}
+
+#[test]
+fn project_dry_run_reports_plan_without_touching_state_or_target() {
+    let root = TestDir::new("project-dry-run");
+    let workspace = root.path().join("work/project-a");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let binding_id = setup_binding(root.path(), "managed", &workspace);
+    let target_skill_path = root.path().join("live/claude-project-a/model-onboarding");
+    let operations_before = operations_log(root.path());
+    let pending_before = pending_log(root.path());
+
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            &binding_id,
+            "--dry-run",
+        ],
+    );
+
+    assert!(output.status.success(), "dry-run should succeed");
+    assert_eq!(env["data"]["dry_run"], Value::Bool(true));
+    assert_eq!(
+        env["data"]["operation"],
+        Value::String("skill.project".to_string())
+    );
+    assert_eq!(env["data"]["safe_to_run"], Value::Bool(true));
+    assert!(
+        !target_skill_path.exists(),
+        "dry-run must not materialize projection"
+    );
+    assert_eq!(operations_log(root.path()), operations_before);
+    assert_eq!(pending_log(root.path()), pending_before);
+}
+
+#[test]
+fn project_dry_run_reports_unsafe_observed_target() {
+    let root = TestDir::new("project-dry-run-observed");
+    let workspace = root.path().join("work/project-a");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let binding_id = setup_binding(root.path(), "observed", &workspace);
+
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "skill",
+            "project",
+            "model-onboarding",
+            "--binding",
+            &binding_id,
+            "--dry-run",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "dry-run should return a blocked plan"
+    );
+    assert_eq!(env["data"]["safe_to_run"], Value::Bool(false));
+    assert!(
+        env["data"]["risks"]
+            .as_array()
+            .expect("risks")
+            .iter()
+            .any(|risk| risk["code"] == "TARGET_NOT_MANAGED")
+    );
+}
+
+#[test]
+fn sync_push_dry_run_does_not_clear_pending_queue() {
+    let root = TestDir::new("sync-push-dry-run");
+    let workspace = root.path().join("work/project-a");
+    fs::create_dir_all(&workspace).expect("workspace");
+    setup_binding(root.path(), "managed", &workspace);
+    let pending_before = pending_log(root.path());
+
+    let (output, env) = run_loom(root.path(), &["sync", "push", "--dry-run"]);
+
+    assert!(
+        output.status.success(),
+        "dry-run should return a blocked plan"
+    );
+    assert_eq!(
+        env["data"]["operation"],
+        Value::String("sync.push".to_string())
+    );
+    assert_eq!(env["data"]["safe_to_run"], Value::Bool(false));
+    assert!(
+        env["data"]["risks"]
+            .as_array()
+            .expect("risks")
+            .iter()
+            .any(|risk| risk["code"] == "REMOTE_NOT_CONFIGURED")
+    );
+    assert_eq!(pending_log(root.path()), pending_before);
+}


### PR DESCRIPTION
## Summary
- add `loom agent preflight` so agents can resolve matching bindings, target paths, risks, selectors, and next commands before writing
- add `--dry-run` planning for project, capture, rollback, orphan clean, and sync push without touching registry ops, pending queue, Git refs, or live targets
- document the agent workflow and add contract tests for safe, ambiguous, unmanaged, and sync-push cases

Closes #148

## Verification
- `cargo check --locked`
- `cargo test --test agent_preflight -- --nocapture`
- `cargo test --test cli_surface --test project --test capture --test reliability --test doctor`
- `cargo test panel -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `make test`