### PR TITLE
Style panel search inputs in dark UI

### DIFF
--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -133,8 +133,9 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
           </div>
         </div>
         <div className="header-actions">
-          <div className="searchbar" style={{ width: 260 }}>
+          <div className="searchbar">
             <input
+              aria-label="Filter activity history"
               placeholder="Filter by id / intent / error…"
               value={query}
               onChange={(e) => setQuery(e.target.value)}

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -95,7 +95,12 @@ export function SkillsPage({
         <div className="header-actions">
           <div className="searchbar">
             <SearchIcon />
-            <input placeholder="Filter skills…" value={q} onChange={(e) => setQ(e.target.value)} />
+            <input
+              aria-label="Filter skills"
+              placeholder="Filter skills…"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+            />
             <kbd>⌘K</kbd>
           </div>
           {selectedSkillBindings.length > 1 && (
@@ -105,7 +110,7 @@ export function SkillsPage({
               onChange={(event) => setCaptureBindingId(event.target.value)}
               disabled={readOnly || capture.busy}
               title="Choose which projected binding to capture from"
-              style={captureSelectStyle}
+              className="panel-field capture-select"
             >
               {selectedSkillBindings.map((binding) => (
                 <option key={binding.id} value={binding.id}>
@@ -293,20 +298,6 @@ function formatCaptureBinding(binding: Binding, targets: Target[]): string {
   const targetLabel = target ? `${target.agent}/${target.profile}` : binding.target;
   return `${targetLabel} · ${binding.method} · ${binding.policy}`;
 }
-
-const captureSelectStyle = {
-  height: 32,
-  minWidth: 190,
-  maxWidth: 260,
-  border: "1px solid var(--line)",
-  borderRadius: 6,
-  background: "var(--bg)",
-  color: "var(--ink-0)",
-  padding: "0 8px",
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-  outline: "none",
-};
 
 type DetailTab = "history" | "diff" | "targets";
 

--- a/panel/src/styles/panel/primitives.css
+++ b/panel/src/styles/panel/primitives.css
@@ -39,6 +39,114 @@
   font-size: 11.5px;
 }
 
+.panel-field,
+.searchbar {
+  min-height: 32px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-1);
+  color: var(--ink-0);
+  color-scheme: dark;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+}
+
+.panel-field {
+  padding: 0 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  outline: none;
+}
+
+.panel-field.capture-select {
+  width: 260px;
+  min-width: 190px;
+  max-width: 100%;
+  flex: 0 1 260px;
+}
+
+.panel-field:hover,
+.searchbar:hover {
+  border-color: var(--line-hi);
+  background: var(--bg-2);
+}
+
+.panel-field:focus,
+.searchbar:focus-within {
+  border-color: var(--accent);
+  background: var(--bg-2);
+  box-shadow: 0 0 0 2px rgba(217, 119, 54, 0.18);
+}
+
+.panel-field:disabled,
+.searchbar:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.58;
+  background: var(--bg-0);
+  border-color: var(--line-soft);
+}
+
+.searchbar {
+  width: 260px;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 9px;
+  flex: 1 1 240px;
+}
+
+.searchbar svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  color: var(--ink-2);
+}
+
+.searchbar input {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--ink-0);
+  font-size: 12px;
+}
+
+.searchbar input::placeholder {
+  color: var(--ink-3);
+}
+
+.searchbar input:disabled {
+  cursor: not-allowed;
+}
+
+.searchbar kbd {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 6px;
+  border: 1px solid var(--line-hi);
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.searchbar:focus-within kbd {
+  border-color: rgba(217, 119, 54, 0.42);
+  color: var(--ink-2);
+}
+
 .card {
   background: var(--bg-1);
   border: 1px solid var(--line);


### PR DESCRIPTION
## Summary
- add shared dark Panel styles for search inputs and native panel fields
- apply the shared searchbar treatment to Skills and Activity history filters
- move the Skills capture binding selector onto the shared native-control styling

## Validation
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Headless Chrome computed-style checks for Skills and Activity history at 1280px and 390px widths

Fixes #203