### PR TITLE
feat: loom doctor alias + UI tooltips for pending counts

### DIFF
--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -31,35 +31,46 @@ interface TopbarProps {
   readOnly: boolean;
 }
 
-function statusDisplay(props: TopbarProps): { label: string; dotStyle: React.CSSProperties } {
+interface StatusDisplay {
+  label: string;
+  dotStyle: React.CSSProperties;
+  title: string;
+}
+
+function statusDisplay(props: TopbarProps): StatusDisplay {
   if (props.mode === "offline-stale") {
     return {
       label: "live API offline · stale snapshot",
       dotStyle: { background: "var(--err)", boxShadow: "0 0 0 3px rgba(216,90,90,0.18)" },
+      title: "Last-known registry snapshot — live API is unreachable",
     };
   }
   if (props.error) {
     return {
       label: "registry error",
       dotStyle: { background: "var(--err)", boxShadow: "0 0 0 3px rgba(216,90,90,0.18)" },
+      title: props.error,
     };
   }
   if (props.loading) {
     return {
       label: "connecting…",
       dotStyle: { background: "var(--pending)", boxShadow: "0 0 0 3px rgba(194,160,94,0.14)" },
+      title: "Connecting to the registry API",
     };
   }
   if (!props.live) {
     return {
       label: "registry offline",
       dotStyle: { background: "var(--err)", boxShadow: "0 0 0 3px rgba(216,90,90,0.18)" },
+      title: "Registry API is offline",
     };
   }
   if (props.mode === "first-run") {
     return {
       label: "registry setup required",
       dotStyle: { background: "var(--warn)", boxShadow: "0 0 0 3px rgba(230,180,80,0.18)" },
+      title: "Registry has not been initialized yet — run `loom init`",
     };
   }
   const state = (props.remoteState ?? "").toUpperCase();
@@ -67,17 +78,25 @@ function statusDisplay(props: TopbarProps): { label: string; dotStyle: React.CSS
     return {
       label: `remote ${state.toLowerCase()}`,
       dotStyle: { background: "var(--err)", boxShadow: "0 0 0 3px rgba(216,90,90,0.18)" },
+      title: "Remote and local history differ — run `loom sync pull` to reconcile",
     };
   }
   if (state === "PENDING_PUSH" || state === "LOCAL_ONLY" || props.pendingCount > 0) {
+    const opNoun = props.pendingCount === 1 ? "operation" : "operations";
+    const title =
+      state === "LOCAL_ONLY"
+        ? `${props.pendingCount} ${opNoun} queued — no Git remote configured. Run \`loom workspace remote set\` to enable push.`
+        : `${props.pendingCount} ${opNoun} queued for push to the Git remote`;
     return {
       label: props.pendingCount > 0 ? `${props.pendingCount} pending` : state.toLowerCase().replace("_", " "),
       dotStyle: { background: "var(--warn)", boxShadow: "0 0 0 3px rgba(230,180,80,0.18)" },
+      title,
     };
   }
   return {
     label: "registry clean",
     dotStyle: { background: "var(--ok)", boxShadow: "0 0 0 3px rgba(111,183,138,0.14)" },
+    title: "Registry is in sync with the Git remote",
   };
 }
 
@@ -120,7 +139,7 @@ export function Topbar(props: TopbarProps) {
       </div>
       <div className="spacer" />
       <div className="top-actions">
-        <span className="top-btn" title={props.error ?? undefined}>
+        <span className="top-btn" title={status.title}>
           <span className="status-dot" style={status.dotStyle} /> {status.label}
         </span>
         <span className="top-btn" title={props.live ? "remote sync state" : "registry offline"}>
@@ -131,7 +150,12 @@ export function Topbar(props: TopbarProps) {
             className="top-btn"
             onClick={replay}
             disabled={replaying || props.readOnly}
-            title={replayError ?? (props.readOnly ? "registry offline" : undefined)}
+            title={
+              replayError ??
+              (props.readOnly
+                ? "registry offline"
+                : `Push ${props.pendingCount} queued operation${props.pendingCount === 1 ? "" : "s"} to the Git remote`)
+            }
           >
             <PlayIcon /> {replaying ? "replaying…" : `Replay ${props.pendingCount}`}
           </button>

--- a/panel/src/pages/panel/DoctorPage.tsx
+++ b/panel/src/pages/panel/DoctorPage.tsx
@@ -76,9 +76,19 @@ export function DoctorPage({ live, mode, refreshKey }: DoctorPageProps) {
             label="Health"
             value={state.kind === "ready" ? (state.payload.healthy ? "healthy" : "attention") : state.kind}
             tone={state.kind === "ready" && !state.payload.healthy ? "err" : undefined}
+            title="Aggregate doctor verdict across git, registry, history, queue, and target checks"
           />
-          <Kpi label="Checks" value={checks.length} />
-          <Kpi label="Needs action" value={failed.length} tone={failed.length > 0 ? "pending" : undefined} />
+          <Kpi
+            label="Checks"
+            value={checks.length}
+            title="Total registry integrity probes executed by `loom workspace doctor`"
+          />
+          <Kpi
+            label="Needs action"
+            value={failed.length}
+            tone={failed.length > 0 ? "pending" : undefined}
+            title="Doctor checks reporting a failure. Independent from sync pending counts shown in the top bar."
+          />
         </div>
 
         {state.kind === "loading" && <div className="empty mono">loading...</div>}
@@ -207,10 +217,20 @@ function sectionLabel(section: string): string {
   return section.replace(/_/g, " ");
 }
 
-function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {
+function Kpi({
+  label,
+  value,
+  tone,
+  title,
+}: {
+  label: string;
+  value: string | number;
+  tone?: "pending" | "err";
+  title?: string;
+}) {
   const color = tone === "pending" ? "var(--pending)" : tone === "err" ? "var(--err)" : "var(--ink-0)";
   return (
-    <div className="kpi">
+    <div className="kpi" title={title}>
       <div className="label">{label}</div>
       <div className="value" style={{ color }}>
         {value}

--- a/panel/src/pages/panel/OpsPage.tsx
+++ b/panel/src/pages/panel/OpsPage.tsx
@@ -95,7 +95,10 @@ export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
       )}
       <div className="page-body">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 18 }}>
-          <div className="card">
+          <div
+            className="card"
+            title="Total operation history recorded by the registry — includes done, failed, and pending. The top-bar pending count tracks only the unpushed subset."
+          >
             <div className="card-body">
               <div style={section_label}>Tracked changes</div>
               <div style={{ fontFamily: "var(--font-display)", fontSize: 24 }}>{counts.all}</div>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,13 +59,15 @@ pub enum Command {
         #[command(subcommand)]
         command: OpsCommand,
     },
-    #[command(about = "Plan safe agent automation before mutating state")]
+    #[command(about = "Plan safe agent automation before mutating state. Requires an existing workspace binding (`loom workspace binding add`) so preflight knows which target to project into.")]
     Agent {
         #[command(subcommand)]
         command: AgentCommand,
     },
     #[command(about = "Serve the local registry control panel")]
     Panel(PanelArgs),
+    #[command(about = "Run registry integrity, history, and projection checks (alias for `workspace doctor`)")]
+    Doctor,
 }
 
 #[derive(Debug, Clone, Subcommand, Serialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,14 +59,18 @@ pub enum Command {
         #[command(subcommand)]
         command: OpsCommand,
     },
-    #[command(about = "Plan safe agent automation before mutating state. Requires an existing workspace binding (`loom workspace binding add`) so preflight knows which target to project into.")]
+    #[command(
+        about = "Plan safe agent automation before mutating state. Requires an existing workspace binding (`loom workspace binding add`) so preflight knows which target to project into."
+    )]
     Agent {
         #[command(subcommand)]
         command: AgentCommand,
     },
     #[command(about = "Serve the local registry control panel")]
     Panel(PanelArgs),
-    #[command(about = "Run registry integrity, history, and projection checks (alias for `workspace doctor`)")]
+    #[command(
+        about = "Run registry integrity, history, and projection checks (alias for `workspace doctor`)"
+    )]
     Doctor,
 }
 

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -96,6 +96,7 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
     match command {
         Command::Init => "init",
         Command::Monitor(_) => "monitor",
+        Command::Doctor => "workspace.doctor",
         Command::Workspace { command } => match command {
             WorkspaceCommand::Status => "workspace.status",
             WorkspaceCommand::Doctor => "workspace.doctor",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -157,6 +157,7 @@ impl App {
                 self.cmd_workspace_init(&args, &request_id)
             }
             Command::Monitor(args) => self.cmd_monitor_observed(args, &request_id),
+            Command::Doctor => self.cmd_doctor(),
             Command::Workspace { command } => match command {
                 WorkspaceCommand::Status => self.cmd_status(),
                 WorkspaceCommand::Doctor => self.cmd_doctor(),
@@ -316,6 +317,7 @@ fn command_records_audit(command: &Command) -> bool {
 fn command_requires_durable_audit(command: &Command) -> bool {
     match command {
         Command::Init | Command::Monitor(_) => true,
+        Command::Doctor => false,
         Command::Workspace { command } => match command {
             WorkspaceCommand::Status | WorkspaceCommand::Doctor => false,
             WorkspaceCommand::Init(_) => true,

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -309,8 +309,7 @@ fn loom_doctor_alias_dispatches_to_workspace_doctor() {
     let root = TestDir::new("doctor-alias-dispatch");
 
     let (aliased_output, aliased_env) = run_loom(root.path(), &["doctor"]);
-    let (canonical_output, canonical_env) =
-        run_loom(root.path(), &["workspace", "doctor"]);
+    let (canonical_output, canonical_env) = run_loom(root.path(), &["workspace", "doctor"]);
 
     assert!(
         aliased_output.status.success(),

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -303,3 +303,30 @@ fn workspace_doctor_agent_skill_inventory_when_home_unset() {
     assert_eq!(inventory["details"]["home_set"], Value::Bool(false));
     assert_eq!(inventory["details"]["total"], Value::from(0));
 }
+
+#[test]
+fn loom_doctor_alias_dispatches_to_workspace_doctor() {
+    let root = TestDir::new("doctor-alias-dispatch");
+
+    let (aliased_output, aliased_env) = run_loom(root.path(), &["doctor"]);
+    let (canonical_output, canonical_env) =
+        run_loom(root.path(), &["workspace", "doctor"]);
+
+    assert!(
+        aliased_output.status.success(),
+        "loom doctor failed: stderr={}",
+        String::from_utf8_lossy(&aliased_output.stderr)
+    );
+    assert!(canonical_output.status.success());
+
+    assert_eq!(
+        aliased_env["cmd"],
+        Value::String("workspace.doctor".to_string()),
+        "alias must report the same audit cmd name as the canonical invocation"
+    );
+    assert_eq!(aliased_env["cmd"], canonical_env["cmd"]);
+    assert_eq!(
+        aliased_env["data"]["healthy"], canonical_env["data"]["healthy"],
+        "alias and canonical must produce the same doctor verdict on the same registry"
+    );
+}


### PR DESCRIPTION
## Summary

Three small UX fixes uncovered while dogfooding `main` end-to-end:

- **`loom doctor` top-level alias** — discoverable from `loom --help`, dispatches to `workspace doctor`. Audit envelope keeps `cmd: workspace.doctor` so agent automation is untouched.
- **Agent preflight help** — `loom agent --help` now states up-front that preflight requires an existing workspace binding (`loom workspace binding add`), so first-time users don't hit the missing-binding error.
- **Panel pending-count tooltips** — top-bar status badge, Doctor KPIs, and Activity `Tracked changes` card now expose hover tooltips that disambiguate the three different \"pending\" surfaces:
  - Top bar (`N pending`) = operations queued for git push
  - Doctor (`Needs action`) = doctor check failures (independent from sync)
  - Activity (`Tracked changes`) = total op history (done + failed + pending)

Integration test asserts the new alias and the canonical `workspace doctor` invocation share the same \`cmd\` and verdict on the same registry.

## Test plan

- [x] \`cargo nextest run --workspace\` — **261/261 passed** (260 existing + 1 new)
- [x] \`cargo build --release\` — succeeds, binary 1.8 MB
- [x] \`npx tsc --noEmit\` — exit 0
- [x] \`npx vitest run\` — **44/44 passed**
- [x] \`npx vite build\` — succeeds, panel.js gzip 27.75 KB (+0.44 KB)
- [x] Manual: \`loom doctor\` on fresh registry returns same envelope as \`loom workspace doctor\`
- [x] Manual: hovered top-bar \`3 pending\` badge in browser, tooltip reads \"3 operations queued — no Git remote configured. Run \\\`loom workspace remote set\\\` to enable push.\"
- [x] Manual: hovered Doctor \"Needs action\" KPI, tooltip reads \"Doctor checks reporting a failure. Independent from sync pending counts shown in the top bar.\"

## Scope

- 7 files changed, +88/-9
- No API/contract changes — \`cmd\` field in JSON envelope is unchanged
- No data migrations