### PR TITLE
[codex] Document skill diagnose 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable public release changes are tracked here. Loom also publishes release
 archives, checksums, and provenance details on GitHub Releases.
 
+## [0.1.3] - 2026-06-04
+
+### Added
+
+- `loom skill diagnose <skill>` for read-only skill health reports covering
+  source files, Git drift, bindings, targets, projections, pending queue state,
+  and related registry operations.
+- Panel Diagnose tab on skill detail pages, including loading/error handling and
+  refresh after lifecycle mutations.
+
+### Fixed
+
+- Diagnose reports now surface pending queue read problems and Git/source drift
+  read failures instead of silently treating them as healthy.
+- Projection-only/orphaned skills now report missing targets when no rule covers
+  the projection target.
+
 ## [0.1.2] - 2026-06-01
 
 ### Added
@@ -60,6 +77,7 @@ archives, checksums, and provenance details on GitHub Releases.
 
 - Initial public release archives for Loom.
 
+[0.1.3]: https://github.com/majiayu000/loom/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/majiayu000/loom/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/majiayu000/loom/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/majiayu000/loom/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "skillloom"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillloom"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 build = "build.rs"
 description = "Git-backed skill manager and registry for AI coding agents"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 ```bash
 # 1. Install a prebuilt release archive (recommended)
 # Pick one target: aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu
-VERSION="0.1.2" # replace with the latest release version
+VERSION="0.1.3" # replace with the latest release version
 TARGET="aarch64-apple-darwin"
 BASE_URL="https://github.com/majiayu000/loom/releases/download/v${VERSION}"
 curl -LO "${BASE_URL}/skillloom-${VERSION}-${TARGET}.tar.gz"
@@ -130,6 +130,7 @@ Prefer a guided walkthrough? Run `./scripts/demo.sh` for a scripted end-to-end t
 - **🔗 Binding matchers** — route a skill to a target by `path-prefix`, `exact-path`, or `name`
 - **📦 Profiles** — multiple config sets per agent (e.g. work/home Claude profiles)
 - **🧬 Git-backed lifecycle** — `add → capture → save → snapshot → release → rollback → diff` ([when to use which](#skill-lifecycle-verbs))
+- **🩺 Skill diagnosis** — `skill diagnose` checks source, bindings, targets, projections, drift, and related operations
 - **🔁 Git-backed sync** — `sync push / pull / replay` between a team's registries
 - **🛠️ Ops with audit** — `ops list / retry / purge` and `ops history diagnose / repair`
 - **🛡️ Hard write guard** — refuses to write when `--root` points at the Loom tool repo itself
@@ -181,8 +182,9 @@ The chain `add → capture → save → snapshot → release → rollback` is th
 | `loom skill rollback` | Reset the source to an earlier revision (with `recovery_ref`) | A capture or save introduced bad state — undo it without losing the recovery point | Source (history) |
 | `loom skill diff` | Compare two revisions of a skill source | Inspect what changed between any two refs (commit, snapshot, release tag) | Source (read-only) |
 | `loom skill verify` | Detect uncommitted drift in a skill source | Confirm `skills/<name>` matches the committed source tree; flag external edits that bypassed `save` | Source (read-only) |
+| `loom skill diagnose` | Run a read-only health report for one skill | Explain missing source, broken bindings/targets/projections, source drift, pending queue issues, and recent failures | Source + registry metadata (read-only) |
 
-Quick decision: **edits from the agent side → `capture`; edits inside the registry repo → `save`; anchor → `snapshot`; public version → `release`; undo → `rollback`; integrity audit → `verify`.**
+Quick decision: **edits from the agent side → `capture`; edits inside the registry repo → `save`; anchor → `snapshot`; public version → `release`; undo → `rollback`; integrity audit → `verify`; health triage → `diagnose`.**
 
 ## Comparison
 
@@ -255,6 +257,7 @@ loom skill release <skill> <version>
 loom skill rollback <skill> [--to <ref> | --steps <n>] [--preview]
 loom skill diff <skill> <from> <to>
 loom skill verify <skill>
+loom skill diagnose <skill>
 loom skill import-observed [--target <target-id>]
 loom skill monitor-observed [--target <target-id>] [--once] [--interval-seconds <seconds>]
 loom skill orphan list


### PR DESCRIPTION
## Summary
- bump the CLI crate version to 0.1.3
- add README coverage for `loom skill diagnose`
- add CHANGELOG entries for the skill diagnose CLI/API/Panel work

## Verification
- `cargo check`
- `cargo test`