### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable public release changes are tracked here. Loom also publishes release
 archives, checksums, and provenance details on GitHub Releases.
 
+## [0.1.2] - 2026-06-01
+
+### Added
+
+- Skill trash, history timeline, realtime save watch mode, and registry backup
+  export/restore workflows.
+- Panel support for pending review follow-ups and the split handler module
+  layout used by the V1 read/write surface.
+- Launch readiness metadata: changelog, repository topics, issue templates, PR
+  template, and README release-note links.
+
+### Changed
+
+- Refreshed Rust and Panel dependencies, including `uuid`, `serde_json`,
+  TypeScript, Vite, Vitest, jsdom, and coverage tooling.
+- Kept release archives aligned with the bundled Panel build and current
+  dependency lockfiles.
+
+### Fixed
+
+- Addressed post-review follow-ups across the skill lifecycle, registry
+  operations, and Panel routes merged after `v0.1.1`.
+
 ## [0.1.1] - 2026-05-31
 
 ### Added
@@ -37,5 +60,6 @@ archives, checksums, and provenance details on GitHub Releases.
 
 - Initial public release archives for Loom.
 
+[0.1.2]: https://github.com/majiayu000/loom/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/majiayu000/loom/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/majiayu000/loom/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "skillloom"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillloom"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 build = "build.rs"
 description = "Git-backed skill manager and registry for AI coding agents"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ```bash
 # 1. Install a prebuilt release archive (recommended)
 # Pick one target: aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu
-VERSION="0.1.1" # replace with the latest release version
+VERSION="0.1.2" # replace with the latest release version
 TARGET="aarch64-apple-darwin"
 BASE_URL="https://github.com/majiayu000/loom/releases/download/v${VERSION}"
 curl -LO "${BASE_URL}/skillloom-${VERSION}-${TARGET}.tar.gz"


### PR DESCRIPTION
## Summary
- bump skillloom crate version and Cargo.lock from 0.1.1 to 0.1.2
- update README release install example to 0.1.2
- add CHANGELOG.md notes for v0.1.2

## Validation
- git diff --check
- cargo metadata --no-deps --format-version 1 => 0.1.2
- make check
- cargo publish --dry-run --locked
- target/release/loom --version => loom 0.1.2