### PR TITLE
Humanize Activity and Audit log row hierarchy

### DIFF
--- a/panel/src/components/panel/OpRow.tsx
+++ b/panel/src/components/panel/OpRow.tsx
@@ -1,36 +1,21 @@
 import type { Op } from "../../lib/types";
+import { describeActivityOperation, statusWord } from "../../lib/operation_labels";
 
 function StatusRing({ status }: { status: Op["status"] }) {
   return <span className={`ring ${status}`} />;
 }
 
-function kindLabel(kind: string): string {
-  const normalized = kind.toLowerCase();
-  if (normalized === "project") return "apply";
-  if (normalized === "sync-push") return "sync push";
-  if (normalized === "sync-pull") return "sync pull";
-  if (normalized === "sync-replay") return "sync replay";
-  return kind.replace(/[._-]/g, " ");
-}
-
-function statusLabel(status: Op["status"]): string {
-  if (status === "ok") return "done";
-  if (status === "err") return "failed";
-  return "pending";
-}
-
 export function OpRow({ op }: { op: Op }) {
+  const label = describeActivityOperation(op);
   return (
     <div className="op-row">
       <StatusRing status={op.status} />
       <div className="op-main">
         <div className="op-title">
           <span className="op-kind" title={`source command: ${op.kind}`}>
-            {kindLabel(op.kind)}
+            {label.category}
           </span>
-          <span style={{ color: "var(--ink-0)" }}>{op.skill}</span>
-          {op.target !== "—" && <span style={{ color: "var(--ink-3)" }}> → </span>}
-          {op.target !== "—" && <span className="mono" style={{ color: "var(--ink-1)" }}>{op.target}</span>}
+          <span style={{ color: "var(--ink-0)" }}>{label.title}</span>
           {op.method !== "—" && (
             <span
               className={`chip method ${op.method}`}
@@ -41,9 +26,12 @@ export function OpRow({ op }: { op: Op }) {
           )}
         </div>
         <div className="op-sub">
-          <span className={`op-status ${op.status}`}>{statusLabel(op.status)}</span>
-          <span className="mono">{op.id}</span>
-          {op.reason ? ` · ${op.status === "err" ? "Blocked: " : ""}${op.reason}` : ""}
+          <span className={`op-status ${op.status}`}>{statusWord(op.status)}</span>
+          {label.details.map((detail) => (
+            <span key={detail} className="op-meta" title={detail.startsWith("id ") ? label.technicalId : undefined}>
+              {detail}
+            </span>
+          ))}
         </div>
       </div>
       <div className="op-time">{op.time}</div>

--- a/panel/src/lib/operation_labels.test.ts
+++ b/panel/src/lib/operation_labels.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeActivityOperation,
+  describeRegistryOperation,
+  registryOperationDisplayId,
+} from "./operation_labels";
+import type { RegistryOperationRecord } from "./api/client";
+import type { Op } from "./types";
+
+function registryOperation(overrides: Partial<RegistryOperationRecord> = {}): RegistryOperationRecord {
+  return {
+    op_id: "op_123",
+    intent: "target.add",
+    status: "pending",
+    ack: false,
+    created_at: "2026-04-09T10:05:00Z",
+    updated_at: "2026-04-09T10:05:00Z",
+    ...overrides,
+  };
+}
+
+describe("operation labels", () => {
+  it("puts the operator-facing action before raw target ids in Activity rows", () => {
+    const op: Op = {
+      id: "op_123",
+      status: "pending",
+      kind: "target.add",
+      skill: "target.add",
+      target: "target_claude_proj_a",
+      method: "—",
+      time: "now",
+    };
+
+    const label = describeActivityOperation(op);
+
+    expect(label.category).toBe("Target");
+    expect(label.title).toBe("Claude target registration pending");
+    expect(label.title).not.toContain("op_123");
+    expect(label.details).toContain("id op_123");
+    expect(label.details).toContain("target target_claude_proj_a");
+  });
+
+  it("keeps audit ids accessible without making them the History row title", () => {
+    const label = describeRegistryOperation(
+      registryOperation({
+        target: "target_claude_proj_a",
+        status: "succeeded",
+        ack: true,
+      }),
+    );
+
+    expect(label.title).toBe("Claude target registration done");
+    expect(label.title).not.toContain("op_123");
+    expect(label.details).toContain("intent target.add");
+    expect(label.details).toContain("id op_123");
+    expect(label.details).toContain("synced");
+  });
+
+  it("uses the action phrase directly when a target id has no agent hint", () => {
+    const label = describeActivityOperation({
+      id: "op_456",
+      status: "pending",
+      kind: "target.add",
+      skill: "target.add",
+      target: "target-1",
+      method: "—",
+      time: "now",
+    });
+
+    expect(label.title).toBe("Target registration pending");
+  });
+
+  it("falls back to audit or request ids when registry operation ids are absent", () => {
+    expect(
+      registryOperationDisplayId(
+        registryOperation({
+          op_id: null,
+          audit_id: "audit_1",
+          request_id: "req_1",
+        }),
+      ),
+    ).toBe("audit_1");
+  });
+});

--- a/panel/src/lib/operation_labels.ts
+++ b/panel/src/lib/operation_labels.ts
@@ -1,0 +1,164 @@
+import type { RegistryOperationRecord } from "./api/client";
+import type { Op } from "./types";
+
+export interface OperationLabel {
+  category: string;
+  title: string;
+  details: string[];
+  technicalId: string;
+}
+
+type OperationStatus = "ok" | "pending" | "err";
+
+interface IntentDescriptor {
+  category: string;
+  phrase: string;
+}
+
+const INTENT_LABELS: Record<string, IntentDescriptor> = {
+  "target.add": { category: "Target", phrase: "target registration" },
+  "target.remove": { category: "Target", phrase: "target removal" },
+  "workspace.binding.add": { category: "Binding", phrase: "workspace binding registration" },
+  "workspace.binding.remove": { category: "Binding", phrase: "workspace binding removal" },
+  "skill.project": { category: "Projection", phrase: "skill projection" },
+  "skill.capture": { category: "Capture", phrase: "skill capture" },
+  "skill.import_observed": { category: "Import", phrase: "observed skill import" },
+  "skill.monitor_observed": { category: "Monitor", phrase: "observed skill monitor" },
+  "skill.orphan.clean": { category: "Cleanup", phrase: "orphan cleanup" },
+  "skill.save": { category: "Skill", phrase: "skill save" },
+  "skill.snapshot": { category: "Snapshot", phrase: "skill snapshot" },
+  "sync.push": { category: "Sync", phrase: "remote sync push" },
+  "sync.pull": { category: "Sync", phrase: "remote sync pull" },
+  "sync.replay": { category: "Sync", phrase: "pending sync replay" },
+  "sync-push": { category: "Sync", phrase: "remote sync push" },
+  "sync-pull": { category: "Sync", phrase: "remote sync pull" },
+  "sync-replay": { category: "Sync", phrase: "pending sync replay" },
+};
+
+export function describeActivityOperation(op: Op): OperationLabel {
+  const descriptor = descriptorForIntent(op.kind);
+  const status = statusWord(op.status);
+  const subject = subjectForActivity(op, descriptor);
+  const targetDetail = meaningfulField(op.target) ? `target ${op.target}` : null;
+  const methodDetail = meaningfulField(op.method) ? `method ${op.method}` : null;
+  const details = compact([
+    `intent ${normalizeIntent(op.kind)}`,
+    targetDetail,
+    methodDetail,
+    `id ${op.id}`,
+    op.reason ? `${op.status === "err" ? "blocked" : "note"} ${op.reason}` : null,
+  ]);
+
+  return {
+    category: descriptor.category,
+    title: buildTitle(subject, descriptor.phrase, status),
+    details,
+    technicalId: op.id,
+  };
+}
+
+export function describeRegistryOperation(op: RegistryOperationRecord): OperationLabel {
+  const descriptor = descriptorForIntent(op.intent);
+  const status = statusWord(bucketRegistryOperation(op));
+  const technicalId = registryOperationDisplayId(op);
+  const subject = subjectForRegistryOperation(op, descriptor);
+  const details = compact([
+    `intent ${normalizeIntent(op.intent)}`,
+    meaningfulString(op.skill) ? `skill ${op.skill}` : null,
+    meaningfulString(op.target) ? `target ${op.target}` : null,
+    meaningfulString(op.binding) ? `binding ${op.binding}` : null,
+    meaningfulString(op.method) ? `method ${op.method}` : null,
+    op.ack ? "synced" : "not synced",
+    `id ${technicalId}`,
+  ]);
+
+  return {
+    category: descriptor.category,
+    title: buildTitle(subject, descriptor.phrase, status),
+    details,
+    technicalId,
+  };
+}
+
+export function registryOperationDisplayId(op: RegistryOperationRecord): string {
+  return op.op_id ?? op.audit_id ?? op.request_id ?? `${op.intent}-${op.updated_at}`;
+}
+
+export function bucketRegistryOperation(op: RegistryOperationRecord): OperationStatus {
+  if (op.last_error) return "err";
+  const s = op.status.toLowerCase();
+  if (s === "pending" || s === "enqueued" || s === "in_flight" || s === "retrying") return "pending";
+  if (s === "ok" || s === "applied" || s === "completed" || s === "done" || s === "succeeded") return "ok";
+  if (s === "err" || s === "error" || s === "failed") return "err";
+  return op.ack ? "ok" : "pending";
+}
+
+export function statusWord(status: OperationStatus): string {
+  if (status === "ok") return "done";
+  if (status === "err") return "failed";
+  return "pending";
+}
+
+function descriptorForIntent(intent: string): IntentDescriptor {
+  const normalized = normalizeIntent(intent);
+  return INTENT_LABELS[normalized] ?? {
+    category: titleCase(normalized.split(/[._-]/)[0] ?? "Change"),
+    phrase: normalized.replace(/[._-]/g, " "),
+  };
+}
+
+function subjectForActivity(op: Op, descriptor: IntentDescriptor): string {
+  const targetSubject = subjectFromTarget(op.target);
+  if (descriptor.category === "Target") return targetSubject ?? "";
+  if (descriptor.category === "Binding") return subjectFromBinding(op.target) ?? targetSubject ?? "";
+  if (meaningfulField(op.skill) && op.skill !== op.kind) return op.skill;
+  return targetSubject ?? "";
+}
+
+function subjectForRegistryOperation(op: RegistryOperationRecord, descriptor: IntentDescriptor): string {
+  const targetSubject = subjectFromTarget(op.target ?? null);
+  if (descriptor.category === "Target") return targetSubject ?? "";
+  if (descriptor.category === "Binding") return subjectFromBinding(op.binding ?? null) ?? targetSubject ?? "";
+  if (meaningfulString(op.skill)) return op.skill;
+  return targetSubject ?? "";
+}
+
+function subjectFromTarget(target: string | null | undefined): string | null {
+  const value = target?.trim();
+  if (!value || value === "—") return null;
+  const withoutPrefix = value.startsWith("target_") ? value.slice("target_".length) : value;
+  const candidate = withoutPrefix.split(/[_/-]/).find((part) => part.length > 0);
+  return candidate && candidate !== "target" ? titleCase(candidate) : null;
+}
+
+function subjectFromBinding(binding: string | null | undefined): string | null {
+  const value = binding?.trim();
+  if (!value || value === "—") return null;
+  return value.startsWith("bind_") ? `${titleCase(value.slice("bind_".length).split(/[_/-]/)[0] ?? "")} binding` : "Workspace";
+}
+
+function normalizeIntent(intent: string): string {
+  return intent.trim().toLowerCase();
+}
+
+function meaningfulField(value: string | null | undefined): value is string {
+  return Boolean(value && value.trim() !== "" && value !== "—");
+}
+
+function meaningfulString(value: string | null | undefined): value is string {
+  return Boolean(value && value.trim() !== "");
+}
+
+function titleCase(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1).replace(/-/g, " ");
+}
+
+function buildTitle(subject: string, phrase: string, status: string): string {
+  const action = subject ? `${subject} ${phrase}` : titleCase(phrase);
+  return `${action} ${status}`;
+}
+
+function compact(values: Array<string | null | undefined>): string[] {
+  return values.filter((value): value is string => Boolean(value && value.trim() !== ""));
+}

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
 import { api, ApiError, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import {
+  bucketRegistryOperation,
+  describeRegistryOperation,
+  registryOperationDisplayId,
+} from "../../lib/operation_labels";
 import { useMutation } from "../../lib/useMutation";
 
 type FilterKey = "all" | "pending" | "ok" | "err";
@@ -96,7 +101,8 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
       if (filter !== "all" && bucket(op) !== filter) return false;
       if (!needle) return true;
       return (
-        operationDisplayId(op).toLowerCase().includes(needle) ||
+        registryOperationDisplayId(op).toLowerCase().includes(needle) ||
+        describeRegistryOperation(op).title.toLowerCase().includes(needle) ||
         op.intent.toLowerCase().includes(needle) ||
         (op.last_error?.message ?? "").toLowerCase().includes(needle)
       );
@@ -245,20 +251,19 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
         </div>
 
         <div
+          className="history-table-wrap"
           style={{
             background: "var(--bg-1)",
             borderRadius: 10,
-            overflow: "hidden",
             border: "1px solid var(--line)",
           }}
         >
-          <table className="tbl">
+          <table className="tbl history-table">
             <thead>
               <tr>
-                <th>Change id</th>
-                <th>Intent</th>
+                <th>Action</th>
+                <th>Details</th>
                 <th>Status</th>
-                <th>ack</th>
                 <th>Created</th>
                 <th>Updated</th>
               </tr>
@@ -266,14 +271,14 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
             <tbody>
               {state.kind === "loading" && (
                 <tr>
-                  <td colSpan={6} className="mono" style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
+                  <td colSpan={5} className="mono" style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
                     loading…
                   </td>
                 </tr>
               )}
               {state.kind === "ready" && filtered.length === 0 && (
                 <tr>
-                  <td colSpan={6} style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
+                  <td colSpan={5} style={{ textAlign: "center", color: "var(--ink-3)", padding: 18 }}>
                     {operations.length === 0
                       ? "No activity recorded yet — every CLI or Panel change will show up here."
                       : "No activity matches the current filter."}
@@ -281,7 +286,7 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
                 </tr>
               )}
               {filtered.map((op) => (
-                <OpHistoryRow key={operationDisplayId(op)} op={op} />
+                <OpHistoryRow key={registryOperationDisplayId(op)} op={op} />
               ))}
             </tbody>
           </table>
@@ -315,26 +320,17 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
 }
 
 export function bucket(op: RegistryOperationRecord): "pending" | "ok" | "err" {
-  if (op.last_error) return "err";
-  const s = op.status.toLowerCase();
-  if (s === "pending" || s === "enqueued" || s === "in_flight" || s === "retrying") return "pending";
-  if (s === "ok" || s === "applied" || s === "completed" || s === "done" || s === "succeeded") return "ok";
-  if (s === "err" || s === "error" || s === "failed") return "err";
-  return op.ack ? "ok" : "pending";
-}
-
-function operationDisplayId(op: RegistryOperationRecord): string {
-  return op.op_id ?? op.audit_id ?? op.request_id ?? `${op.intent}-${op.updated_at}`;
+  return bucketRegistryOperation(op);
 }
 
 function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
   const kind = bucket(op);
   const color = kind === "err" ? "var(--err)" : kind === "pending" ? "var(--pending)" : "var(--ok)";
+  const label = describeRegistryOperation(op);
   return (
     <tr>
-      <td className="mono dim">{operationDisplayId(op)}</td>
       <td className="name">
-        {op.intent}
+        <div>{label.title}</div>
         {op.last_error && (
           <div className="mono" style={{ color: "var(--err)", fontSize: 10.5, marginTop: 3 }}>
             {op.last_error.message}
@@ -342,11 +338,19 @@ function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
         )}
       </td>
       <td>
+        <div className="op-detail-stack">
+          {label.details.map((detail) => (
+            <span key={detail} className="op-meta" title={detail.startsWith("id ") ? label.technicalId : undefined}>
+              {detail}
+            </span>
+          ))}
+        </div>
+      </td>
+      <td>
         <span className="chip" style={{ color }}>
           {op.last_error ? op.last_error.code : op.status}
         </span>
       </td>
-      <td className="mono dim">{op.ack ? "✓" : "—"}</td>
       <td className="mono dim" style={{ fontSize: 10.5 }}>
         {op.created_at}
       </td>

--- a/panel/src/styles/panel/data.css
+++ b/panel/src/styles/panel/data.css
@@ -49,6 +49,18 @@
   font-weight: 500;
 }
 
+.history-table-wrap {
+  overflow: hidden;
+}
+
+.history-table td:first-child {
+  min-width: 220px;
+}
+
+.history-table td:nth-child(2) {
+  min-width: 260px;
+}
+
 .two-col {
   display: grid;
   grid-template-columns: 1fr 360px;
@@ -98,6 +110,14 @@
 
   .projections-list .tbl {
     min-width: 720px;
+  }
+
+  .history-table-wrap {
+    overflow-x: auto;
+  }
+
+  .history-table {
+    min-width: 680px;
   }
 
   .projections-detail-panel {
@@ -234,12 +254,18 @@
 }
 .op-row .op-title {
   color: var(--ink-0);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 .op-row .op-sub {
-  font-family: var(--font-mono);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  align-items: center;
   font-size: 11px;
   color: var(--ink-3);
   margin-top: 2px;
+  min-width: 0;
 }
 .op-row .op-time {
   font-family: var(--font-mono);
@@ -260,7 +286,6 @@
 .op-status {
   display: inline-flex;
   align-items: center;
-  margin-right: 8px;
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -274,6 +299,20 @@
 }
 .op-status.err {
   color: var(--err);
+}
+
+.op-meta {
+  font-family: var(--font-mono);
+  color: var(--ink-3);
+  overflow-wrap: anywhere;
+}
+
+.op-detail-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  align-items: center;
+  max-width: 520px;
 }
 
 .spark {


### PR DESCRIPTION
## Summary
- humanize Activity row primary labels so operator-facing actions lead the scan path
- move operation ids, raw intents, target ids, and sync details into secondary metadata
- update Activity history table to lead with action/details instead of change ids

## Validation
- `cd panel && bun run typecheck`
- `cd panel && bun run test src/lib/operation_labels.test.ts src/pages/panel/panel_state.test.tsx src/pages/panel/PanelOperationLoop.test.tsx`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `cd panel && npx tsc --noEmit`
- `git diff --check`
- `curl -sS -I http://127.0.0.1:5179/`

Closes #207
