### PR TITLE
docs: add launch readiness metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a reproducible problem in Loom.
+title: "bug: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please include enough detail
+        for someone else to reproduce the issue from a clean checkout or release
+        archive.
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest command sequence or workflow that shows the problem.
+      placeholder: |
+        1. Run `loom ...`
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, install method, Loom version, shell, and whether you used `--root`.
+      placeholder: |
+        - OS:
+        - Loom version:
+        - Install method:
+        - Registry root:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant command output. Redact secrets before submitting.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Propose a Loom capability or workflow improvement.
+title: "feat: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow is hard, missing, or unsafe today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the smallest useful shape of the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workaround or different design did you consider?
+    validations:
+      required: false
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and validation
+      description: Mention compatibility, safety, docs, or test expectations.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Issue
+
+Closes #
+
+## Checklist
+
+- [ ] I checked for related code, docs, and tests before adding new files.
+- [ ] I included fresh validation output for the changed surface.
+- [ ] I did not include secrets, credentials, or local-only paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable public release changes are tracked here. Loom also publishes release
+archives, checksums, and provenance details on GitHub Releases.
+
+## [0.1.1] - 2026-05-31
+
+### Added
+
+- Rollback preview and impact analysis for safer registry recovery planning.
+- `loom skill verify` with documentation for the skill source threat model.
+- Agent preflight dry-run planning for high-risk automation flows.
+- Panel pages and APIs for projections, doctor checks, orphan cleanup, lifecycle
+  actions, activity, and operations history.
+- V1 registry contracts for health envelopes, command audit, snapshot audit, and
+  union skill read models.
+
+### Changed
+
+- Panel release builds now bundle the frontend into the Rust binary.
+- Release trust guidance now covers archive checksums and GitHub attestation
+  verification.
+- CI now uses cargo-nextest for the Rust test suite.
+- Dependency refreshes for Rust, GitHub Actions, and the Panel toolchain.
+
+### Fixed
+
+- Hardened audit-critical registry flows, rollback failure reporting, command
+  audit recording, target path canonicalization, and secret redaction in command
+  events.
+- Improved CLI agent ergonomics, `--version` wiring, Panel failure visibility,
+  and skill lifecycle documentation.
+
+## [0.1.0] - 2026-04-30
+
+### Added
+
+- Initial public release archives for Loom.
+
+[0.1.1]: https://github.com/majiayu000/loom/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/majiayu000/loom/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
   <p>
     <a href="#quick-start">Quick Start</a> ·
+    <a href="CHANGELOG.md">Changelog</a> ·
     <a href="#features">Features</a> ·
     <a href="#how-it-works">How It Works</a> ·
     <a href="#comparison">Comparison</a> ·
@@ -37,7 +38,7 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ```bash
 # 1. Install a prebuilt release archive (recommended)
 # Pick one target: aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu
-VERSION="0.1.0" # replace with the latest release version
+VERSION="0.1.1" # replace with the latest release version
 TARGET="aarch64-apple-darwin"
 BASE_URL="https://github.com/majiayu000/loom/releases/download/v${VERSION}"
 curl -LO "${BASE_URL}/skillloom-${VERSION}-${TARGET}.tar.gz"
@@ -105,6 +106,8 @@ loom panel        # -> http://localhost:43117
 `loom panel` now serves a frontend bundled into the Rust binary at build time, so it works even when `--root` points at a separate registry directory. If panel assets are unavailable in your build, reinstall from a checkout with `bun` available so Loom can package the frontend during compile.
 
 Release archives are the preferred install path because their binaries are built with the Panel frontend already bundled and smoke-tested. To verify a downloaded archive, use the release `SHA256SUMS` file as shown above; if you use GitHub CLI, you can also verify provenance with `gh attestation verify skillloom-${VERSION}-${TARGET}.tar.gz --repo majiayu000/loom`.
+
+Release notes live in [CHANGELOG.md](CHANGELOG.md) and the [GitHub Releases](https://github.com/majiayu000/loom/releases) page.
 
 Prefer a guided walkthrough? Run `./scripts/demo.sh` for a scripted end-to-end tour (init → target add → status → panel hint) against a throwaway registry. `./scripts/e2e-agent-flow.sh` runs the four real integration scenarios used in CI.
 
@@ -212,7 +215,7 @@ Quick decision: **edits from the agent side → `capture`; edits inside the regi
 - State-changing registry commands commit `state/registry` to Git, and `sync push` has a safety commit before pushing.
 - Hard write guard: if `--root` points to the Loom tool repo itself, write operations are rejected. Use an independent skill registry repo for mutable operations.
 - English is the primary documentation language. [中文完整指南](docs/LOOM_COMPLETE_GUIDE_ZH.md).
-- Release and install trust notes live in [Releasing Loom](docs/RELEASING.md) and [Security Policy](SECURITY.md).
+- Release notes and install trust guidance live in [CHANGELOG.md](CHANGELOG.md), [Releasing Loom](docs/RELEASING.md), and [Security Policy](SECURITY.md).
 - V1 planning lives in [Loom V1 Core Spec](docs/LOOM_V1_CORE_SPEC.md).
 
 ## Command Surface


### PR DESCRIPTION
## Summary
- add CHANGELOG.md with v0.1.0/v0.1.1 release history and README release-note links
- add GitHub issue forms for bugs/features and a PR template
- update README quick-start version to latest release v0.1.1
- set repository topics directly on GitHub: agent-tools, ai-agents, automation, claude-code, codex, developer-tools, rust-cli, skill-registry, skills

## Validation
- git diff --check
- ruby YAML parse for both issue templates
- cargo check --locked

Fixes #193