### PR TITLE
[codex] Add skill diagnose panel tab

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -374,6 +374,36 @@ export interface SkillHistoryPayload {
   meta?: { warnings?: string[] };
 }
 
+export type SkillDiagnoseStatus = "healthy" | "attention" | "blocked";
+
+export interface SkillDiagnoseCheck {
+  section: string;
+  id: string;
+  ok: boolean;
+  severity: "ok" | "warning" | "error" | string;
+  message: string;
+  next_action?: string | null;
+  details?: Record<string, unknown>;
+}
+
+export interface SkillDiagnosePayload {
+  skill: string;
+  healthy: boolean;
+  status: SkillDiagnoseStatus | string;
+  summary: {
+    source_status: string;
+    binding_count: number;
+    target_count: number;
+    projection_count: number;
+    failed_check_count: number;
+    warning_check_count: number;
+    drifted_path_count: number;
+    recent_failed_op_count: number;
+  };
+  checks: SkillDiagnoseCheck[];
+  related?: Record<string, unknown>;
+}
+
 export interface DoctorCheck {
   section: string;
   id: string;
@@ -452,6 +482,12 @@ export const api = {
   skillHistory: (name: string, signal?: AbortSignal) =>
     getJson<SkillHistoryPayload>(
       `/api/registry/skills/${encodeURIComponent(name)}/history`,
+      signal,
+    ),
+
+  skillDiagnose: (name: string, signal?: AbortSignal) =>
+    getJsonData<SkillDiagnosePayload>(
+      `/api/v1/skills/${encodeURIComponent(name)}/diagnose`,
       signal,
     ),
 

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -351,6 +351,11 @@ describe("SkillsPage — diagnose tab", () => {
     });
     (api.skillDiff as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
     (api.skillDiagnose as ReturnType<typeof vi.fn>).mockResolvedValue(makeDiagnose());
+    (api.skillSave as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      cmd: "skill.save",
+      request_id: "req-save",
+    });
   });
 
   it("does not fetch diagnose data while Lifecycle remains active", async () => {
@@ -374,6 +379,64 @@ describe("SkillsPage — diagnose tab", () => {
       expect(
         screen.getByText(/restore the source skill, re-add it, or clean orphaned references/),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state while diagnose data is in-flight", () => {
+    (api.skillDiagnose as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnose" }));
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("shows diagnose errors when the fetch rejects", async () => {
+    (api.skillDiagnose as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("diagnose unavailable"),
+    );
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnose" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("diagnose unavailable")).toBeInTheDocument();
+    });
+  });
+
+  it("refetches diagnose data after lifecycle mutations while Diagnose is active", async () => {
+    (api.skillDiagnose as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeDiagnose({ status: "blocked" }))
+      .mockResolvedValueOnce(
+        makeDiagnose({
+          healthy: true,
+          status: "healthy",
+          summary: {
+            source_status: "present",
+            binding_count: 0,
+            target_count: 0,
+            projection_count: 0,
+            failed_check_count: 0,
+            warning_check_count: 0,
+            drifted_path_count: 0,
+            recent_failed_op_count: 0,
+          },
+          checks: [],
+        }),
+      );
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnose" }));
+    await waitFor(() => {
+      expect(screen.getByText("blocked")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(api.skillSave).toHaveBeenCalledWith("my-skill");
+      expect(api.skillDiagnose).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("healthy")).toBeInTheDocument();
     });
   });
 });

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -7,6 +7,7 @@ import type { RegistryProjection } from "../../generated/RegistryProjection";
 vi.mock("../../lib/api/client", () => ({
   api: {
     skillHistory: vi.fn(),
+    skillDiagnose: vi.fn(),
     skillDiff: vi.fn(),
     capture: vi.fn(),
     skillSave: vi.fn(),
@@ -82,6 +83,55 @@ function makeTarget(overrides: Partial<Target> = {}): Target {
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
     ...mockSkill,
+    ...overrides,
+  };
+}
+
+function makeDiagnose(overrides: Record<string, unknown> = {}) {
+  return {
+    skill: "my-skill",
+    healthy: false,
+    status: "blocked",
+    summary: {
+      source_status: "missing",
+      binding_count: 0,
+      target_count: 0,
+      projection_count: 0,
+      failed_check_count: 1,
+      warning_check_count: 1,
+      drifted_path_count: 0,
+      recent_failed_op_count: 0,
+    },
+    checks: [
+      {
+        section: "source",
+        id: "source_directory_exists",
+        ok: false,
+        severity: "error",
+        message: "source skill directory is missing",
+        next_action: "restore the source skill, re-add it, or clean orphaned references",
+        details: { path: "/tmp/skills/my-skill" },
+      },
+      {
+        section: "git",
+        id: "source_drift",
+        ok: false,
+        severity: "warning",
+        message: "source has unsaved drift",
+        next_action: "run loom skill save my-skill or inspect loom skill diff",
+        details: { drifted_paths: ["SKILL.md"] },
+      },
+      {
+        section: "operations",
+        id: "recent_failed_ops",
+        ok: true,
+        severity: "ok",
+        message: "no recent failed operations for this skill",
+        next_action: null,
+        details: { operations: [] },
+      },
+    ],
+    related: {},
     ...overrides,
   };
 }
@@ -288,6 +338,42 @@ describe("SkillsPage — history tab", () => {
 
     await waitFor(() => {
       expect(api.skillHistory).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("SkillsPage — diagnose tab", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (api.skillHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      data: { skill: "my-skill", count: 0, events: [] },
+    });
+    (api.skillDiff as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    (api.skillDiagnose as ReturnType<typeof vi.fn>).mockResolvedValue(makeDiagnose());
+  });
+
+  it("does not fetch diagnose data while Lifecycle remains active", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(api.skillHistory).toHaveBeenCalledTimes(1);
+    });
+    expect(api.skillDiagnose).not.toHaveBeenCalled();
+  });
+
+  it("fetches diagnose data when clicked and renders blocked checks with next action", async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnose" }));
+
+    await waitFor(() => {
+      expect(api.skillDiagnose).toHaveBeenCalledWith("my-skill", expect.any(AbortSignal));
+      expect(screen.getByText("blocked")).toBeInTheDocument();
+      expect(screen.getByText("source_directory_exists")).toBeInTheDocument();
+      expect(
+        screen.getByText(/restore the source skill, re-add it, or clean orphaned references/),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -3,7 +3,7 @@ import type { Binding, Skill, Target } from "../../lib/types";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon, SearchIcon } from "../../components/icons/nav_icons";
-import { api } from "../../lib/api/client";
+import { api, type SkillDiagnoseCheck, type SkillDiagnosePayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
 import {
   Lifecycle,
@@ -308,7 +308,7 @@ const captureSelectStyle = {
   outline: "none",
 };
 
-type DetailTab = "history" | "diff" | "targets";
+type DetailTab = "history" | "diff" | "targets" | "diagnose";
 
 function SkillDetail({
   skill,
@@ -328,6 +328,9 @@ function SkillDetail({
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [historyEvents, setHistoryEvents] = useState<LifecycleEvent[]>([]);
   const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+  const [diagnoseLoading, setDiagnoseLoading] = useState(false);
+  const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
+  const [diagnose, setDiagnose] = useState<SkillDiagnosePayload | null>(null);
 
   const targetObjs = skill.targets
     .map((tid) => targets.find((t) => t.id === tid))
@@ -355,6 +358,29 @@ function SkillDetail({
       });
     return () => ctrl.abort();
   }, [skill.name, skill.latestRev, tab, historyRefreshKey]);
+
+  useEffect(() => {
+    if (tab !== "diagnose") return;
+    const ctrl = new AbortController();
+    setDiagnoseLoading(true);
+    setDiagnoseError(null);
+    setDiagnose(null);
+    api
+      .skillDiagnose(skill.name, ctrl.signal)
+      .then((payload) => {
+        if (ctrl.signal.aborted) return;
+        setDiagnose(payload);
+        setDiagnoseLoading(false);
+      })
+      .catch((err: Error) => {
+        if (err.name !== "AbortError") {
+          setDiagnoseError(err.message);
+          setDiagnose(null);
+          setDiagnoseLoading(false);
+        }
+      });
+    return () => ctrl.abort();
+  }, [skill.name, tab]);
 
   const onLifecycleMutation = () => {
     setHistoryRefreshKey((value) => value + 1);
@@ -392,6 +418,9 @@ function SkillDetail({
         <button className={tab === "targets" ? "active" : ""} onClick={() => setTab("targets")}>
           Targets ({targetObjs.length})
         </button>
+        <button className={tab === "diagnose" ? "active" : ""} onClick={() => setTab("diagnose")}>
+          Diagnose
+        </button>
       </div>
 
       {tab === "history" && (
@@ -422,8 +451,152 @@ function SkillDetail({
           <TargetsTab targets={targetObjs} />
         </>
       )}
+      {tab === "diagnose" && (
+        <DiagnoseTab loading={diagnoseLoading} error={diagnoseError} diagnose={diagnose} />
+      )}
     </div>
   );
+}
+
+function DiagnoseTab({
+  loading,
+  error,
+  diagnose,
+}: {
+  loading: boolean;
+  error: string | null;
+  diagnose: SkillDiagnosePayload | null;
+}) {
+  if (loading) {
+    return <div style={{ color: "var(--ink-3)", fontSize: 12 }}>Loading...</div>;
+  }
+  if (error) {
+    return (
+      <div style={{ color: "var(--err)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
+        {error}
+      </div>
+    );
+  }
+  if (!diagnose) {
+    return <div className="empty" style={{ padding: "18px 4px" }}>No diagnose data loaded.</div>;
+  }
+
+  const grouped = groupDiagnoseChecks(diagnose.checks);
+  const failed = diagnose.summary.failed_check_count;
+  const warnings = diagnose.summary.warning_check_count;
+
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      <div className="card">
+        <div className="card-head">
+          <h3>Diagnose</h3>
+          <span className={`chip ${statusChipClass(diagnose.status)}`}>{diagnose.status}</span>
+        </div>
+        <div
+          className="card-body"
+          style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 10 }}
+        >
+          <MiniStat label="Failed" value={failed} tone={failed > 0 ? "err" : "ok"} />
+          <MiniStat label="Warnings" value={warnings} tone={warnings > 0 ? "warn" : "ok"} />
+          <MiniStat label="Checks" value={diagnose.checks.length} />
+        </div>
+      </div>
+
+      {diagnose.checks.length === 0 ? (
+        <div className="empty" style={{ padding: "18px 4px" }}>No diagnose checks returned.</div>
+      ) : (
+        grouped.map(([section, checks]) => (
+          <div className="card" key={section}>
+            <div className="card-head">
+              <h3>{sectionLabel(section)}</h3>
+              <span className={`chip ${checks.every((check) => check.ok) ? "present" : "missing"}`}>
+                {checks.filter((check) => !check.ok).length} / {checks.length}
+              </span>
+            </div>
+            <div className="card-body" style={{ padding: 0 }}>
+              <table className="tbl" style={{ fontSize: 12 }}>
+                <tbody>
+                  {checks.map((check) => (
+                    <DiagnoseCheckRow key={check.id} check={check} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function DiagnoseCheckRow({ check }: { check: SkillDiagnoseCheck }) {
+  return (
+    <tr>
+      <td style={{ width: 190 }}>
+        <span className="mono dim">{check.id}</span>
+      </td>
+      <td style={{ width: 96 }}>
+        <span className={`chip ${severityChipClass(check)}`}>
+          {check.ok ? "ok" : check.severity}
+        </span>
+      </td>
+      <td>
+        <div style={{ color: "var(--ink-1)" }}>{check.message}</div>
+        {!check.ok && check.next_action && (
+          <div className="mono" style={{ color: "var(--ink-3)", marginTop: 3 }}>
+            next_action: {check.next_action}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function MiniStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string | number;
+  tone?: "ok" | "warn" | "err";
+}) {
+  const color = tone === "ok" ? "var(--ok)" : tone === "warn" ? "var(--warn)" : tone === "err" ? "var(--err)" : "var(--ink-0)";
+  return (
+    <div className="kpi">
+      <div className="label">{label}</div>
+      <div className="value" style={{ color }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function groupDiagnoseChecks(checks: SkillDiagnoseCheck[]): Array<[string, SkillDiagnoseCheck[]]> {
+  const groups = new Map<string, SkillDiagnoseCheck[]>();
+  for (const check of checks) {
+    const existing = groups.get(check.section);
+    if (existing) existing.push(check);
+    else groups.set(check.section, [check]);
+  }
+  return [...groups.entries()];
+}
+
+function statusChipClass(status: string): string {
+  if (status === "healthy") return "present";
+  if (status === "attention") return "missing";
+  if (status === "blocked") return "non-compliant";
+  return "";
+}
+
+function severityChipClass(check: SkillDiagnoseCheck): string {
+  if (check.ok || check.severity === "ok") return "present";
+  if (check.severity === "warning") return "missing";
+  return "non-compliant";
+}
+
+function sectionLabel(section: string): string {
+  return section.replace(/_/g, " ");
 }
 
 function ProjectSkillForm({

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -331,6 +331,7 @@ function SkillDetail({
   const [diagnoseLoading, setDiagnoseLoading] = useState(false);
   const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
   const [diagnose, setDiagnose] = useState<SkillDiagnosePayload | null>(null);
+  const [diagnoseRefreshKey, setDiagnoseRefreshKey] = useState(0);
 
   const targetObjs = skill.targets
     .map((tid) => targets.find((t) => t.id === tid))
@@ -380,10 +381,11 @@ function SkillDetail({
         }
       });
     return () => ctrl.abort();
-  }, [skill.name, tab]);
+  }, [skill.name, tab, diagnoseRefreshKey]);
 
   const onLifecycleMutation = () => {
     setHistoryRefreshKey((value) => value + 1);
+    setDiagnoseRefreshKey((value) => value + 1);
     onMutation();
   };
 


### PR DESCRIPTION
Part of #227. Stacked on #229.

## Summary
- Add a Diagnose tab to the Skills panel detail view.
- Call the new `/api/v1/skills/{skill}/diagnose` API and render status, summary, failed checks, related registry data, operations, and source metadata.
- Add panel API client typing and SkillsPage tests for loading, error, and tab state behavior.

## Verification
- cd panel && npm run typecheck
- cd panel && npm test -- SkillsPage
- cd panel && npm test

## Dependency
- Depends on #229 for the CLI/API diagnosis contract.