### PR TITLE
Add action-oriented panel empty states

### DIFF
--- a/panel/src/components/panel/ActionEmptyState.tsx
+++ b/panel/src/components/panel/ActionEmptyState.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+interface ActionEmptyStateProps {
+  title: string;
+  body: ReactNode;
+  primaryLabel: string;
+  onPrimary?: () => void;
+  primaryDisabled?: boolean;
+  primaryTitle?: string;
+  primaryIcon?: ReactNode;
+  command?: string;
+  compact?: boolean;
+}
+
+export function ActionEmptyState({
+  title,
+  body,
+  primaryLabel,
+  onPrimary,
+  primaryDisabled = false,
+  primaryTitle,
+  primaryIcon,
+  command,
+  compact = false,
+}: ActionEmptyStateProps) {
+  return (
+    <div className={`action-empty-state${compact ? " compact" : ""}`}>
+      <div className="action-empty-state-title">{title}</div>
+      <div className="action-empty-state-body">{body}</div>
+      <div className="action-empty-state-actions">
+        <button
+          type="button"
+          className="btn primary"
+          onClick={onPrimary}
+          disabled={primaryDisabled}
+          title={primaryTitle}
+        >
+          {primaryIcon}
+          {primaryLabel}
+        </button>
+      </div>
+      {command && <code className="action-empty-state-command mono">{command}</code>}
+    </div>
+  );
+}

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -199,6 +199,7 @@ export function PanelApp() {
             targets={targets}
             projections={live.projections}
             onMutation={onMutation}
+            onNewTarget={onNewTarget}
             readOnly={readOnly}
             mutationVersion={mutationVersion}
           />
@@ -212,6 +213,7 @@ export function PanelApp() {
             bindings={bindings}
             readOnly={readOnly}
             onMutation={onMutation}
+            onNewBinding={onNewBinding}
           />
         );
         break;

--- a/panel/src/pages/panel/BindingsPage.tsx
+++ b/panel/src/pages/panel/BindingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { Binding, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon } from "../../components/icons/nav_icons";
+import { ActionEmptyState } from "../../components/panel/ActionEmptyState";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
 import { api, ApiError, type BindingShowPayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
@@ -12,6 +13,7 @@ interface BindingsPageProps {
   targets: Target[];
   projections?: RegistryProjection[];
   onMutation: () => void;
+  onNewTarget: () => void;
   readOnly: boolean;
   mutationVersion: number;
 }
@@ -21,6 +23,7 @@ export function BindingsPage({
   targets,
   projections = [],
   onMutation,
+  onNewTarget,
   readOnly,
   mutationVersion,
 }: BindingsPageProps) {
@@ -30,6 +33,8 @@ export function BindingsPage({
   const sel = bindings.find((b) => b.id === selectedId) ?? null;
   const cleanOrphans = useMutation();
   const orphanProjections = projections.filter((p) => !p.binding_id && p.health === "orphaned");
+  const canAddBinding = !readOnly && targets.length > 0;
+  const addBindingTitle = readOnly ? "registry offline" : targets.length === 0 ? "add a target first" : undefined;
 
   const runCleanOrphans = () => {
     if (readOnly || orphanProjections.length === 0) return;
@@ -58,8 +63,8 @@ export function BindingsPage({
           <button
             className="btn primary"
             onClick={() => setAddOpen((v) => !v)}
-            disabled={readOnly}
-            title={readOnly ? "registry offline" : undefined}
+            disabled={!canAddBinding}
+            title={addBindingTitle}
           >
             <PlusIcon /> {addOpen ? "close" : "New binding"}
           </button>
@@ -134,75 +139,134 @@ export function BindingsPage({
             />
           </div>
         )}
-        <div className="two-col" style={{ height: "100%", gap: 0 }}>
-          <div style={{ overflow: "auto", borderRight: "1px solid var(--line)" }}>
-            <table className="tbl">
-              <thead>
-                <tr>
-                  <th>Binding</th>
-                  <th>Skill</th>
-                  <th>Target</th>
-                  <th>Matcher</th>
-                  <th>Method</th>
-                  <th>Policy</th>
-                </tr>
-              </thead>
-              <tbody>
-                {bindings.map((b) => {
-                  const t = targets.find((x) => x.id === b.target);
-                  return (
-                    <tr
-                      key={b.id}
-                      className={selectedId === b.id ? "selected" : ""}
-                      onClick={() => setSelectedId(b.id === selectedId ? null : b.id)}
-                    >
-                      <td className="mono dim">{b.id}</td>
-                      <td className="name">{b.skill}</td>
-                      <td>
-                        {t && (
-                          <span className="row-flex">
-                            <AgentAvatar agent={t.agent} />
-                            <span style={{ color: "var(--ink-1)" }}>
-                              {t.agent}/{t.profile}
+        {bindings.length === 0 ? (
+          <BindingsEmptyState
+            readOnly={readOnly}
+            hasTargets={targets.length > 0}
+            onAddBinding={() => setAddOpen(true)}
+            onNewTarget={onNewTarget}
+          />
+        ) : (
+          <div className="two-col" style={{ height: "100%", gap: 0 }}>
+            <div style={{ overflow: "auto", borderRight: "1px solid var(--line)" }}>
+              <table className="tbl">
+                <thead>
+                  <tr>
+                    <th>Binding</th>
+                    <th>Skill</th>
+                    <th>Target</th>
+                    <th>Matcher</th>
+                    <th>Method</th>
+                    <th>Policy</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bindings.map((b) => {
+                    const t = targets.find((x) => x.id === b.target);
+                    return (
+                      <tr
+                        key={b.id}
+                        className={selectedId === b.id ? "selected" : ""}
+                        onClick={() => setSelectedId(b.id === selectedId ? null : b.id)}
+                      >
+                        <td className="mono dim">{b.id}</td>
+                        <td className="name">{b.skill}</td>
+                        <td>
+                          {t && (
+                            <span className="row-flex">
+                              <AgentAvatar agent={t.agent} />
+                              <span style={{ color: "var(--ink-1)" }}>
+                                {t.agent}/{t.profile}
+                              </span>
                             </span>
+                          )}
+                        </td>
+                        <td className="mono">{b.matcher}</td>
+                        <td>
+                          <span className={`chip method ${b.method}`}>{b.method}</span>
+                        </td>
+                        <td>
+                          <span
+                            className="chip"
+                            style={{ color: b.policy === "auto" ? "var(--ok)" : "var(--warn)" }}
+                          >
+                            {b.policy}
                           </span>
-                        )}
-                      </td>
-                      <td className="mono">{b.matcher}</td>
-                      <td>
-                        <span className={`chip method ${b.method}`}>{b.method}</span>
-                      </td>
-                      <td>
-                        <span
-                          className="chip"
-                          style={{ color: b.policy === "auto" ? "var(--ok)" : "var(--warn)" }}
-                        >
-                          {b.policy}
-                        </span>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <div style={{ padding: 20, overflow: "auto" }}>
+              {sel ? (
+                <BindingDetail
+                  binding={sel}
+                  targets={targets}
+                  readOnly={readOnly}
+                  onMutation={onMutation}
+                  mutationVersion={mutationVersion}
+                  onRemoved={(bindingId) => setSelectedId((cur) => (cur === bindingId ? null : cur))}
+                />
+              ) : (
+                <div className="empty">Select a binding to inspect its rules, projections, and default target.</div>
+              )}
+            </div>
           </div>
-          <div style={{ padding: 20, overflow: "auto" }}>
-            {sel ? (
-              <BindingDetail
-                binding={sel}
-                targets={targets}
-                readOnly={readOnly}
-                onMutation={onMutation}
-                mutationVersion={mutationVersion}
-                onRemoved={(bindingId) => setSelectedId((cur) => (cur === bindingId ? null : cur))}
-              />
-            ) : (
-              <div className="empty">Select a binding to inspect its rules, projections, and default target.</div>
-            )}
-          </div>
-        </div>
+        )}
       </div>
     </>
+  );
+}
+
+function BindingsEmptyState({
+  readOnly,
+  hasTargets,
+  onAddBinding,
+  onNewTarget,
+}: {
+  readOnly: boolean;
+  hasTargets: boolean;
+  onAddBinding: () => void;
+  onNewTarget: () => void;
+}) {
+  if (readOnly) {
+    return (
+      <ActionEmptyState
+        title="Registry API offline"
+        body="Start the panel backend to load live binding rules before editing routes."
+        primaryLabel="Start panel"
+        primaryDisabled
+        primaryTitle="run the CLI command below"
+        primaryIcon={<PlusIcon />}
+        command="loom panel"
+      />
+    );
+  }
+
+  if (!hasTargets) {
+    return (
+      <ActionEmptyState
+        title="No bindings yet"
+        body="Add a target before creating the first workspace binding."
+        primaryLabel="Add target"
+        onPrimary={onNewTarget}
+        primaryIcon={<PlusIcon />}
+        command="loom target add --agent <agent> --path <abs-path> --ownership observed"
+      />
+    );
+  }
+
+  return (
+    <ActionEmptyState
+      title="No bindings yet"
+      body="Create a workspace binding so Loom knows which skill rules map to a target."
+      primaryLabel="New binding"
+      onPrimary={onAddBinding}
+      primaryIcon={<PlusIcon />}
+      command="loom workspace binding add --agent <agent> --profile <id> --matcher-kind path-prefix --matcher-value <workspace> --target <target-id>"
+    />
   );
 }
 

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -1,6 +1,7 @@
 import type { Op, ProjectionLink, Skill, Target, VizMode } from "../../lib/types";
 import { OpRow } from "../../components/panel/OpRow";
 import { ProjectionGraph } from "../../components/panel/ProjectionGraph";
+import { ActionEmptyState } from "../../components/panel/ActionEmptyState";
 import { PlusIcon, RefreshIcon, ShieldIcon, TargetIcon } from "../../components/icons/nav_icons";
 
 interface OverviewPageProps {
@@ -214,45 +215,60 @@ export function OverviewPage({
             </div>
           </div>
           <div className="proj-canvas">
-            <ProjectionGraph
-              mode={vizMode}
-              selectedSkill={selectedSkill}
-              selectedTarget={selectedTarget}
-              onSelectSkill={onSelectSkill}
-              onSelectTarget={onSelectTarget}
-              skills={skills}
-              targets={targets}
-              projections={projections}
-            />
-            <div className="proj-legend proj-legend-grouped">
-              <span className="legend-group-title">Projection method</span>
-              <span>
-                <span className="dot" style={{ background: "#6fb78a" }} />
-                symlink
-              </span>
-              <span>
-                <span className="dot" style={{ background: "#e6b450" }} />
-                copy
-              </span>
-              <span>
-                <span className="dot" style={{ background: "#c79ee0" }} />
-                materialize
-              </span>
-              <span className="divider">│</span>
-              <span className="legend-group-title">Target ownership</span>
-              <span>
-                <span className="dot" style={{ background: "#d97736" }} />
-                managed
-              </span>
-              <span>
-                <span className="dot" style={{ background: "#4ea9a0" }} />
-                observed
-              </span>
-              <span>
-                <span className="dot" style={{ background: "#8a8271" }} />
-                external
-              </span>
-            </div>
+            {projections.length === 0 ? (
+              <OverviewProjectionEmptyState
+                skillsCount={skills.length}
+                targetsCount={targets.length}
+                totalRules={totalRules}
+                readOnly={readOnly}
+                onOpenSkills={onOpenSkills}
+                onNewTarget={onNewTarget}
+                onNewBinding={onNewBinding}
+                onOpenSync={onOpenSync}
+              />
+            ) : (
+              <>
+                <ProjectionGraph
+                  mode={vizMode}
+                  selectedSkill={selectedSkill}
+                  selectedTarget={selectedTarget}
+                  onSelectSkill={onSelectSkill}
+                  onSelectTarget={onSelectTarget}
+                  skills={skills}
+                  targets={targets}
+                  projections={projections}
+                />
+                <div className="proj-legend proj-legend-grouped">
+                  <span className="legend-group-title">Projection method</span>
+                  <span>
+                    <span className="dot" style={{ background: "#6fb78a" }} />
+                    symlink
+                  </span>
+                  <span>
+                    <span className="dot" style={{ background: "#e6b450" }} />
+                    copy
+                  </span>
+                  <span>
+                    <span className="dot" style={{ background: "#c79ee0" }} />
+                    materialize
+                  </span>
+                  <span className="divider">│</span>
+                  <span className="legend-group-title">Target ownership</span>
+                  <span>
+                    <span className="dot" style={{ background: "#d97736" }} />
+                    managed
+                  </span>
+                  <span>
+                    <span className="dot" style={{ background: "#4ea9a0" }} />
+                    observed
+                  </span>
+                  <span>
+                    <span className="dot" style={{ background: "#8a8271" }} />
+                    external
+                  </span>
+                </div>
+              </>
+            )}
           </div>
         </div>
 
@@ -307,6 +323,95 @@ export function OverviewPage({
         </div>
       </div>
     </>
+  );
+}
+
+function OverviewProjectionEmptyState({
+  skillsCount,
+  targetsCount,
+  totalRules,
+  readOnly,
+  onOpenSkills,
+  onNewTarget,
+  onNewBinding,
+  onOpenSync,
+}: {
+  skillsCount: number;
+  targetsCount: number;
+  totalRules: number;
+  readOnly: boolean;
+  onOpenSkills: () => void;
+  onNewTarget: () => void;
+  onNewBinding: () => void;
+  onOpenSync: () => void;
+}) {
+  if (readOnly) {
+    return (
+      <ActionEmptyState
+        title="Registry API offline"
+        body="Start the panel backend to load live projection data."
+        primaryLabel="Start panel"
+        primaryDisabled
+        primaryTitle="run the CLI command below"
+        primaryIcon={<RefreshIcon />}
+        command="loom panel"
+        compact
+      />
+    );
+  }
+
+  if (skillsCount === 0) {
+    return (
+      <ActionEmptyState
+        title="No projections yet"
+        body="Add a skill first, then connect it to a target with a binding."
+        primaryLabel="Open Skills"
+        onPrimary={onOpenSkills}
+        primaryIcon={<PlusIcon />}
+        command="loom skill add <source> --name <name>"
+        compact
+      />
+    );
+  }
+
+  if (targetsCount === 0) {
+    return (
+      <ActionEmptyState
+        title="No projections yet"
+        body="Add an agent target before creating bindings and projections."
+        primaryLabel="Add target"
+        onPrimary={onNewTarget}
+        primaryIcon={<TargetIcon />}
+        command="loom target add --agent <agent> --path <abs-path> --ownership observed"
+        compact
+      />
+    );
+  }
+
+  if (totalRules === 0) {
+    return (
+      <ActionEmptyState
+        title="No projections yet"
+        body="Create a binding rule so Loom knows which skill should project into which target."
+        primaryLabel="Add binding"
+        onPrimary={onNewBinding}
+        primaryIcon={<PlusIcon />}
+        command="loom workspace binding add --agent <agent> --profile <id> --matcher-kind path-prefix --matcher-value <workspace> --target <target-id>"
+        compact
+      />
+    );
+  }
+
+  return (
+    <ActionEmptyState
+      title="No projections yet"
+      body="Apply the existing binding rules to materialize skills into their target directories."
+      primaryLabel="Replay / sync"
+      onPrimary={onOpenSync}
+      primaryIcon={<RefreshIcon />}
+      command="loom skill project <skill> --binding <binding-id> --method symlink"
+      compact
+    />
   );
 }
 

--- a/panel/src/pages/panel/ProjectionsPage.tsx
+++ b/panel/src/pages/panel/ProjectionsPage.tsx
@@ -3,7 +3,8 @@ import type { RegistryProjection } from "../../generated/RegistryProjection";
 import type { Binding, Target } from "../../lib/types";
 import { api } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
-import { RefreshIcon } from "../../components/icons/nav_icons";
+import { PlusIcon, RefreshIcon } from "../../components/icons/nav_icons";
+import { ActionEmptyState } from "../../components/panel/ActionEmptyState";
 
 interface ProjectionsPageProps {
   projections: RegistryProjection[];
@@ -11,6 +12,7 @@ interface ProjectionsPageProps {
   bindings: Binding[];
   readOnly: boolean;
   onMutation: () => void;
+  onNewBinding: () => void;
 }
 
 type ProjectionFilter = "all" | "healthy" | "drifted" | "orphaned";
@@ -43,7 +45,7 @@ function healthClass(projection: RegistryProjection): string {
   return "err";
 }
 
-export function ProjectionsPage({ projections, targets, bindings, readOnly, onMutation }: ProjectionsPageProps) {
+export function ProjectionsPage({ projections, targets, bindings, readOnly, onMutation, onNewBinding }: ProjectionsPageProps) {
   const [filter, setFilter] = useState<ProjectionFilter>("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [deleteLivePaths, setDeleteLivePaths] = useState(false);
@@ -57,7 +59,7 @@ export function ProjectionsPage({ projections, targets, bindings, readOnly, onMu
     });
   }, [filter, projections]);
 
-  const selected = projections.find((projection) => projection.instance_id === selectedId) ?? filtered[0] ?? null;
+  const selected = filtered.find((projection) => projection.instance_id === selectedId) ?? filtered[0] ?? null;
   const selectedBinding = selected?.binding_id
     ? bindings.find((binding) => binding.id === selected.binding_id)
     : undefined;
@@ -117,48 +119,56 @@ export function ProjectionsPage({ projections, targets, bindings, readOnly, onMu
         </div>
       </div>
       <div className="page-body" style={{ padding: 0 }}>
-        <div className="two-col projections-layout">
-          <div className="projections-list">
-            <table className="tbl">
-              <thead>
-                <tr>
-                  <th>Instance</th>
-                  <th>Skill</th>
-                  <th>Target</th>
-                  <th>Method</th>
-                  <th>Health</th>
-                  <th>Rev</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((projection) => (
-                  <tr
-                    key={projection.instance_id}
-                    className={selected?.instance_id === projection.instance_id ? "selected" : ""}
-                    onClick={() => setSelectedId(projection.instance_id)}
-                  >
-                    <td className="mono dim">{projection.instance_id}</td>
-                    <td className="name">{projection.skill_id}</td>
-                    <td>{targetLabel(targets, projection.target_id)}</td>
-                    <td>{projection.method}</td>
-                    <td>
-                      <span className={`badge ${healthClass(projection)}`}>
-                        {projection.observed_drift ? "drifted" : projection.health}
-                      </span>
-                    </td>
-                    <td className="mono dim">{shortRev(projection.last_applied_rev)}</td>
+        {filtered.length === 0 ? (
+          <ProjectionsEmptyState
+            filter={filter}
+            hasProjections={projections.length > 0}
+            hasBindings={bindings.length > 0}
+            readOnly={readOnly}
+            onShowAll={() => setFilter("all")}
+            onNewBinding={onNewBinding}
+          />
+        ) : (
+          <div className="two-col projections-layout">
+            <div className="projections-list">
+              <table className="tbl">
+                <thead>
+                  <tr>
+                    <th>Instance</th>
+                    <th>Skill</th>
+                    <th>Target</th>
+                    <th>Method</th>
+                    <th>Health</th>
+                    <th>Rev</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-            {filtered.length === 0 && <div className="empty">No projections match this filter.</div>}
-          </div>
-          <div className="projections-detail-panel">
-            {selected ? (
+                </thead>
+                <tbody>
+                  {filtered.map((projection) => (
+                    <tr
+                      key={projection.instance_id}
+                      className={selected?.instance_id === projection.instance_id ? "selected" : ""}
+                      onClick={() => setSelectedId(projection.instance_id)}
+                    >
+                      <td className="mono dim">{projection.instance_id}</td>
+                      <td className="name">{projection.skill_id}</td>
+                      <td>{targetLabel(targets, projection.target_id)}</td>
+                      <td>{projection.method}</td>
+                      <td>
+                        <span className={`badge ${healthClass(projection)}`}>
+                          {projection.observed_drift ? "drifted" : projection.health}
+                        </span>
+                      </td>
+                      <td className="mono dim">{shortRev(projection.last_applied_rev)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="projections-detail-panel">
               <ProjectionDetail
-                projection={selected}
+                projection={selected!}
                 binding={selectedBinding}
-                targetLabel={targetLabel(targets, selected.target_id)}
+                targetLabel={targetLabel(targets, selected!.target_id)}
                 readOnly={readOnly}
                 actionBusy={action.busy}
                 canCapture={canCapture}
@@ -172,13 +182,77 @@ export function ProjectionsPage({ projections, targets, bindings, readOnly, onMu
                 message={action.error ?? action.success}
                 messageTone={action.error ? "var(--err)" : "var(--ok)"}
               />
-            ) : (
-              <div className="empty">No projections found.</div>
-            )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </>
+  );
+}
+
+function ProjectionsEmptyState({
+  filter,
+  hasProjections,
+  hasBindings,
+  readOnly,
+  onShowAll,
+  onNewBinding,
+}: {
+  filter: ProjectionFilter;
+  hasProjections: boolean;
+  hasBindings: boolean;
+  readOnly: boolean;
+  onShowAll: () => void;
+  onNewBinding: () => void;
+}) {
+  if (hasProjections) {
+    return (
+      <ActionEmptyState
+        title={`No ${filter} projections`}
+        body="The current filter has no projection rows."
+        primaryLabel="Show all"
+        onPrimary={onShowAll}
+        primaryIcon={<RefreshIcon />}
+      />
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <ActionEmptyState
+        title="Registry API offline"
+        body="Start the panel backend to load live projections before inspecting materialized skills."
+        primaryLabel="Start panel"
+        primaryDisabled
+        primaryTitle="run the CLI command below"
+        primaryIcon={<RefreshIcon />}
+        command="loom panel"
+      />
+    );
+  }
+
+  if (!hasBindings) {
+    return (
+      <ActionEmptyState
+        title="No projections yet"
+        body="Create a binding first, then project a skill into its target."
+        primaryLabel="Add binding"
+        onPrimary={onNewBinding}
+        primaryIcon={<PlusIcon />}
+        command="loom workspace binding add --agent <agent> --profile <id> --matcher-kind path-prefix --matcher-value <workspace> --target <target-id>"
+      />
+    );
+  }
+
+  return (
+    <ActionEmptyState
+      title="No projections yet"
+      body="Project a skill through an existing binding to materialize it into an agent target."
+      primaryLabel="Open bindings"
+      onPrimary={onNewBinding}
+      primaryIcon={<RefreshIcon />}
+      command="loom skill project <skill> --binding <binding-id> --method symlink"
+    />
   );
 }
 

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -305,9 +305,8 @@ describe("SkillsPage — empty registry", () => {
       />,
     );
 
-    // The CTA references the in-panel button by its label so users notice it.
-    expect(screen.getAllByText(/\+ skill add/).length).toBeGreaterThan(0);
-    // And it surfaces the equivalent CLI invocation for terminal-first users.
+    expect(screen.getByText("No tracked skills yet")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "skill add" }).length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(/loom skill add <source> --name <name>/).length,
     ).toBeGreaterThan(0);

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -3,6 +3,7 @@ import type { Binding, Skill, Target } from "../../lib/types";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon, SearchIcon } from "../../components/icons/nav_icons";
+import { ActionEmptyState } from "../../components/panel/ActionEmptyState";
 import { api } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
 import {
@@ -61,17 +62,6 @@ export function SkillsPage({
       selectedSkillBindings.some((b) => b.id === current) ? current : selectedSkillBindings[0].id,
     );
   }, [bindingOptionKey]);
-
-  const emptyMessage: React.ReactNode = readOnly
-    ? "Registry API offline."
-    : q
-    ? "No skills match the current filter."
-    : (
-        <>
-          No skills in this registry yet — use the <strong>+ skill add</strong> button above, or run{" "}
-          <code className="mono">loom skill add &lt;source&gt; --name &lt;name&gt;</code>.
-        </>
-      );
 
   const runCapture = () => {
     if (!sel || !captureBinding) return;
@@ -158,58 +148,105 @@ export function SkillsPage({
             />
           </div>
         )}
-        <div className="two-col" style={{ height: "100%", gap: 0 }}>
-          <div style={{ overflow: "auto", borderRight: "1px solid var(--line)" }}>
-            <table className="tbl">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Source</th>
-                  <th>Latest rev</th>
-                  <th>Tags</th>
-                  <th>Bindings</th>
-                  <th>Projections</th>
-                  <th>Changed</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((s) => (
-                  <tr
-                    key={s.id}
-                    className={sel?.id === s.id ? "selected" : ""}
-                    onClick={() => onSelectSkill(s.id)}
-                  >
-                    <td className="name">{s.name}</td>
-                    <td>
-                      <span className={`chip ${s.sourceStatus}`}>{s.sourceStatus}</span>
-                    </td>
-                    <td className="mono">{s.latestRev}</td>
-                    <td className="mono dim">{formatSkillTags(s)}</td>
-                    <td className="mono dim">{s.bindingCount}</td>
-                    <td className="mono">{s.projectionCount}</td>
-                    <td className="mono dim">{s.changed}</td>
-                  </tr>
-                ))}
-                {filtered.length === 0 && (
+        {filtered.length === 0 ? (
+          <SkillsEmptyState
+            query={q}
+            readOnly={readOnly}
+            onClearFilter={() => setQ("")}
+            onAddSkill={() => setAddOpen(true)}
+          />
+        ) : (
+          <div className="two-col" style={{ height: "100%", gap: 0 }}>
+            <div style={{ overflow: "auto", borderRight: "1px solid var(--line)" }}>
+              <table className="tbl">
+                <thead>
                   <tr>
-                    <td colSpan={7} style={{ color: "var(--ink-3)", padding: 22, textAlign: "center" }}>
-                      {emptyMessage}
-                    </td>
+                    <th>Name</th>
+                    <th>Source</th>
+                    <th>Latest rev</th>
+                    <th>Tags</th>
+                    <th>Bindings</th>
+                    <th>Projections</th>
+                    <th>Changed</th>
                   </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-          <div style={{ padding: 20, overflow: "auto" }}>
-            {sel ? (
+                </thead>
+                <tbody>
+                  {filtered.map((s) => (
+                    <tr
+                      key={s.id}
+                      className={sel?.id === s.id ? "selected" : ""}
+                      onClick={() => onSelectSkill(s.id)}
+                    >
+                      <td className="name">{s.name}</td>
+                      <td>
+                        <span className={`chip ${s.sourceStatus}`}>{s.sourceStatus}</span>
+                      </td>
+                      <td className="mono">{s.latestRev}</td>
+                      <td className="mono dim">{formatSkillTags(s)}</td>
+                      <td className="mono dim">{s.bindingCount}</td>
+                      <td className="mono">{s.projectionCount}</td>
+                      <td className="mono dim">{s.changed}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div style={{ padding: 20, overflow: "auto" }}>
               <SkillDetail skill={sel} targets={targets} bindings={bindings} onMutation={onMutation} readOnly={readOnly} />
-            ) : (
-              <div className="empty">{emptyMessage}</div>
-            )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </>
+  );
+}
+
+function SkillsEmptyState({
+  query,
+  readOnly,
+  onClearFilter,
+  onAddSkill,
+}: {
+  query: string;
+  readOnly: boolean;
+  onClearFilter: () => void;
+  onAddSkill: () => void;
+}) {
+  if (query) {
+    return (
+      <ActionEmptyState
+        title="No skills match this filter"
+        body="Clear the filter to return to the tracked skill list."
+        primaryLabel="Clear filter"
+        onPrimary={onClearFilter}
+        primaryIcon={<SearchIcon />}
+      />
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <ActionEmptyState
+        title="Registry API offline"
+        body="Start the panel backend to load live skills before adding to the registry."
+        primaryLabel="Start panel"
+        primaryDisabled
+        primaryTitle="run the CLI command below"
+        primaryIcon={<PlusIcon />}
+        command="loom panel"
+      />
+    );
+  }
+
+  return (
+    <ActionEmptyState
+      title="No tracked skills yet"
+      body="Add the first skill source to start capturing lifecycle history and projections."
+      primaryLabel="skill add"
+      onPrimary={onAddSkill}
+      primaryIcon={<PlusIcon />}
+      command="loom skill add <source> --name <name>"
+    />
   );
 }
 

--- a/panel/src/pages/panel/panel_state.test.tsx
+++ b/panel/src/pages/panel/panel_state.test.tsx
@@ -383,6 +383,39 @@ test("OverviewPage disables add binding until a target exists", async () => {
   expect(addBinding.props.title).toBe("add a target first");
 });
 
+test("OverviewPage turns an empty projection graph into an action state", async () => {
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <OverviewPage
+        skills={[makeSkill()]}
+        targets={[makeTarget()]}
+        ops={[]}
+        projections={[]}
+        vizMode="loom"
+        setVizMode={() => {}}
+        selectedSkill={null}
+        selectedTarget={null}
+        onSelectSkill={() => {}}
+        onSelectTarget={() => {}}
+        registryRoot="/tmp/loom"
+        onMutation={() => {}}
+        onNewTarget={() => {}}
+        onNewBinding={() => {}}
+        onOpenSkills={() => {}}
+        onViewActivity={() => {}}
+        onOpenSync={() => {}}
+        readOnly={false}
+      />,
+    );
+  });
+
+  const html = markup(renderer!);
+  expect(html.includes("No projections yet")).toBe(true);
+  expect(html.includes("loom skill project <skill> --binding <binding-id> --method symlink")).toBe(true);
+  expect(html.includes("Projection method")).toBe(false);
+});
+
 test("BindingAddForm submits the canonical matcher kind", async () => {
   const originalBindingAdd = api.bindingAdd;
   const submissions: Array<Parameters<typeof api.bindingAdd>[0]> = [];
@@ -457,6 +490,7 @@ test("BindingsPage refetches selected binding details after a successful project
           readOnly={false}
           mutationVersion={mutationVersion}
           onMutation={() => setMutationVersion((cur) => cur + 1)}
+          onNewTarget={() => {}}
         />
       );
     }
@@ -517,6 +551,7 @@ test("BindingsPage exposes orphan cleanup from live projection data", async () =
           onMutation={() => {
             mutations += 1;
           }}
+          onNewTarget={() => {}}
         />,
       );
     });
@@ -535,6 +570,27 @@ test("BindingsPage exposes orphan cleanup from live projection data", async () =
   } finally {
     api.orphanClean = originalOrphanClean;
   }
+});
+
+test("BindingsPage replaces the empty table and detail pane with one action state", async () => {
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <BindingsPage
+        bindings={[]}
+        targets={[makeTarget()]}
+        readOnly={false}
+        mutationVersion={0}
+        onMutation={() => {}}
+        onNewTarget={() => {}}
+      />,
+    );
+  });
+
+  const html = markup(renderer!);
+  expect(html.includes("No bindings yet")).toBe(true);
+  expect(html.includes("loom workspace binding add")).toBe(true);
+  expect(html.includes("Select a binding to inspect")).toBe(false);
 });
 
 test("ProjectionsPage can capture and re-project a selected projection", async () => {
@@ -575,6 +631,7 @@ test("ProjectionsPage can capture and re-project a selected projection", async (
           onMutation={() => {
             mutations += 1;
           }}
+          onNewBinding={() => {}}
         />,
       );
     });
@@ -622,6 +679,7 @@ test("ProjectionsPage cleans orphaned projection metadata", async () => {
           onMutation={() => {
             mutations += 1;
           }}
+          onNewBinding={() => {}}
         />,
       );
     });
@@ -637,6 +695,36 @@ test("ProjectionsPage cleans orphaned projection metadata", async () => {
   } finally {
     api.orphanClean = originalOrphanClean;
   }
+});
+
+test("ProjectionsPage replaces empty list and detail messages with one action state", async () => {
+  let openedBindings = 0;
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <ProjectionsPage
+        projections={[]}
+        targets={[makeTarget()]}
+        bindings={[]}
+        readOnly={false}
+        onMutation={() => {}}
+        onNewBinding={() => {
+          openedBindings += 1;
+        }}
+      />,
+    );
+  });
+
+  const html = markup(renderer!);
+  expect(html.includes("No projections yet")).toBe(true);
+  expect(html.includes("loom workspace binding add")).toBe(true);
+  expect(html.includes("No projections found")).toBe(false);
+  expect(html.includes("No projections match this filter")).toBe(false);
+
+  await act(async () => {
+    buttonByLabel(renderer!, "Add binding").props.onClick();
+  });
+  expect(openedBindings).toBe(1);
 });
 
 test("HistoryPage refetches when a panel mutation completes", async () => {
@@ -913,6 +1001,7 @@ test("BindingsPage keeps a newer selection when a previous binding delete comple
           readOnly={false}
           mutationVersion={0}
           onMutation={() => {}}
+          onNewTarget={() => {}}
         />
       );
     }
@@ -973,6 +1062,7 @@ test("BindingsPage skips live detail fetches in read-only mode", async () => {
           readOnly={true}
           mutationVersion={0}
           onMutation={() => {}}
+          onNewTarget={() => {}}
         />,
       );
     });

--- a/panel/src/styles/panel/primitives.css
+++ b/panel/src/styles/panel/primitives.css
@@ -335,3 +335,52 @@
   font-family: var(--font-mono);
   font-size: 12px;
 }
+
+.action-empty-state {
+  min-height: 300px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 10px;
+  padding: 42px 24px;
+  text-align: center;
+  color: var(--ink-2);
+}
+
+.action-empty-state.compact {
+  min-height: 100%;
+}
+
+.action-empty-state-title {
+  font-family: var(--font-display);
+  font-size: 19px;
+  color: var(--ink-0);
+}
+
+.action-empty-state-body {
+  max-width: 540px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+
+.action-empty-state-actions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.action-empty-state-command {
+  max-width: min(560px, 100%);
+  margin-top: 2px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-1);
+  color: var(--ink-1);
+  font-size: 11px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary
- add a shared panel action empty state component with primary CTA and optional CLI command
- replace passive/duplicate empty table/detail states on Skills, Bindings, Projections, and the Overview graph
- add panel tests covering the new empty-state behavior

## Validation
- npx tsc --noEmit
- npm --prefix panel run typecheck
- npm --prefix panel run test -- src/pages/panel/panel_state.test.tsx src/pages/panel/SkillsPage.test.tsx
- npm --prefix panel run test
- npm --prefix panel run build

Closes #204