### PR TITLE
Fix unresolved review followups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /panel
     schedule:
       interval: weekly

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ panel-typecheck:
 e2e:
 	./scripts/e2e-agent-flow.sh
 
-perf-smoke:
+perf-smoke: panel-build
 	cargo build --release --locked
 	./scripts/perf-smoke.sh
 

--- a/panel/src/lib/api/adapters.test.ts
+++ b/panel/src/lib/api/adapters.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { adaptRegistryOperation } from "./adapters";
+import type { RegistryOperationRecord } from "./client";
+
+function operation(overrides: Partial<RegistryOperationRecord> = {}): RegistryOperationRecord {
+  return {
+    op_id: "op-1",
+    intent: "skill.save",
+    status: "succeeded",
+    ack: false,
+    created_at: "2026-05-29T00:00:00Z",
+    updated_at: "2026-05-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("adaptRegistryOperation", () => {
+  it("treats succeeded registry rows as complete even before sync ack", () => {
+    expect(adaptRegistryOperation(operation()).status).toBe("ok");
+  });
+
+  it("keeps queued rows pending and failed rows errored", () => {
+    expect(adaptRegistryOperation(operation({ status: "pending" })).status).toBe("pending");
+    expect(
+      adaptRegistryOperation(
+        operation({ status: "succeeded", last_error: { code: "IO_ERROR", message: "failed" } }),
+      ).status,
+    ).toBe("err");
+  });
+});

--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -206,7 +206,7 @@ export function adaptRegistryOperation(op: RegistryOperationRecord): Op {
 function operationStatus(op: RegistryOperationRecord): Op["status"] {
   const status = op.status.toLowerCase();
   if (op.last_error || status === "failed" || status === "error") return "err";
-  if (!op.ack || status === "pending" || status === "queued") return "pending";
+  if (status === "pending" || status === "queued") return "pending";
   return "ok";
 }
 

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -170,6 +170,7 @@ export function PanelApp() {
             skills={skills}
             targets={targets}
             bindings={bindings}
+            projections={live.projections}
             selectedSkill={selectedSkill}
             onSelectSkill={(id) => setSelectedSkill(id)}
             onMutation={onMutation}
@@ -234,6 +235,7 @@ export function PanelApp() {
             remote={live.remote}
             pendingCount={live.pendingCount}
             registryRoot={live.registryRoot}
+            refreshKey={live.lastUpdated}
             readOnly={readOnly}
             onMutation={onMutation}
           />

--- a/panel/src/pages/panel/PanelOperationLoop.test.tsx
+++ b/panel/src/pages/panel/PanelOperationLoop.test.tsx
@@ -255,3 +255,48 @@ test("SyncPage surfaces history repair actions", async () => {
     api.opsHistoryRepair = originalRepair;
   }
 });
+
+test("SyncPage re-runs history diagnose when refreshed data arrives", async () => {
+  const originalDiagnose = api.opsHistoryDiagnose;
+  let diagnoseCalls = 0;
+  api.opsHistoryDiagnose = async () => {
+    diagnoseCalls += 1;
+    return historyDiagnosePayload(diagnoseCalls === 1 ? 1 : 0);
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <SyncPage
+          remote={{ configured: true, url: "git@example.com:loom.git", ahead: 0, behind: 0, sync_state: "clean" }}
+          pendingCount={0}
+          registryRoot="/tmp/loom"
+          refreshKey="first"
+          readOnly={false}
+          onMutation={() => {}}
+        />,
+      );
+    });
+    await flush();
+    expect(diagnoseCalls).toBe(1);
+
+    await act(async () => {
+      renderer!.update(
+        <SyncPage
+          remote={{ configured: true, url: "git@example.com:loom.git", ahead: 0, behind: 0, sync_state: "clean" }}
+          pendingCount={0}
+          registryRoot="/tmp/loom"
+          refreshKey="second"
+          readOnly={false}
+          onMutation={() => {}}
+        />,
+      );
+    });
+    await flush();
+
+    expect(diagnoseCalls).toBe(2);
+  } finally {
+    api.opsHistoryDiagnose = originalDiagnose;
+  }
+});

--- a/panel/src/pages/panel/SkillLifecycle.tsx
+++ b/panel/src/pages/panel/SkillLifecycle.tsx
@@ -1,0 +1,375 @@
+import { useEffect, useState, type CSSProperties, type FormEvent } from "react";
+import { api, type RegistryObservationEvent, type SkillDiffFile } from "../../lib/api/client";
+import { useMutation } from "../../lib/useMutation";
+
+export interface LifecycleEvent {
+  kind: "release" | "capture" | "save" | "snapshot" | "project" | "rollback";
+  v: string;
+  time: string;
+  who: string;
+  desc: string;
+}
+
+const KIND_COLOR: Record<LifecycleEvent["kind"], string> = {
+  release: "var(--accent)",
+  capture: "var(--pending)",
+  save: "var(--ink-2)",
+  snapshot: "var(--warn)",
+  project: "var(--ok)",
+  rollback: "var(--err)",
+};
+
+const KIND_MAP: Record<string, LifecycleEvent["kind"]> = {
+  captured: "capture",
+  projected: "project",
+  rollback: "rollback",
+  monitor: "save",
+  snapshot: "snapshot",
+  released: "release",
+  saved: "save",
+  file_changed: "save",
+  health_changed: "snapshot",
+};
+
+export function mapObsToLifecycle(ev: RegistryObservationEvent): LifecycleEvent {
+  return {
+    kind: KIND_MAP[ev.kind] ?? "capture",
+    v: ev.event_id.slice(0, 8),
+    time: toRelative(ev.observed_at),
+    who: ev.instance_id.slice(0, 8),
+    desc: ev.path ?? (ev.from && ev.to ? `${ev.from} -> ${ev.to}` : ev.kind),
+  };
+}
+
+export function LifecycleActions({
+  skillName,
+  onMutation,
+  readOnly,
+}: {
+  skillName: string;
+  onMutation: () => void;
+  readOnly: boolean;
+}) {
+  const [version, setVersion] = useState("");
+  const [rollbackRef, setRollbackRef] = useState("");
+  const save = useMutation();
+  const snapshot = useMutation();
+  const release = useMutation();
+  const rollback = useMutation();
+
+  const runSave = () => {
+    save.run("skill save", () => api.skillSave(skillName), onMutation);
+  };
+
+  const runSnapshot = () => {
+    snapshot.run("skill snapshot", () => api.skillSnapshot(skillName), onMutation);
+  };
+
+  const submitRelease = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = version.trim();
+    if (!trimmed) return;
+    release.run("skill release", () => api.skillRelease(skillName, { version: trimmed }), () => {
+      setVersion("");
+      onMutation();
+    });
+  };
+
+  const submitRollback = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = rollbackRef.trim();
+    rollback.run(
+      "skill rollback",
+      () => api.skillRollback(skillName, trimmed ? { to: trimmed } : {}),
+      () => {
+        setRollbackRef("");
+        onMutation();
+      },
+    );
+  };
+
+  const busy = save.busy || snapshot.busy || release.busy || rollback.busy;
+  const disabled = readOnly || busy;
+  const status =
+    save.error ??
+    snapshot.error ??
+    release.error ??
+    rollback.error ??
+    save.success ??
+    snapshot.success ??
+    release.success ??
+    rollback.success;
+  const hasError = Boolean(save.error ?? snapshot.error ?? release.error ?? rollback.error);
+
+  return (
+    <div className="card" style={{ padding: 12, margin: "14px 0" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))", gap: 10 }}>
+        <button
+          className="btn ghost"
+          onClick={runSave}
+          disabled={disabled}
+          title={readOnly ? "registry offline" : undefined}
+          style={fullWidthButtonStyle}
+        >
+          {save.busy ? "saving..." : "Save"}
+        </button>
+        <button
+          className="btn ghost"
+          onClick={runSnapshot}
+          disabled={disabled}
+          title={readOnly ? "registry offline" : undefined}
+          style={fullWidthButtonStyle}
+        >
+          {snapshot.busy ? "snapshotting..." : "Snapshot"}
+        </button>
+        <form onSubmit={submitRelease} style={{ display: "flex", gap: 8, minWidth: 0 }}>
+          <input
+            value={version}
+            onChange={(event) => setVersion(event.target.value)}
+            placeholder="version"
+            style={formInputStyle}
+            disabled={disabled}
+          />
+          <button className="btn primary" type="submit" disabled={disabled || !version.trim()}>
+            {release.busy ? "releasing..." : "Release"}
+          </button>
+        </form>
+        <form onSubmit={submitRollback} style={{ display: "flex", gap: 8, minWidth: 0 }}>
+          <input
+            value={rollbackRef}
+            onChange={(event) => setRollbackRef(event.target.value)}
+            placeholder="HEAD~1"
+            style={formInputStyle}
+            disabled={disabled}
+          />
+          <button className="btn ghost danger" type="submit" disabled={disabled}>
+            {rollback.busy ? "rolling back..." : "Rollback"}
+          </button>
+        </form>
+      </div>
+      {status && <div style={hasError ? errorStyle : okStyle}>{hasError ? status : `✓ ${status}`}</div>}
+    </div>
+  );
+}
+
+export function Lifecycle({ events, skillName }: { events: LifecycleEvent[]; skillName: string }) {
+  if (events.length === 0) {
+    return (
+      <div style={{ padding: "18px 4px", fontSize: 12, color: "var(--ink-2)" }}>
+        <div style={{ marginBottom: 6 }}>No lifecycle events yet.</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+          Run <span style={{ color: "var(--ink-1)" }}>loom capture {skillName}</span> to start the chain.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ position: "relative", paddingLeft: 22 }}>
+      <div style={{ position: "absolute", left: 7, top: 4, bottom: 4, width: 1, background: "var(--line)" }} />
+      {events.map((e, i) => (
+        <div key={i} style={{ position: "relative", marginBottom: 14 }}>
+          <div
+            style={{
+              position: "absolute",
+              left: -22,
+              top: 4,
+              width: 15,
+              height: 15,
+              borderRadius: 8,
+              background: "var(--bg-0)",
+              border: `2px solid ${KIND_COLOR[e.kind]}`,
+            }}
+          />
+          <div style={{ fontSize: 12 }}>
+            <span style={{ color: "var(--ink-0)", fontWeight: 500 }}>{e.kind}</span>
+            <span className="mono" style={{ color: "var(--ink-2)", marginLeft: 6 }}>
+              {e.v}
+            </span>
+            <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
+              by {e.who} · {e.time}
+            </span>
+          </div>
+          <div style={{ fontSize: 11.5, color: "var(--ink-2)", marginTop: 2 }}>{e.desc}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function SkillDiff({ skillName }: { skillName: string }) {
+  const [revA, setRevA] = useState("");
+  const [revB, setRevB] = useState("");
+  const [files, setFiles] = useState<SkillDiffFile[] | null>(null);
+  const [header, setHeader] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+    api
+      .skillDiff(skillName, revA || undefined, revB || undefined, ctrl.signal)
+      .then((payload) => {
+        if (payload.data) {
+          setFiles(payload.data.files);
+          setHeader(`${payload.data.rev_a.slice(0, 7)} -> ${payload.data.rev_b.slice(0, 7)}`);
+        }
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (err.name !== "AbortError") {
+          setError(err.message);
+          setFiles(null);
+          setHeader("");
+          setLoading(false);
+        }
+      });
+    return () => ctrl.abort();
+  }, [skillName, revA, revB]);
+
+  const inputStyle: CSSProperties = {
+    fontSize: 11,
+    padding: "2px 6px",
+    background: "var(--bg-1)",
+    border: "1px solid var(--line)",
+    borderRadius: 4,
+    color: "var(--ink-0)",
+    width: 130,
+    fontFamily: "var(--font-mono)",
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+        <input
+          style={inputStyle}
+          placeholder="rev_a"
+          value={revA}
+          onChange={(e) => setRevA(e.target.value)}
+        />
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{"->"}</span>
+        <input
+          style={inputStyle}
+          placeholder="rev_b"
+          value={revB}
+          onChange={(e) => setRevB(e.target.value)}
+        />
+      </div>
+
+      {loading && <div style={{ color: "var(--ink-3)", fontSize: 12 }}>Loading...</div>}
+      {error && (
+        <div style={{ color: "var(--err)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && files !== null && (
+        <>
+          {header && <div className="section-title">{header}</div>}
+          {files.length === 0 ? (
+            <div style={{ color: "var(--ink-3)", fontSize: 12 }}>
+              No changes in skills/{skillName}/
+            </div>
+          ) : (
+            files.map((file) => (
+              <div key={file.path} style={{ marginBottom: 16 }}>
+                <div
+                  className="mono"
+                  style={{ fontSize: 11, color: "var(--ink-2)", marginBottom: 4 }}
+                >
+                  {file.path}{" "}
+                  <span style={{ color: "var(--ok)" }}>+{file.added}</span>{" "}
+                  <span style={{ color: "var(--err)" }}>-{file.removed}</span>
+                  {file.truncated && (
+                    <span
+                      title={
+                        `${file.truncated_lines ?? 0} hidden diff line(s); narrow the revision range.`
+                      }
+                      style={{
+                        marginLeft: 8,
+                        padding: "0 6px",
+                        borderRadius: 3,
+                        background: "var(--bg-2)",
+                        color: "var(--warn, var(--ink-3))",
+                        fontSize: 10,
+                      }}
+                    >
+                      truncated +{file.truncated_lines ?? 0}
+                    </span>
+                  )}
+                </div>
+                <div style={{ border: "1px solid var(--line)", borderRadius: 6, overflow: "hidden" }}>
+                  {file.hunks.map((hunk, hi) => (
+                    <div key={hi}>
+                      <div className="diff-row" style={{ background: "var(--bg-1)" }}>
+                        <div className="mark" />
+                        <div className="l" style={{ color: "var(--ink-3)" }}>{hunk.header}</div>
+                      </div>
+                      {hunk.lines.map((line, li) => (
+                        <div
+                          key={li}
+                          className={`diff-row${line.startsWith("+") ? " add" : line.startsWith("-") ? " del" : ""}`}
+                        >
+                          <div className="mark">
+                            {line.startsWith("+") ? "+" : line.startsWith("-") ? "-" : ""}
+                          </div>
+                          <div className="l">{line.slice(1)}</div>
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function toRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+const formInputStyle: CSSProperties = {
+  padding: "6px 10px",
+  borderRadius: 6,
+  border: "1px solid var(--line-hi)",
+  background: "var(--bg-2)",
+  color: "var(--ink-0)",
+  fontSize: 12,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const fullWidthButtonStyle: CSSProperties = {
+  width: "100%",
+  justifyContent: "center",
+};
+
+const errorStyle: CSSProperties = {
+  marginTop: 10,
+  padding: "6px 10px",
+  color: "var(--err)",
+  background: "rgba(216,90,90,0.08)",
+  border: "1px solid rgba(216,90,90,0.3)",
+  borderRadius: 6,
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+};
+
+const okStyle: CSSProperties = {
+  ...errorStyle,
+  color: "var(--ok)",
+  background: "rgba(111,183,138,0.08)",
+  border: "1px solid rgba(111,183,138,0.3)",
+};

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SkillsPage } from "./SkillsPage";
 import type { Binding, Skill, Target } from "../../lib/types";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
 
 vi.mock("../../lib/api/client", () => ({
   api: {
@@ -43,12 +44,20 @@ const mockBinding: Binding = {
   policy: "auto",
 };
 
-function renderPage(overrides: { onMutation?: () => void; bindings?: Binding[]; targets?: Target[] } = {}) {
+function renderPage(
+  overrides: {
+    onMutation?: () => void;
+    bindings?: Binding[];
+    targets?: Target[];
+    projections?: RegistryProjection[];
+  } = {},
+) {
   return render(
     <SkillsPage
       skills={[mockSkill]}
       targets={overrides.targets ?? []}
       bindings={overrides.bindings ?? []}
+      projections={overrides.projections ?? []}
       selectedSkill="skill-1"
       onSelectSkill={() => {}}
       onMutation={overrides.onMutation ?? (() => {})}
@@ -130,6 +139,32 @@ describe("SkillsPage — capture action", () => {
     renderPage();
 
     expect(screen.getByRole("button", { name: "Capture" })).toBeDisabled();
+  });
+
+  it("derives capture choices from projections when bindings are shared across skills", async () => {
+    const onMutation = vi.fn();
+    const projection: RegistryProjection = {
+      instance_id: "inst-1",
+      skill_id: "my-skill",
+      binding_id: "shared-binding",
+      target_id: "target-1",
+      materialized_path: "/tmp/target-1/my-skill",
+      method: "copy",
+      last_applied_rev: "abc12345",
+      health: "healthy",
+    };
+    renderPage({
+      bindings: [{ ...mockBinding, id: "shared-binding", skill: "other-skill" }],
+      projections: [projection],
+      onMutation,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture" }));
+
+    await waitFor(() => {
+      expect(api.capture).toHaveBeenCalledWith({ skill: "my-skill", binding: "shared-binding" });
+      expect(onMutation).toHaveBeenCalledTimes(1);
+    });
   });
 });
 
@@ -320,6 +355,25 @@ describe("SkillsPage — lifecycle actions", () => {
     await waitFor(() => {
       expect(api.skillRollback).toHaveBeenCalledWith("my-skill", { to: "snapshot/my-skill/abc" });
       expect(onMutation).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  it("refetches lifecycle history after successful lifecycle mutations", async () => {
+    (api.skillHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      data: { skill: "my-skill", count: 0, events: [] },
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(api.skillHistory).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("version"), { target: { value: "v1.2.3" } });
+    fireEvent.click(screen.getByRole("button", { name: "Release" }));
+
+    await waitFor(() => {
+      expect(api.skillHistory).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -1,29 +1,47 @@
 import { useEffect, useState } from "react";
 import type { Binding, Skill, Target } from "../../lib/types";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon, SearchIcon } from "../../components/icons/nav_icons";
-import { api, type SkillDiffFile, type RegistryObservationEvent } from "../../lib/api/client";
+import { api } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
+import {
+  Lifecycle,
+  LifecycleActions,
+  SkillDiff,
+  mapObsToLifecycle,
+  type LifecycleEvent,
+} from "./SkillLifecycle";
 
 interface SkillsPageProps {
   skills: Skill[];
   targets: Target[];
   bindings?: Binding[];
+  projections?: RegistryProjection[];
   selectedSkill: string | null;
   onSelectSkill: (id: string) => void;
   onMutation: () => void;
   readOnly: boolean;
 }
 
-export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSelectSkill, onMutation, readOnly }: SkillsPageProps) {
+export function SkillsPage({
+  skills,
+  targets,
+  bindings = [],
+  projections = [],
+  selectedSkill,
+  onSelectSkill,
+  onMutation,
+  readOnly,
+}: SkillsPageProps) {
   const [q, setQ] = useState("");
   const [addOpen, setAddOpen] = useState(false);
   const [captureBindingId, setCaptureBindingId] = useState("");
   const filtered = skills.filter((s) => s.name.includes(q) || s.tag.includes(q));
   const sel = skills.find((s) => s.id === selectedSkill) ?? skills[0];
   const capture = useMutation();
-  const selectedSkillBindings = sel ? bindings.filter((b) => b.skill === sel.name) : [];
-  const bindingOptionKey = selectedSkillBindings.map((b) => b.id).join("\u001f");
+  const selectedSkillBindings = sel ? captureBindingsForSkill(sel.name, bindings, projections) : [];
+  const bindingOptionKey = selectedSkillBindings.map((b) => `${b.id}\u001f${b.target}\u001f${b.method}`).join("\u001e");
   const captureBinding = selectedSkillBindings.find((b) => b.id === captureBindingId) ?? null;
   const captureDisabled = capture.busy || readOnly || !sel || !captureBinding;
   const captureTitle = readOnly
@@ -31,7 +49,7 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
     : !sel
       ? "select a skill first"
       : !captureBinding
-        ? "capture requires a projected binding"
+        ? "projection required"
         : undefined;
 
   useEffect(() => {
@@ -45,7 +63,7 @@ export function SkillsPage({ skills, targets, bindings = [], selectedSkill, onSe
   }, [bindingOptionKey]);
 
   const emptyMessage: React.ReactNode = readOnly
-    ? "Live registry API is offline. Start the panel backend to load real skills."
+    ? "Registry API offline."
     : q
     ? "No skills match the current filter."
     : (
@@ -246,6 +264,20 @@ function summarizePolicy(skillBindings: Binding[]): string {
   return kinds.map((k) => `${counts[k]} ${k}`).join(" · ");
 }
 
+function captureBindingsForSkill(
+  skillName: string,
+  bindings: Binding[],
+  projections: RegistryProjection[],
+): Binding[] {
+  return bindings.filter(
+    (binding) =>
+      binding.skill === skillName ||
+      projections.some(
+        (projection) => projection.skill_id === skillName && projection.binding_id === binding.id,
+      ),
+  );
+}
+
 function formatSkillTags(skill: Skill): string {
   const tags = [
     ...skill.releaseTags.map((tag) => `release:${tag}`),
@@ -278,57 +310,6 @@ const captureSelectStyle = {
 
 type DetailTab = "history" | "diff" | "targets";
 
-interface LifecycleEvent {
-  kind: "release" | "capture" | "save" | "snapshot" | "project" | "rollback";
-  v: string;
-  time: string;
-  who: string;
-  desc: string;
-}
-
-const KIND_COLOR: Record<LifecycleEvent["kind"], string> = {
-  release: "var(--accent)",
-  capture: "var(--pending)",
-  save: "var(--ink-2)",
-  snapshot: "var(--warn)",
-  project: "var(--ok)",
-  rollback: "var(--err)",
-};
-
-const KIND_MAP: Record<string, LifecycleEvent["kind"]> = {
-  captured: "capture",
-  projected: "project",
-  rollback: "rollback",
-  monitor: "save",
-  snapshot: "snapshot",
-  released: "release",
-  saved: "save",
-  file_changed: "save",
-  health_changed: "snapshot",
-};
-
-function toRelative(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
-
-function mapObsToLifecycle(ev: RegistryObservationEvent): LifecycleEvent {
-  return {
-    kind: KIND_MAP[ev.kind] ?? "capture",
-    v: ev.event_id.slice(0, 8),
-    time: toRelative(ev.observed_at),
-    who: ev.instance_id.slice(0, 8),
-    desc: ev.path ?? (ev.from && ev.to ? `${ev.from} → ${ev.to}` : ev.kind),
-  };
-}
-
-
 function SkillDetail({
   skill,
   targets,
@@ -346,6 +327,7 @@ function SkillDetail({
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [historyEvents, setHistoryEvents] = useState<LifecycleEvent[]>([]);
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
 
   const targetObjs = skill.targets
     .map((tid) => targets.find((t) => t.id === tid))
@@ -372,7 +354,12 @@ function SkillDetail({
         }
       });
     return () => ctrl.abort();
-  }, [skill.name, skill.latestRev, tab]);
+  }, [skill.name, skill.latestRev, tab, historyRefreshKey]);
+
+  const onLifecycleMutation = () => {
+    setHistoryRefreshKey((value) => value + 1);
+    onMutation();
+  };
 
   return (
     <div className="detail">
@@ -393,7 +380,7 @@ function SkillDetail({
         <div className="v">{policyLabel}</div>
       </div>
 
-      <LifecycleActions skillName={skill.name} onMutation={onMutation} readOnly={readOnly} />
+      <LifecycleActions skillName={skill.name} onMutation={onLifecycleMutation} readOnly={readOnly} />
 
       <div className="tabs">
         <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")}>
@@ -433,297 +420,6 @@ function SkillDetail({
             readOnly={readOnly}
           />
           <TargetsTab targets={targetObjs} />
-        </>
-      )}
-    </div>
-  );
-}
-
-function LifecycleActions({
-  skillName,
-  onMutation,
-  readOnly,
-}: {
-  skillName: string;
-  onMutation: () => void;
-  readOnly: boolean;
-}) {
-  const [version, setVersion] = useState("");
-  const [rollbackRef, setRollbackRef] = useState("");
-  const save = useMutation();
-  const snapshot = useMutation();
-  const release = useMutation();
-  const rollback = useMutation();
-
-  const runSave = () => {
-    save.run("skill save", () => api.skillSave(skillName), onMutation);
-  };
-
-  const runSnapshot = () => {
-    snapshot.run("skill snapshot", () => api.skillSnapshot(skillName), onMutation);
-  };
-
-  const submitRelease = (event: React.FormEvent) => {
-    event.preventDefault();
-    const trimmed = version.trim();
-    if (!trimmed) return;
-    release.run("skill release", () => api.skillRelease(skillName, { version: trimmed }), () => {
-      setVersion("");
-      onMutation();
-    });
-  };
-
-  const submitRollback = (event: React.FormEvent) => {
-    event.preventDefault();
-    const trimmed = rollbackRef.trim();
-    rollback.run(
-      "skill rollback",
-      () => api.skillRollback(skillName, trimmed ? { to: trimmed } : {}),
-      () => {
-        setRollbackRef("");
-        onMutation();
-      },
-    );
-  };
-
-  const busy = save.busy || snapshot.busy || release.busy || rollback.busy;
-  const disabled = readOnly || busy;
-  const status =
-    save.error ??
-    snapshot.error ??
-    release.error ??
-    rollback.error ??
-    save.success ??
-    snapshot.success ??
-    release.success ??
-    rollback.success;
-  const hasError = Boolean(save.error ?? snapshot.error ?? release.error ?? rollback.error);
-
-  return (
-    <div className="card" style={{ padding: 12, margin: "14px 0" }}>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))", gap: 10 }}>
-        <button
-          className="btn ghost"
-          onClick={runSave}
-          disabled={disabled}
-          title={readOnly ? "registry offline" : undefined}
-          style={fullWidthButtonStyle}
-        >
-          {save.busy ? "saving..." : "Save"}
-        </button>
-        <button
-          className="btn ghost"
-          onClick={runSnapshot}
-          disabled={disabled}
-          title={readOnly ? "registry offline" : undefined}
-          style={fullWidthButtonStyle}
-        >
-          {snapshot.busy ? "snapshotting..." : "Snapshot"}
-        </button>
-        <form onSubmit={submitRelease} style={{ display: "flex", gap: 8, minWidth: 0 }}>
-          <input
-            value={version}
-            onChange={(event) => setVersion(event.target.value)}
-            placeholder="version"
-            style={formInputStyle}
-            disabled={disabled}
-          />
-          <button className="btn primary" type="submit" disabled={disabled || !version.trim()}>
-            {release.busy ? "releasing..." : "Release"}
-          </button>
-        </form>
-        <form onSubmit={submitRollback} style={{ display: "flex", gap: 8, minWidth: 0 }}>
-          <input
-            value={rollbackRef}
-            onChange={(event) => setRollbackRef(event.target.value)}
-            placeholder="HEAD~1"
-            style={formInputStyle}
-            disabled={disabled}
-          />
-          <button className="btn ghost danger" type="submit" disabled={disabled}>
-            {rollback.busy ? "rolling back..." : "Rollback"}
-          </button>
-        </form>
-      </div>
-      {status && <div style={hasError ? errorStyle : okStyle}>{hasError ? status : `✓ ${status}`}</div>}
-    </div>
-  );
-}
-
-function Lifecycle({ events, skillName }: { events: LifecycleEvent[]; skillName: string }) {
-  if (events.length === 0) {
-    return (
-      <div style={{ padding: "18px 4px", fontSize: 12, color: "var(--ink-2)" }}>
-        <div style={{ marginBottom: 6 }}>No lifecycle events yet.</div>
-        <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
-          Run <span style={{ color: "var(--ink-1)" }}>loom capture {skillName}</span> to start the chain.
-        </div>
-      </div>
-    );
-  }
-  return (
-    <div style={{ position: "relative", paddingLeft: 22 }}>
-      <div style={{ position: "absolute", left: 7, top: 4, bottom: 4, width: 1, background: "var(--line)" }} />
-      {events.map((e, i) => (
-        <div key={i} style={{ position: "relative", marginBottom: 14 }}>
-          <div
-            style={{
-              position: "absolute",
-              left: -22,
-              top: 4,
-              width: 15,
-              height: 15,
-              borderRadius: 8,
-              background: "var(--bg-0)",
-              border: `2px solid ${KIND_COLOR[e.kind]}`,
-            }}
-          />
-          <div style={{ fontSize: 12 }}>
-            <span style={{ color: "var(--ink-0)", fontWeight: 500 }}>{e.kind}</span>
-            <span className="mono" style={{ color: "var(--ink-2)", marginLeft: 6 }}>
-              {e.v}
-            </span>
-            <span style={{ color: "var(--ink-3)", marginLeft: 8 }}>
-              by {e.who} · {e.time}
-            </span>
-          </div>
-          <div style={{ fontSize: 11.5, color: "var(--ink-2)", marginTop: 2 }}>{e.desc}</div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function SkillDiff({ skillName }: { skillName: string }) {
-  const [revA, setRevA] = useState("");
-  const [revB, setRevB] = useState("");
-  const [files, setFiles] = useState<SkillDiffFile[] | null>(null);
-  const [header, setHeader] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const ctrl = new AbortController();
-    setLoading(true);
-    setError(null);
-    api
-      .skillDiff(skillName, revA || undefined, revB || undefined, ctrl.signal)
-      .then((payload) => {
-        if (payload.data) {
-          setFiles(payload.data.files);
-          setHeader(`${payload.data.rev_a.slice(0, 7)} → ${payload.data.rev_b.slice(0, 7)}`);
-        }
-        setLoading(false);
-      })
-      .catch((err: Error) => {
-        if (err.name !== "AbortError") {
-          setError(err.message);
-          setFiles(null);
-          setHeader("");
-          setLoading(false);
-        }
-      });
-    return () => ctrl.abort();
-  }, [skillName, revA, revB]);
-
-  const inputStyle: React.CSSProperties = {
-    fontSize: 11,
-    padding: "2px 6px",
-    background: "var(--bg-1)",
-    border: "1px solid var(--line)",
-    borderRadius: 4,
-    color: "var(--ink-0)",
-    width: 130,
-    fontFamily: "var(--font-mono)",
-  };
-
-  return (
-    <div>
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
-        <input
-          style={inputStyle}
-          placeholder="rev_a (default: prev)"
-          value={revA}
-          onChange={(e) => setRevA(e.target.value)}
-        />
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>→</span>
-        <input
-          style={inputStyle}
-          placeholder="rev_b (default: HEAD)"
-          value={revB}
-          onChange={(e) => setRevB(e.target.value)}
-        />
-      </div>
-
-      {loading && (
-        <div style={{ color: "var(--ink-3)", fontSize: 12 }}>Loading diff…</div>
-      )}
-      {error && (
-        <div style={{ color: "var(--err)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
-          {error}
-        </div>
-      )}
-
-      {!loading && files !== null && (
-        <>
-          {header && <div className="section-title">{header}</div>}
-          {files.length === 0 ? (
-            <div style={{ color: "var(--ink-3)", fontSize: 12 }}>
-              No changes in skills/{skillName}/
-            </div>
-          ) : (
-            files.map((file) => (
-              <div key={file.path} style={{ marginBottom: 16 }}>
-                <div
-                  className="mono"
-                  style={{ fontSize: 11, color: "var(--ink-2)", marginBottom: 4 }}
-                >
-                  {file.path}{" "}
-                  <span style={{ color: "var(--ok)" }}>+{file.added}</span>{" "}
-                  <span style={{ color: "var(--err)" }}>-{file.removed}</span>
-                  {file.truncated && (
-                    <span
-                      title={
-                        `${file.truncated_lines ?? 0} more +/- line(s) counted but not displayed; ` +
-                        "narrow the revision range or fetch the file directly to see the full diff."
-                      }
-                      style={{
-                        marginLeft: 8,
-                        padding: "0 6px",
-                        borderRadius: 3,
-                        background: "var(--bg-2)",
-                        color: "var(--warn, var(--ink-3))",
-                        fontSize: 10,
-                      }}
-                    >
-                      truncated +{file.truncated_lines ?? 0}
-                    </span>
-                  )}
-                </div>
-                <div style={{ border: "1px solid var(--line)", borderRadius: 6, overflow: "hidden" }}>
-                  {file.hunks.map((hunk, hi) => (
-                    <div key={hi}>
-                      <div className="diff-row" style={{ background: "var(--bg-1)" }}>
-                        <div className="mark" />
-                        <div className="l" style={{ color: "var(--ink-3)" }}>{hunk.header}</div>
-                      </div>
-                      {hunk.lines.map((line, li) => (
-                        <div
-                          key={li}
-                          className={`diff-row${line.startsWith("+") ? " add" : line.startsWith("-") ? " del" : ""}`}
-                        >
-                          <div className="mark">
-                            {line.startsWith("+") ? "+" : line.startsWith("-") ? "-" : ""}
-                          </div>
-                          <div className="l">{line.slice(1)}</div>
-                        </div>
-                      ))}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))
-          )}
         </>
       )}
     </div>

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -11,11 +11,12 @@ interface SyncPageProps {
   remote: RemotePayload | null;
   pendingCount: number;
   registryRoot: string | null;
+  refreshKey?: string | null;
   readOnly: boolean;
   onMutation: () => void;
 }
 
-export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutation }: SyncPageProps) {
+export function SyncPage({ remote, pendingCount, registryRoot, refreshKey, readOnly, onMutation }: SyncPageProps) {
   const push = useMutation();
   const pull = useMutation();
   const replay = useMutation();
@@ -66,7 +67,7 @@ export function SyncPage({ remote, pendingCount, registryRoot, readOnly, onMutat
         if (!controller.signal.aborted) setDiagnoseLoading(false);
       });
     return () => controller.abort();
-  }, [readOnly, repairVersion]);
+  }, [readOnly, repairVersion, refreshKey]);
 
   const submitRemote = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/scripts/perf-smoke.sh
+++ b/scripts/perf-smoke.sh
@@ -40,13 +40,18 @@ measure([bin_path, "--version"], 300)
 measure([bin_path, "--help"], 300)
 
 dist = pathlib.Path("panel/dist")
-if dist.exists():
-    total = 0
-    for path in dist.rglob("*"):
-        if path.is_file() and path.suffix in {".css", ".html", ".js"}:
-            total += len(gzip.compress(path.read_bytes(), compresslevel=9))
-    limit = 100 * 1024
-    if total > limit:
-        raise SystemExit(f"panel gzip payload is {total} bytes; limit is {limit}")
-    print(f"panel gzip payload={total} bytes")
+if not dist.is_dir():
+    raise SystemExit("panel/dist is missing; run `make panel-build` before perf-smoke")
+
+total = 0
+for path in dist.rglob("*"):
+    rel = path.relative_to(dist).as_posix()
+    if not path.is_file():
+        continue
+    if rel == "index.html" or rel.endswith(".css") or rel.startswith("assets/base-") or rel.startswith("assets/panel-"):
+        total += len(gzip.compress(path.read_bytes(), compresslevel=9))
+limit = 100 * 1024
+if total > limit:
+    raise SystemExit(f"panel gzip payload is {total} bytes; limit is {limit}")
+print(f"panel gzip payload={total} bytes")
 PY

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -100,7 +100,8 @@ impl App {
             .clone()
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         let audit_required = command_requires_durable_audit(&cli.command);
-        let audit_enabled = command_records_audit(&cli.command);
+        let audit_enabled = command_records_audit(&cli.command)
+            && (audit_required || self.ctx.ensure_not_loom_tool_repo_root().is_ok());
         if audit_required && let Err(err) = self.ctx.ensure_not_loom_tool_repo_root() {
             let message = err.to_string();
             let message = message

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -165,15 +165,15 @@ impl App {
             return Err(map_git(err));
         }
         if let Err(err) = gitops::stage_path(&self.ctx, Path::new(&skill_rel)) {
-            restore_path_best_effort(
+            let mut rollback_errors = restore_path_best_effort(
                 &skill_path,
                 skill_backup.as_ref(),
                 "restore_skill_path",
                 "remove_skill_path",
             );
             remove_backup_path_best_effort(skill_backup.as_ref());
-            let _ = gitops::restore_index(&self.ctx, &previous_index);
-            return Err(map_git(err));
+            rollback_errors.extend(restore_index_best_effort(&self.ctx, &previous_index));
+            return Err(map_git(err).with_rollback_errors(rollback_errors));
         }
 
         let changed = match gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel)) {

--- a/tests/root_guard.rs
+++ b/tests/root_guard.rs
@@ -96,3 +96,26 @@ version = "0.1.0"
         "guard must reject before command audit initialization"
     );
 }
+
+#[test]
+fn read_commands_skip_audit_in_loom_tool_repo_root() {
+    let root = TestDir::new("fake-tool-root-read-audit");
+    write_file(
+        &root.path().join("Cargo.toml"),
+        r#"[package]
+name = "skillloom"
+version = "0.1.0"
+"#,
+    );
+    write_file(&root.path().join("src/main.rs"), "fn main() {}\n");
+    write_file(&root.path().join("src/commands/mod.rs"), "");
+
+    let (output, env) = run_loom(root.path(), &["workspace", "status"]);
+
+    assert!(output.status.success());
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert!(
+        !root.path().join("state/events").exists(),
+        "read-only commands must not create command audit files in the tool repo root"
+    );
+}


### PR DESCRIPTION
## Summary
- refresh skill lifecycle and sync diagnostics after successful mutations
- include projection-backed shared bindings in capture choices
- stop showing unacked succeeded operations as pending
- avoid command-audit writes for read-only commands in the tool repo root and preserve rollback cleanup errors
- switch Dependabot panel updates to Bun and make perf-smoke require a real panel bundle

## Review-thread coverage
- Follow-up issue for backend handler split items: #191
- Closes #177

## Validation
- `cd panel && bun install --frozen-lockfile`
- `cd panel && bun run typecheck`
- `cd panel && bun run test`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check`
- `cargo test --test root_guard`
- `cargo test`
- `make perf-smoke`