### PR TITLE
[codex] Add skill diagnose backend

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,6 +206,8 @@ pub enum SkillCommand {
     },
     #[command(about = "Verify a skill source has no uncommitted drift")]
     Verify(SkillOnlyArgs),
+    #[command(about = "Diagnose one skill source and registry projection state")]
+    Diagnose(SkillOnlyArgs),
     #[command(about = "Watch registry skill sources and autosave stable local edits")]
     Watch(WatchArgs),
     #[command(about = "Continuously import and update skills from observed targets")]

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -133,6 +133,7 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
             SkillCommand::Rollback(_) => "skill.rollback",
             SkillCommand::Diff(_) => "skill.diff",
             SkillCommand::History(_) => "skill.history",
+            SkillCommand::Diagnose(_) => "skill.diagnose",
             SkillCommand::Trash {
                 command: SkillTrashCommand::Add(_),
             } => "skill.trash.add",

--- a/src/commands/history_cmds.rs
+++ b/src/commands/history_cmds.rs
@@ -375,11 +375,15 @@ fn operation_json(record: &RegistryOperationRecord) -> Value {
     })
 }
 
-fn operation_mentions_skill(record: &RegistryOperationRecord, skill: &str) -> bool {
+pub(crate) fn operation_mentions_skill(record: &RegistryOperationRecord, skill: &str) -> bool {
     json_field_eq(&record.payload, "skill", skill)
         || json_field_eq(&record.payload, "skill_id", skill)
         || json_field_eq(&record.effects, "skill", skill)
         || json_field_eq(&record.effects, "skill_id", skill)
+        || json_string_array_contains(&record.payload, "skills", skill)
+        || json_string_array_contains(&record.effects, "skills", skill)
+        || json_item_array_contains_skill(&record.effects, "imported", skill)
+        || json_item_array_contains_skill(&record.effects, "updated", skill)
 }
 
 fn json_field_eq(value: &Value, key: &str, expected: &str) -> bool {
@@ -388,6 +392,25 @@ fn json_field_eq(value: &Value, key: &str, expected: &str) -> bool {
 
 fn json_field_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
     value.get(key).and_then(Value::as_str)
+}
+
+fn json_string_array_contains(value: &Value, key: &str, expected: &str) -> bool {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(expected)))
+}
+
+fn json_item_array_contains_skill(value: &Value, key: &str, expected: &str) -> bool {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items.iter().any(|item| {
+                item.get("skill").and_then(Value::as_str) == Some(expected)
+                    || item.get("skill_id").and_then(Value::as_str) == Some(expected)
+            })
+        })
 }
 
 fn skill_history_diff_stat(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,9 @@ mod helpers;
 mod history_cmds;
 mod projections;
 mod skill_cmds;
+mod skill_diagnose;
+#[cfg(test)]
+mod skill_diagnose_tests;
 mod skill_verify;
 mod sync_cmds;
 mod target_cmds;
@@ -203,6 +206,7 @@ impl App {
                     command: SkillTrashCommand::Purge(args),
                 } => self.cmd_skill_trash_purge(args, &request_id),
                 SkillCommand::Verify(args) => self.cmd_verify(args),
+                SkillCommand::Diagnose(args) => self.cmd_skill_diagnose(args),
                 SkillCommand::Orphan {
                     command: SkillOrphanCommand::List,
                 } => self.cmd_skill_orphan_list(),
@@ -337,6 +341,7 @@ fn command_records_audit(command: &Command) -> bool {
             | Command::Backup { .. }
             | Command::Skill {
                 command: SkillCommand::History(_)
+                    | SkillCommand::Diagnose(_)
                     | SkillCommand::Trash {
                         command: SkillTrashCommand::List,
                     }
@@ -384,6 +389,7 @@ fn command_requires_durable_audit(command: &Command) -> bool {
             SkillCommand::Diff(_)
             | SkillCommand::History(_)
             | SkillCommand::Verify(_)
+            | SkillCommand::Diagnose(_)
             | SkillCommand::Trash {
                 command: SkillTrashCommand::List,
             }

--- a/src/commands/skill_diagnose.rs
+++ b/src/commands/skill_diagnose.rs
@@ -140,36 +140,60 @@ fn build_skill_diagnosis(
         ));
     }
 
-    if let Ok(report) = ctx.read_pending_report() {
-        pending_ops = report
-            .ops
-            .iter()
-            .rev()
-            .filter(|op| pending_op_mentions_skill(op, skill))
-            .take(MAX_RELATED_OPS)
-            .map(|op| {
-                json!({
-                    "op_id": op.op_id,
-                    "request_id": op.request_id,
-                    "command": op.command,
-                    "created_at": op.created_at,
-                    "details": op.details
+    match ctx.read_pending_report() {
+        Ok(report) => {
+            pending_ops = report
+                .ops
+                .iter()
+                .rev()
+                .filter(|op| pending_op_mentions_skill(op, skill))
+                .take(MAX_RELATED_OPS)
+                .map(|op| {
+                    json!({
+                        "op_id": op.op_id,
+                        "request_id": op.request_id,
+                        "command": op.command,
+                        "created_at": op.created_at,
+                        "details": op.details
+                    })
                 })
-            })
-            .collect();
-        checks.push(check(
+                .collect();
+            checks.push(check(
+                "operations",
+                "recent_pending_ops",
+                pending_ops.is_empty(),
+                "warning",
+                if pending_ops.is_empty() {
+                    "no pending operations for this skill"
+                } else {
+                    "pending operations exist for this skill"
+                },
+                "run loom ops list and resolve or retry pending work",
+                json!({"operations": pending_ops}),
+            ));
+            checks.push(check(
+                "operations",
+                "pending_queue_warnings",
+                report.warnings.is_empty(),
+                "warning",
+                if report.warnings.is_empty() {
+                    "pending operation queue parsed cleanly"
+                } else {
+                    "pending operation queue has parse warnings"
+                },
+                "inspect state/pending_ops.jsonl and pending_ops_history for malformed entries",
+                json!({"warnings": report.warnings}),
+            ));
+        }
+        Err(err) => checks.push(check(
             "operations",
-            "recent_pending_ops",
-            pending_ops.is_empty(),
-            "warning",
-            if pending_ops.is_empty() {
-                "no pending operations for this skill"
-            } else {
-                "pending operations exist for this skill"
-            },
-            "run loom ops list and resolve or retry pending work",
-            json!({"operations": pending_ops}),
-        ));
+            "pending_queue_read",
+            false,
+            "error",
+            "pending operation queue could not be read",
+            "inspect state/pending_ops.jsonl and pending_ops_history permissions or file shape",
+            json!({"error": err.to_string()}),
+        )),
     }
 
     let error_count = checks_with_severity(&checks, "error");
@@ -274,28 +298,55 @@ fn add_git_checks(ctx: &AppContext, skill: &str, source_exists: bool, checks: &m
         return;
     }
     let skill_rel = format!("skills/{skill}");
-    let head_tree = head_tree_oid_for_path(ctx, &skill_rel).ok().flatten();
-    checks.push(check(
-        "git",
-        "source_tracked_at_head",
-        head_tree.is_some(),
-        "error",
-        if head_tree.is_some() {
-            "source skill is tracked at HEAD"
-        } else {
-            "source skill is not tracked at HEAD"
-        },
-        &format!("run loom skill save {skill}"),
-        json!({"head_tree_oid": head_tree}),
-    ));
 
-    let last_commit = last_saved_commit_for_skill(ctx, skill)
-        .ok()
-        .flatten()
-        .or_else(|| last_commit_for_path(ctx, &skill_rel).ok().flatten());
-    let mut drifted =
-        drifted_paths_under(ctx, &skill_rel, last_commit.as_deref()).unwrap_or_default();
-    let truncated = drifted.len() > MAX_DRIFTED_PATHS;
+    match head_tree_oid_for_path(ctx, &skill_rel) {
+        Ok(head_tree) => checks.push(check(
+            "git",
+            "source_tracked_at_head",
+            head_tree.is_some(),
+            "error",
+            if head_tree.is_some() {
+                "source skill is tracked at HEAD"
+            } else {
+                "source skill is not tracked at HEAD"
+            },
+            &format!("run loom skill save {skill}"),
+            json!({"head_tree_oid": head_tree}),
+        )),
+        Err(err) => checks.push(check(
+            "git",
+            "source_tracked_at_head",
+            false,
+            "error",
+            "source tracking could not be verified",
+            "inspect the Git repository before saving or projecting this skill",
+            json!({"error": err.to_string()}),
+        )),
+    }
+
+    let last_commit = match last_saved_commit_for_skill(ctx, skill) {
+        Ok(Some(commit)) => Some(commit),
+        Ok(None) => match last_commit_for_path(ctx, &skill_rel) {
+            Ok(commit) => commit,
+            Err(err) => {
+                push_source_drift_error(checks, None, err);
+                return;
+            }
+        },
+        Err(err) => {
+            push_source_drift_error(checks, None, err);
+            return;
+        }
+    };
+    let mut drifted = match drifted_paths_under(ctx, &skill_rel, last_commit.as_deref()) {
+        Ok(paths) => paths,
+        Err(err) => {
+            push_source_drift_error(checks, last_commit, err);
+            return;
+        }
+    };
+    let drifted_total = drifted.len();
+    let truncated = drifted_total > MAX_DRIFTED_PATHS;
     drifted.truncate(MAX_DRIFTED_PATHS);
     checks.push(check(
         "git",
@@ -310,8 +361,28 @@ fn add_git_checks(ctx: &AppContext, skill: &str, source_exists: bool, checks: &m
         &format!("run loom skill save {skill} or inspect loom skill diff"),
         json!({
             "last_source_commit": last_commit,
+            "drifted_path_count": drifted_total,
             "drifted_paths": drifted,
             "drifted_paths_truncated": truncated
+        }),
+    ));
+}
+
+fn push_source_drift_error(
+    checks: &mut Vec<Value>,
+    last_commit: Option<String>,
+    err: anyhow::Error,
+) {
+    checks.push(check(
+        "git",
+        "source_drift",
+        false,
+        "error",
+        "source drift could not be verified",
+        "inspect the Git repository before saving or projecting this skill",
+        json!({
+            "last_source_commit": last_commit,
+            "error": err.to_string()
         }),
     ));
 }
@@ -604,7 +675,7 @@ fn value_mentions_skill(value: &Value, skill: &str) -> bool {
 }
 
 fn pending_op_mentions_skill(op: &PendingOp, skill: &str) -> bool {
-    op.command.contains(skill) || value_mentions_skill(&op.details, skill)
+    value_mentions_skill(&op.details, skill)
 }
 
 fn checks_with_severity(checks: &[Value], severity: &str) -> usize {
@@ -618,7 +689,11 @@ fn drifted_path_count(checks: &[Value]) -> usize {
     checks
         .iter()
         .find(|check| check["id"].as_str() == Some("source_drift"))
-        .and_then(|check| check["details"]["drifted_paths"].as_array())
-        .map(Vec::len)
+        .and_then(|check| {
+            check["details"]["drifted_path_count"]
+                .as_u64()
+                .map(|count| count as usize)
+                .or_else(|| check["details"]["drifted_paths"].as_array().map(Vec::len))
+        })
         .unwrap_or(0)
 }

--- a/src/commands/skill_diagnose.rs
+++ b/src/commands/skill_diagnose.rs
@@ -1,0 +1,624 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+
+use crate::cli::SkillOnlyArgs;
+use crate::envelope::Meta;
+use crate::state::AppContext;
+use crate::state_model::{RegistryProjectionInstance, RegistrySnapshot, RegistryStatePaths};
+use crate::types::{ErrorCode, PendingOp};
+
+use super::helpers::{map_arg, map_registry_state, validate_skill_name};
+use super::history_cmds::operation_mentions_skill as registry_operation_mentions_skill;
+use super::skill_verify::{
+    drifted_paths_under, head_tree_oid_for_path, last_commit_for_path, last_saved_commit_for_skill,
+};
+use super::{App, CommandFailure};
+
+const MAX_DRIFTED_PATHS: usize = 100;
+const MAX_RELATED_OPS: usize = 10;
+
+impl App {
+    pub fn cmd_skill_diagnose(
+        &self,
+        args: &SkillOnlyArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        validate_skill_name(&args.skill).map_err(map_arg)?;
+        let paths = RegistryStatePaths::from_app_context(&self.ctx);
+        let snapshot = paths.maybe_load_snapshot().map_err(map_registry_state)?;
+        build_skill_diagnosis(&self.ctx, &args.skill, snapshot.as_ref())
+    }
+}
+
+fn build_skill_diagnosis(
+    ctx: &AppContext,
+    skill: &str,
+    snapshot: Option<&RegistrySnapshot>,
+) -> std::result::Result<(Value, Meta), CommandFailure> {
+    let source_path = ctx.skill_path(skill);
+    let source_exists = source_path.is_dir();
+    let referenced = source_exists || snapshot.is_some_and(|s| skill_is_referenced(s, skill));
+    if !referenced {
+        return Err(CommandFailure::new(
+            ErrorCode::SkillNotFound,
+            format!("skill '{}' not found", skill),
+        ));
+    }
+
+    let mut checks = Vec::new();
+    let mut bindings = Vec::new();
+    let mut rules = Vec::new();
+    let mut targets = Vec::new();
+    let mut projections = Vec::new();
+    let mut recent_ops = Vec::new();
+    let mut pending_ops = Vec::new();
+
+    add_source_checks(ctx, skill, &source_path, source_exists, &mut checks);
+    add_git_checks(ctx, skill, source_exists, &mut checks);
+
+    if let Some(snapshot) = snapshot {
+        for rule in snapshot
+            .rules
+            .rules
+            .iter()
+            .filter(|rule| rule.skill_id == skill)
+        {
+            rules.push(json!(rule));
+            if let Some(binding) = snapshot.binding(&rule.binding_id) {
+                bindings.push(json!(binding));
+                add_binding_checks(snapshot, binding, &mut checks);
+            }
+            checks.push(check(
+                "registry",
+                &format!("binding_target_exists:{}", rule.binding_id),
+                snapshot.binding(&rule.binding_id).is_some(),
+                "error",
+                "binding exists for skill rule",
+                "remove or recreate the missing binding",
+                json!({"binding_id": rule.binding_id}),
+            ));
+            add_target_checks(snapshot, &rule.target_id, &rule.method, &mut checks);
+        }
+
+        for projection in snapshot
+            .projections
+            .projections
+            .iter()
+            .filter(|projection| projection.skill_id == skill)
+        {
+            projections.push(json!(projection));
+            add_projection_checks(ctx, snapshot, projection, &mut checks);
+        }
+
+        for target in &snapshot.targets.targets {
+            let used_by_rule = rules
+                .iter()
+                .any(|rule| rule["target_id"].as_str() == Some(&target.target_id));
+            let used_by_projection = projections
+                .iter()
+                .any(|p| p["target_id"].as_str() == Some(&target.target_id));
+            if used_by_rule || used_by_projection {
+                targets.push(json!(target));
+            }
+        }
+
+        recent_ops = snapshot
+            .operations
+            .iter()
+            .rev()
+            .filter(|op| registry_operation_mentions_skill(op, skill))
+            .take(MAX_RELATED_OPS)
+            .map(|op| {
+                json!({
+                    "op_id": op.op_id,
+                    "intent": op.intent,
+                    "status": op.status,
+                    "last_error": op.last_error,
+                    "created_at": op.created_at,
+                    "updated_at": op.updated_at
+                })
+            })
+            .collect();
+        let failed_ops = recent_ops
+            .iter()
+            .filter(|op| !op["last_error"].is_null())
+            .cloned()
+            .collect::<Vec<_>>();
+        checks.push(check(
+            "operations",
+            "recent_failed_ops",
+            failed_ops.is_empty(),
+            "warning",
+            if failed_ops.is_empty() {
+                "no recent failed operations for this skill"
+            } else {
+                "recent operations failed for this skill"
+            },
+            "inspect the failed operation details before retrying",
+            json!({"operations": failed_ops}),
+        ));
+    }
+
+    if let Ok(report) = ctx.read_pending_report() {
+        pending_ops = report
+            .ops
+            .iter()
+            .rev()
+            .filter(|op| pending_op_mentions_skill(op, skill))
+            .take(MAX_RELATED_OPS)
+            .map(|op| {
+                json!({
+                    "op_id": op.op_id,
+                    "request_id": op.request_id,
+                    "command": op.command,
+                    "created_at": op.created_at,
+                    "details": op.details
+                })
+            })
+            .collect();
+        checks.push(check(
+            "operations",
+            "recent_pending_ops",
+            pending_ops.is_empty(),
+            "warning",
+            if pending_ops.is_empty() {
+                "no pending operations for this skill"
+            } else {
+                "pending operations exist for this skill"
+            },
+            "run loom ops list and resolve or retry pending work",
+            json!({"operations": pending_ops}),
+        ));
+    }
+
+    let error_count = checks_with_severity(&checks, "error");
+    let warning_count = checks_with_severity(&checks, "warning");
+    let status = if error_count > 0 {
+        "blocked"
+    } else if warning_count > 0 {
+        "attention"
+    } else {
+        "healthy"
+    };
+
+    Ok((
+        json!({
+            "skill": skill,
+            "healthy": status == "healthy",
+            "status": status,
+            "summary": {
+                "source_status": if source_exists { "present" } else { "missing" },
+                "binding_count": bindings.len(),
+                "target_count": targets.len(),
+                "projection_count": projections.len(),
+                "failed_check_count": error_count,
+                "warning_check_count": warning_count,
+                "drifted_path_count": drifted_path_count(&checks),
+                "recent_failed_op_count": recent_ops.iter().filter(|op| !op["last_error"].is_null()).count()
+            },
+            "checks": checks,
+            "related": {
+                "source": {
+                    "path": source_path.display().to_string(),
+                    "entrypoint": skill_entrypoint(&source_path).map(|p| p.display().to_string()),
+                    "description": skill_description(&source_path).ok().flatten()
+                },
+                "bindings": bindings,
+                "rules": rules,
+                "targets": targets,
+                "projections": projections,
+                "recent_operations": recent_ops,
+                "pending_operations": pending_ops
+            }
+        }),
+        Meta::default(),
+    ))
+}
+
+fn add_source_checks(
+    ctx: &AppContext,
+    skill: &str,
+    source_path: &Path,
+    source_exists: bool,
+    checks: &mut Vec<Value>,
+) {
+    checks.push(check(
+        "source",
+        "source_directory_exists",
+        source_exists,
+        "error",
+        if source_exists {
+            "source skill directory exists"
+        } else {
+            "source skill directory is missing"
+        },
+        "restore the source skill, re-add it, or clean orphaned references",
+        json!({"path": source_path.display().to_string()}),
+    ));
+    let entrypoint = skill_entrypoint(source_path);
+    checks.push(check(
+        "source",
+        "skill_file_exists",
+        entrypoint.is_some(),
+        "error",
+        if entrypoint.is_some() {
+            "skill entrypoint exists"
+        } else {
+            "skill entrypoint is missing"
+        },
+        &format!("add skills/{skill}/SKILL.md or remove the non-compliant source"),
+        json!({
+            "accepted": ["SKILL.md", "skill.md"],
+            "found": entrypoint.map(|p| p.file_name().unwrap_or_default().to_string_lossy().to_string())
+        }),
+    ));
+    let description = skill_description(source_path).ok().flatten();
+    checks.push(check(
+        "source",
+        "skill_frontmatter_description",
+        description.is_some() || !source_exists,
+        "warning",
+        if description.is_some() || !source_exists {
+            "skill description is available or source is absent"
+        } else {
+            "skill description is missing"
+        },
+        &format!("add description frontmatter to skills/{skill}/SKILL.md"),
+        json!({"root": ctx.root.display().to_string()}),
+    ));
+}
+
+fn add_git_checks(ctx: &AppContext, skill: &str, source_exists: bool, checks: &mut Vec<Value>) {
+    if !source_exists {
+        return;
+    }
+    let skill_rel = format!("skills/{skill}");
+    let head_tree = head_tree_oid_for_path(ctx, &skill_rel).ok().flatten();
+    checks.push(check(
+        "git",
+        "source_tracked_at_head",
+        head_tree.is_some(),
+        "error",
+        if head_tree.is_some() {
+            "source skill is tracked at HEAD"
+        } else {
+            "source skill is not tracked at HEAD"
+        },
+        &format!("run loom skill save {skill}"),
+        json!({"head_tree_oid": head_tree}),
+    ));
+
+    let last_commit = last_saved_commit_for_skill(ctx, skill)
+        .ok()
+        .flatten()
+        .or_else(|| last_commit_for_path(ctx, &skill_rel).ok().flatten());
+    let mut drifted =
+        drifted_paths_under(ctx, &skill_rel, last_commit.as_deref()).unwrap_or_default();
+    let truncated = drifted.len() > MAX_DRIFTED_PATHS;
+    drifted.truncate(MAX_DRIFTED_PATHS);
+    checks.push(check(
+        "git",
+        "source_drift",
+        drifted.is_empty(),
+        "warning",
+        if drifted.is_empty() {
+            "source has no unsaved drift"
+        } else {
+            "source has unsaved drift"
+        },
+        &format!("run loom skill save {skill} or inspect loom skill diff"),
+        json!({
+            "last_source_commit": last_commit,
+            "drifted_paths": drifted,
+            "drifted_paths_truncated": truncated
+        }),
+    ));
+}
+
+fn add_binding_checks(
+    snapshot: &RegistrySnapshot,
+    binding: &crate::state_model::RegistryWorkspaceBinding,
+    checks: &mut Vec<Value>,
+) {
+    checks.push(check(
+        "registry",
+        &format!("binding_active:{}", binding.binding_id),
+        binding.active,
+        "warning",
+        if binding.active {
+            "binding is active"
+        } else {
+            "binding is inactive"
+        },
+        "reactivate or replace the binding before projecting",
+        json!({"binding_id": binding.binding_id}),
+    ));
+    if let Some(default_target) = snapshot.target(&binding.default_target_id) {
+        checks.push(check(
+            "registry",
+            &format!("binding_target_agent_match:{}", binding.binding_id),
+            default_target.agent == binding.agent,
+            "error",
+            if default_target.agent == binding.agent {
+                "binding and target agents match"
+            } else {
+                "binding and target agents do not match"
+            },
+            "point the binding at a target registered for the same agent",
+            json!({
+                "binding_id": binding.binding_id,
+                "binding_agent": binding.agent,
+                "target_id": default_target.target_id,
+                "target_agent": default_target.agent
+            }),
+        ));
+    }
+}
+
+fn add_target_checks(
+    snapshot: &RegistrySnapshot,
+    target_id: &str,
+    method: &str,
+    checks: &mut Vec<Value>,
+) {
+    let Some(target) = snapshot.target(target_id) else {
+        checks.push(check(
+            "targets",
+            &format!("target_path_exists:{target_id}"),
+            false,
+            "error",
+            "target is missing",
+            "recreate the target or remove the rule",
+            json!({"target_id": target_id}),
+        ));
+        return;
+    };
+    checks.push(check(
+        "targets",
+        &format!("target_path_exists:{}", target.target_id),
+        Path::new(&target.path).exists(),
+        "error",
+        if Path::new(&target.path).exists() {
+            "target path exists"
+        } else {
+            "target path is missing"
+        },
+        "recreate the target path or update the target",
+        json!({"target_id": target.target_id, "path": target.path}),
+    ));
+    checks.push(check(
+        "targets",
+        &format!("target_ownership_writeable:{}", target.target_id),
+        target.ownership == "managed",
+        "warning",
+        if target.ownership == "managed" {
+            "target is managed"
+        } else {
+            "target is not managed"
+        },
+        "set target ownership to managed before writing projections",
+        json!({"target_id": target.target_id, "ownership": target.ownership}),
+    ));
+    let capability_ok = match method {
+        "symlink" => target.capabilities.symlink,
+        "copy" | "materialize" => target.capabilities.copy,
+        _ => false,
+    };
+    checks.push(check(
+        "targets",
+        &format!("target_capability:{}:{}", target.target_id, method),
+        capability_ok,
+        "error",
+        "target supports projection method",
+        "choose a supported projection method or update the target",
+        json!({"target_id": target.target_id, "method": method}),
+    ));
+}
+
+fn add_projection_checks(
+    ctx: &AppContext,
+    snapshot: &RegistrySnapshot,
+    projection: &RegistryProjectionInstance,
+    checks: &mut Vec<Value>,
+) {
+    let materialized = Path::new(&projection.materialized_path);
+    checks.push(check(
+        "projection",
+        &format!("projection_path_exists:{}", projection.instance_id),
+        materialized.exists(),
+        "error",
+        if materialized.exists() {
+            "projection path exists"
+        } else {
+            "projection path is missing"
+        },
+        "rerun loom skill project or clean the orphaned projection",
+        json!({"instance_id": projection.instance_id, "path": projection.materialized_path}),
+    ));
+    checks.push(check(
+        "projection",
+        &format!("projection_source_exists:{}", projection.instance_id),
+        ctx.skill_path(&projection.skill_id).exists(),
+        "error",
+        "projection source skill exists",
+        "restore the source skill or clean the projection",
+        json!({"instance_id": projection.instance_id, "skill_id": projection.skill_id}),
+    ));
+    checks.push(check(
+        "projection",
+        &format!("projection_health:{}", projection.instance_id),
+        projection.health == "healthy",
+        if projection.health == "drifted" || projection.health == "orphaned" {
+            "warning"
+        } else {
+            "error"
+        },
+        if projection.health == "healthy" {
+            "projection is healthy"
+        } else {
+            "projection is not healthy"
+        },
+        "inspect projection drift, re-project, capture, or clean orphaned metadata",
+        json!({"instance_id": projection.instance_id, "health": projection.health}),
+    ));
+    checks.push(check(
+        "projection",
+        &format!("projection_observed_drift:{}", projection.instance_id),
+        !projection.observed_drift.unwrap_or(false),
+        "warning",
+        "projection has no observed drift",
+        "capture or re-project the skill",
+        json!({"instance_id": projection.instance_id, "observed_drift": projection.observed_drift}),
+    ));
+    let binding_ok = projection
+        .binding_id
+        .as_deref()
+        .is_some_and(|id| snapshot.binding(id).is_some());
+    let orphan_ok = projection.binding_id.is_none() && projection.health == "orphaned";
+    checks.push(check(
+        "projection",
+        &format!("projection_binding_exists:{}", projection.instance_id),
+        binding_ok || orphan_ok,
+        if orphan_ok { "warning" } else { "error" },
+        if binding_ok {
+            "projection binding exists"
+        } else if orphan_ok {
+            "projection is orphaned"
+        } else {
+            "projection binding is missing"
+        },
+        "recreate the binding or clean orphaned projection metadata",
+        json!({"instance_id": projection.instance_id, "binding_id": projection.binding_id}),
+    ));
+    if projection.method == "symlink" {
+        checks.push(check_symlink_target(ctx, projection, materialized));
+    }
+}
+
+fn check_symlink_target(
+    ctx: &AppContext,
+    projection: &RegistryProjectionInstance,
+    materialized: &Path,
+) -> Value {
+    let expected = ctx.skill_path(&projection.skill_id);
+    let result = fs::read_link(materialized).map(|target| {
+        let resolved = if target.is_absolute() {
+            target
+        } else {
+            materialized
+                .parent()
+                .map(|parent| parent.join(&target))
+                .unwrap_or(target)
+        };
+        resolved.exists() && fs::canonicalize(&resolved).ok() == fs::canonicalize(&expected).ok()
+    });
+    check(
+        "projection",
+        &format!("projection_symlink_target:{}", projection.instance_id),
+        result.unwrap_or(false),
+        "error",
+        "symlink projection points at source skill",
+        "rerun loom skill project with a supported method",
+        json!({"instance_id": projection.instance_id, "path": projection.materialized_path}),
+    )
+}
+
+fn check(
+    section: &str,
+    id: &str,
+    ok: bool,
+    failure_severity: &str,
+    message: &str,
+    next_action: &str,
+    details: Value,
+) -> Value {
+    json!({
+        "section": section,
+        "id": id,
+        "ok": ok,
+        "severity": if ok { "ok" } else { failure_severity },
+        "message": message,
+        "next_action": if ok { Value::Null } else { Value::String(next_action.to_string()) },
+        "details": details
+    })
+}
+
+fn skill_is_referenced(snapshot: &RegistrySnapshot, skill: &str) -> bool {
+    snapshot
+        .rules
+        .rules
+        .iter()
+        .any(|rule| rule.skill_id == skill)
+        || snapshot
+            .projections
+            .projections
+            .iter()
+            .any(|projection| projection.skill_id == skill)
+        || snapshot
+            .operations
+            .iter()
+            .any(|op| registry_operation_mentions_skill(op, skill))
+}
+
+fn skill_entrypoint(path: &Path) -> Option<PathBuf> {
+    for name in ["SKILL.md", "skill.md"] {
+        let candidate = path.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn skill_description(path: &Path) -> anyhow::Result<Option<String>> {
+    let Some(entrypoint) = skill_entrypoint(path) else {
+        return Ok(None);
+    };
+    let raw = fs::read_to_string(entrypoint)?;
+    let Some(rest) = raw.strip_prefix("---") else {
+        return Ok(None);
+    };
+    for line in rest.lines().skip(1) {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            break;
+        }
+        if let Some(value) = trimmed.strip_prefix("description:") {
+            let value = value.trim().trim_matches('"').trim_matches('\'').trim();
+            if !value.is_empty() {
+                return Ok(Some(value.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn value_mentions_skill(value: &Value, skill: &str) -> bool {
+    value.get("skill").and_then(Value::as_str) == Some(skill)
+        || value.get("skill_id").and_then(Value::as_str) == Some(skill)
+        || value
+            .get("skills")
+            .and_then(Value::as_array)
+            .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(skill)))
+}
+
+fn pending_op_mentions_skill(op: &PendingOp, skill: &str) -> bool {
+    op.command.contains(skill) || value_mentions_skill(&op.details, skill)
+}
+
+fn checks_with_severity(checks: &[Value], severity: &str) -> usize {
+    checks
+        .iter()
+        .filter(|check| check["severity"].as_str() == Some(severity))
+        .count()
+}
+
+fn drifted_path_count(checks: &[Value]) -> usize {
+    checks
+        .iter()
+        .find(|check| check["id"].as_str() == Some("source_drift"))
+        .and_then(|check| check["details"]["drifted_paths"].as_array())
+        .map(Vec::len)
+        .unwrap_or(0)
+}

--- a/src/commands/skill_diagnose.rs
+++ b/src/commands/skill_diagnose.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -58,6 +59,9 @@ fn build_skill_diagnosis(
     add_git_checks(ctx, skill, source_exists, &mut checks);
 
     if let Some(snapshot) = snapshot {
+        let mut rule_target_ids = BTreeSet::new();
+        let mut projection_only_target_ids = BTreeSet::new();
+
         for rule in snapshot
             .rules
             .rules
@@ -79,6 +83,7 @@ fn build_skill_diagnosis(
                 json!({"binding_id": rule.binding_id}),
             ));
             add_target_checks(snapshot, &rule.target_id, &rule.method, &mut checks);
+            rule_target_ids.insert(rule.target_id.clone());
         }
 
         for projection in snapshot
@@ -89,6 +94,16 @@ fn build_skill_diagnosis(
         {
             projections.push(json!(projection));
             add_projection_checks(ctx, snapshot, projection, &mut checks);
+            if !rule_target_ids.contains(&projection.target_id)
+                && projection_only_target_ids.insert(projection.target_id.clone())
+            {
+                add_target_checks(
+                    snapshot,
+                    &projection.target_id,
+                    &projection.method,
+                    &mut checks,
+                );
+            }
         }
 
         for target in &snapshot.targets.targets {

--- a/src/commands/skill_diagnose_tests.rs
+++ b/src/commands/skill_diagnose_tests.rs
@@ -253,3 +253,164 @@ fn skill_diagnose_reports_unsaved_source_drift() {
     assert_eq!(payload["status"], json!("attention"));
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn skill_diagnose_reports_total_drift_count_when_paths_are_truncated() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    for index in 0..101 {
+        fs::write(root.join(format!("skills/demo/drift-{index}.md")), "new").expect("write drift");
+    }
+
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let drift_check = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "source_drift")
+        .expect("drift check");
+
+    assert_eq!(payload["summary"]["drifted_path_count"], json!(101));
+    assert_eq!(drift_check["details"]["drifted_path_count"], json!(101));
+    assert_eq!(
+        drift_check["details"]["drifted_paths_truncated"],
+        json!(true)
+    );
+    assert_eq!(
+        drift_check["details"]["drifted_paths"]
+            .as_array()
+            .unwrap()
+            .len(),
+        100
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_reports_pending_queue_warnings() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    let app = app(&root);
+    app.ctx.ensure_state_layout().expect("layout");
+    fs::write(&app.ctx.pending_ops_file, "not-json\n").expect("write malformed pending op");
+
+    let (payload, _) = app
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let pending_warning = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "pending_queue_warnings")
+        .expect("pending warning check");
+
+    assert_eq!(pending_warning["ok"], json!(false));
+    assert_eq!(pending_warning["severity"], json!("warning"));
+    assert!(
+        pending_warning["details"]["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|message| message.contains("skipped malformed pending op")))
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_reports_pending_queue_read_errors() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    let app = app(&root);
+    app.ctx.ensure_state_layout().expect("layout");
+    fs::remove_file(&app.ctx.pending_ops_file).expect("remove pending ops file");
+    fs::create_dir_all(&app.ctx.pending_ops_file).expect("replace pending ops file with directory");
+
+    let (payload, _) = app
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let pending_read = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "pending_queue_read")
+        .expect("pending read check");
+
+    assert_eq!(payload["status"], json!("blocked"));
+    assert_eq!(pending_read["ok"], json!(false));
+    assert_eq!(pending_read["severity"], json!("error"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_matches_pending_operations_by_structured_skill_fields_only() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    let app = app(&root);
+    app.ctx
+        .append_pending(
+            "skill.save demo",
+            json!({"skill": "other"}),
+            "req-1".to_string(),
+        )
+        .expect("append pending op");
+
+    let (payload, _) = app
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let pending = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "recent_pending_ops")
+        .expect("pending check");
+
+    assert_eq!(pending["ok"], json!(true));
+    assert!(
+        payload["related"]["pending_operations"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_reports_source_drift_git_read_errors() {
+    let root = std::env::temp_dir().join(format!("loom-skill-diagnose-no-git-{}", Uuid::new_v4()));
+    fs::create_dir_all(&root).expect("root");
+    write_skill(&root, "demo");
+
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let drift = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "source_drift")
+        .expect("drift check");
+
+    assert_eq!(payload["status"], json!("blocked"));
+    assert_eq!(drift["ok"], json!(false));
+    assert_eq!(drift["severity"], json!("error"));
+    assert!(drift["details"]["error"].as_str().is_some());
+    let _ = fs::remove_dir_all(root);
+}

--- a/src/commands/skill_diagnose_tests.rs
+++ b/src/commands/skill_diagnose_tests.rs
@@ -414,3 +414,76 @@ fn skill_diagnose_reports_source_drift_git_read_errors() {
     assert!(drift["details"]["error"].as_str().is_some());
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn skill_diagnose_checks_projection_only_targets() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    let paths = RegistryStatePaths::from_root(&root);
+    paths.ensure_layout().expect("layout");
+    paths
+        .save_targets(&RegistryTargetsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            targets: vec![],
+        })
+        .expect("targets");
+    paths
+        .save_bindings(&RegistryBindingsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            bindings: vec![],
+        })
+        .expect("bindings");
+    paths
+        .save_rules(&RegistryRulesFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            rules: vec![],
+        })
+        .expect("rules");
+    paths
+        .save_projections(&RegistryProjectionsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            projections: vec![RegistryProjectionInstance {
+                instance_id: "inst-orphan".to_string(),
+                skill_id: "demo".to_string(),
+                binding_id: None,
+                target_id: "deleted-target".to_string(),
+                materialized_path: root.join("deleted/demo").display().to_string(),
+                method: "copy".to_string(),
+                last_applied_rev: "HEAD".to_string(),
+                health: "orphaned".to_string(),
+                observed_drift: Some(false),
+                updated_at: Some(Utc::now()),
+            }],
+        })
+        .expect("projections");
+    paths
+        .save_checkpoint(&RegistryOpsCheckpoint {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            last_scanned_op_id: None,
+            last_acked_op_id: None,
+            updated_at: Utc::now(),
+        })
+        .expect("checkpoint");
+
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let target_check = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "target_path_exists:deleted-target")
+        .expect("projection-only target check");
+
+    assert_eq!(payload["status"], json!("blocked"));
+    assert_eq!(target_check["ok"], json!(false));
+    assert_eq!(target_check["severity"], json!("error"));
+    assert_eq!(
+        target_check["details"]["target_id"],
+        json!("deleted-target")
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/src/commands/skill_diagnose_tests.rs
+++ b/src/commands/skill_diagnose_tests.rs
@@ -1,0 +1,255 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+
+use chrono::Utc;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::cli::SkillOnlyArgs;
+use crate::commands::App;
+use crate::state_model::{
+    REGISTRY_SCHEMA_VERSION, RegistryBindingRule, RegistryBindingsFile, RegistryOperationRecord,
+    RegistryOpsCheckpoint, RegistryProjectionInstance, RegistryProjectionTarget,
+    RegistryProjectionsFile, RegistryRulesFile, RegistryStatePaths, RegistryTargetCapabilities,
+    RegistryTargetsFile, RegistryWorkspaceBinding, RegistryWorkspaceMatcher,
+};
+
+fn test_root() -> PathBuf {
+    let root = std::env::temp_dir().join(format!("loom-skill-diagnose-{}", Uuid::new_v4()));
+    fs::create_dir_all(&root).expect("create root");
+    git(&root, &["init"]);
+    git(&root, &["config", "user.email", "loom@example.com"]);
+    git(&root, &["config", "user.name", "Loom Test"]);
+    root
+}
+
+fn app(root: &Path) -> App {
+    App::new(Some(root.to_path_buf())).expect("app")
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_all(root: &Path) {
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", "test setup"]);
+}
+
+fn write_skill(root: &Path, skill: &str) {
+    let skill_dir = root.join("skills").join(skill);
+    fs::create_dir_all(&skill_dir).expect("skill dir");
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\ndescription: Demo skill\n---\nbody\n",
+    )
+    .expect("skill file");
+}
+
+fn write_snapshot(root: &Path, target_path: &Path, projection_path: &Path, skill: &str) {
+    let paths = RegistryStatePaths::from_root(root);
+    paths.ensure_layout().expect("layout");
+    paths
+        .save_targets(&RegistryTargetsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            targets: vec![RegistryProjectionTarget {
+                target_id: "target-1".to_string(),
+                agent: "claude".to_string(),
+                path: target_path.display().to_string(),
+                ownership: "managed".to_string(),
+                capabilities: RegistryTargetCapabilities {
+                    symlink: true,
+                    copy: true,
+                    watch: true,
+                },
+                created_at: Some(Utc::now()),
+            }],
+        })
+        .expect("targets");
+    paths
+        .save_bindings(&RegistryBindingsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            bindings: vec![RegistryWorkspaceBinding {
+                binding_id: "binding-1".to_string(),
+                agent: "claude".to_string(),
+                profile_id: "default".to_string(),
+                workspace_matcher: RegistryWorkspaceMatcher {
+                    kind: "path_prefix".to_string(),
+                    value: root.display().to_string(),
+                },
+                default_target_id: "target-1".to_string(),
+                policy_profile: "safe-capture".to_string(),
+                active: true,
+                created_at: Some(Utc::now()),
+            }],
+        })
+        .expect("bindings");
+    paths
+        .save_rules(&RegistryRulesFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            rules: vec![RegistryBindingRule {
+                binding_id: "binding-1".to_string(),
+                skill_id: skill.to_string(),
+                target_id: "target-1".to_string(),
+                method: "symlink".to_string(),
+                watch_policy: "manual".to_string(),
+                created_at: Some(Utc::now()),
+            }],
+        })
+        .expect("rules");
+    paths
+        .save_projections(&RegistryProjectionsFile {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            projections: vec![RegistryProjectionInstance {
+                instance_id: "inst-1".to_string(),
+                skill_id: skill.to_string(),
+                binding_id: Some("binding-1".to_string()),
+                target_id: "target-1".to_string(),
+                materialized_path: projection_path.display().to_string(),
+                method: "symlink".to_string(),
+                last_applied_rev: "HEAD".to_string(),
+                health: "healthy".to_string(),
+                observed_drift: Some(false),
+                updated_at: Some(Utc::now()),
+            }],
+        })
+        .expect("projections");
+    paths
+        .save_checkpoint(&RegistryOpsCheckpoint {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            last_scanned_op_id: None,
+            last_acked_op_id: None,
+            updated_at: Utc::now(),
+        })
+        .expect("checkpoint");
+}
+
+#[test]
+fn skill_diagnose_unknown_skill_returns_not_found() {
+    let root = test_root();
+    let err = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "missing".to_string(),
+        })
+        .expect_err("missing skill");
+    assert_eq!(err.code.as_str(), "SKILL_NOT_FOUND");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_reports_missing_source_for_referenced_skill() {
+    let root = test_root();
+    let target = root.join("target");
+    fs::create_dir_all(&target).expect("target");
+    write_snapshot(&root, &target, &target.join("demo"), "demo");
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    assert_eq!(payload["status"], json!("blocked"));
+    assert!(
+        payload["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check["id"] == "source_directory_exists" && check["ok"] == false)
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_recognizes_observed_import_operation_reference() {
+    let root = test_root();
+    let paths = RegistryStatePaths::from_root(&root);
+    paths.ensure_layout().expect("layout");
+    paths
+        .append_operation(&RegistryOperationRecord {
+            op_id: "op-observed".to_string(),
+            intent: "skill.import_observed".to_string(),
+            status: "succeeded".to_string(),
+            ack: true,
+            payload: json!({}),
+            effects: json!({"imported": [{"skill": "observed-skill"}]}),
+            last_error: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+        .expect("append op");
+
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "observed-skill".to_string(),
+        })
+        .expect("diagnose");
+
+    assert_eq!(payload["status"], json!("blocked"));
+    assert_eq!(
+        payload["related"]["recent_operations"][0]["op_id"],
+        json!("op-observed")
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_resolves_relative_symlink_from_link_parent() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    let target = root.join("target");
+    fs::create_dir_all(&target).expect("target");
+    let link = target.join("demo");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("../skills/demo", &link).expect("symlink");
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir("..\\skills\\demo", &link).expect("symlink");
+    write_snapshot(&root, &target, &link, "demo");
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let symlink_check = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "projection_symlink_target:inst-1")
+        .expect("symlink check");
+    assert_eq!(symlink_check["ok"], json!(true));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skill_diagnose_reports_unsaved_source_drift() {
+    let root = test_root();
+    write_skill(&root, "demo");
+    commit_all(&root);
+    fs::write(root.join("skills/demo/notes.md"), "new").expect("write drift");
+    let (payload, _) = app(&root)
+        .cmd_skill_diagnose(&SkillOnlyArgs {
+            skill: "demo".to_string(),
+        })
+        .expect("diagnose");
+    let drift_check = payload["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "source_drift")
+        .expect("drift check");
+    assert_eq!(drift_check["ok"], json!(false));
+    assert_eq!(payload["status"], json!("attention"));
+    let _ = fs::remove_dir_all(root);
+}

--- a/src/commands/skill_verify.rs
+++ b/src/commands/skill_verify.rs
@@ -57,7 +57,7 @@ impl App {
     }
 }
 
-fn last_saved_commit_for_skill(ctx: &AppContext, skill: &str) -> Result<Option<String>> {
+pub(crate) fn last_saved_commit_for_skill(ctx: &AppContext, skill: &str) -> Result<Option<String>> {
     let Some(op_id) = last_save_op_id_for_skill(ctx, skill)? else {
         return Ok(None);
     };
@@ -136,7 +136,7 @@ fn operation_log_contains_op_id(raw: &str, op_id: &str) -> Result<bool> {
     Ok(false)
 }
 
-fn head_tree_oid_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> {
+pub(crate) fn head_tree_oid_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> {
     let output = run_git_allow_failure(ctx, &["rev-parse", &format!("HEAD:{path}")])?;
     if output.status.success() {
         let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -150,7 +150,7 @@ fn head_tree_oid_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>
     }
 }
 
-fn last_commit_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> {
+pub(crate) fn last_commit_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> {
     let stdout = run_git(ctx, &["log", "-1", "--format=%H", "--", path])?;
     let trimmed = stdout.trim();
     if trimmed.is_empty() {
@@ -160,7 +160,7 @@ fn last_commit_for_path(ctx: &AppContext, path: &str) -> Result<Option<String>> 
     }
 }
 
-fn drifted_paths_under(
+pub(crate) fn drifted_paths_under(
     ctx: &AppContext,
     prefix: &str,
     base_commit: Option<&str>,

--- a/src/panel/handlers/skills.rs
+++ b/src/panel/handlers/skills.rs
@@ -2,9 +2,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{Json, extract::Path as AxumPath, extract::State, http::StatusCode};
 use serde_json::json;
 
+use crate::cli::SkillOnlyArgs;
+use crate::commands::App;
 use crate::commands::collect_skill_inventory;
 use crate::envelope::Envelope;
 use crate::gitops;
@@ -13,6 +15,7 @@ use crate::types::ErrorCode;
 
 use super::super::PanelState;
 use super::super::auth::registry_ok;
+use super::common::panel_command_envelope;
 
 #[derive(Debug, Default)]
 struct SkillReadRow {
@@ -71,6 +74,19 @@ pub(in crate::panel) async fn v1_skills(
             ))),
         ),
     }
+}
+
+pub(in crate::panel) async fn v1_skill_diagnose(
+    AxumPath(skill_name): AxumPath<String>,
+    State(state): State<PanelState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let app = App {
+        ctx: state.ctx.as_ref().clone(),
+    };
+    panel_command_envelope(
+        "skill.diagnose",
+        app.cmd_skill_diagnose(&SkillOnlyArgs { skill: skill_name }),
+    )
 }
 
 fn build_skill_read_model(

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -163,6 +163,10 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         )
         .route("/api/v1/skills", get(v1_skills).post(registry_skill_add))
         .route(
+            "/api/v1/skills/{skill_name}/diagnose",
+            get(v1_skill_diagnose),
+        )
+        .route(
             "/api/v1/skills/{skill_name}/save",
             post(registry_skill_save),
         )

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::panel::handlers::{
     OpsQuery, info, pending, registry_ops, registry_orphan_clean, remote_set, remote_status,
-    v1_health, v1_overview, v1_registry_ops, v1_registry_targets, v1_skills, v1_workspace_status,
+    v1_health, v1_overview, v1_registry_ops, v1_registry_targets, v1_skill_diagnose, v1_skills,
+    v1_workspace_status,
 };
 use crate::state_model::{
     REGISTRY_SCHEMA_VERSION, RegistryBindingRule, RegistryOperationRecord,
@@ -359,6 +360,35 @@ async fn v1_skills_returns_union_read_model() {
         json!("abcdef1234567890")
     );
     assert_eq!(by_id("observed-only")["observed_imported"], json!(true));
+
+    cleanup_root(root);
+}
+
+#[tokio::test]
+async fn v1_skill_diagnose_returns_envelope_without_command_audit() {
+    let (root, state) = make_test_state();
+    let source_dir = root.join("skills/present-skill");
+    fs::create_dir_all(&source_dir).expect("create skill");
+    fs::write(
+        source_dir.join("SKILL.md"),
+        "---\ndescription: Present skill\n---\n",
+    )
+    .expect("write skill");
+
+    let (status, Json(payload)) = v1_skill_diagnose(
+        axum::extract::Path("present-skill".to_string()),
+        State(state),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["ok"], json!(true));
+    assert_eq!(payload["cmd"], json!("skill.diagnose"));
+    assert_eq!(payload["data"]["skill"], json!("present-skill"));
+    assert!(
+        !root.join("state/events/commands.jsonl").exists(),
+        "interactive panel diagnose must not append command-audit rows"
+    );
 
     cleanup_root(root);
 }


### PR DESCRIPTION
## Summary
- adds `loom skill diagnose <skill>` with a read-only per-skill diagnosis payload
- exposes `GET /api/v1/skills/{skill_name}/diagnose` without panel command-audit spam
- covers source, git drift, registry relations, targets, projections, symlink target checks, recent ops, and pending ops

## Verification
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test skill_diagnose`
- `cargo test v1_skill_diagnose`
- `cargo test`

Part of #227.