### PR TITLE
Fix tweaks overlay on Skills actions

### DIFF
--- a/panel/src/components/panel/Topbar.tsx
+++ b/panel/src/components/panel/Topbar.tsx
@@ -28,7 +28,9 @@ interface TopbarProps {
   remoteState?: string;
   pendingCount: number;
   onReplay: () => void;
+  onToggleTweaks: () => void;
   readOnly: boolean;
+  tweaksOpen: boolean;
 }
 
 interface StatusDisplay {
@@ -160,6 +162,14 @@ export function Topbar(props: TopbarProps) {
             <PlayIcon /> {replaying ? "replaying…" : `Replay ${props.pendingCount}`}
           </button>
         )}
+        <button
+          className="top-btn"
+          onClick={props.onToggleTweaks}
+          title={props.tweaksOpen ? "hide visual tweaks" : "show visual tweaks"}
+          aria-pressed={props.tweaksOpen}
+        >
+          Tweaks
+        </button>
       </div>
     </div>
   );

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -262,7 +262,9 @@ export function PanelApp() {
         remoteState={live.remote?.sync_state}
         pendingCount={live.pendingCount}
         onReplay={onMutation}
+        onToggleTweaks={() => setTweakVisible((value) => !value)}
         readOnly={readOnly}
+        tweaksOpen={tweakVisible}
       />
       <Sidebar
         page={page}
@@ -281,23 +283,6 @@ export function PanelApp() {
         {live.mode !== "live" && <LiveDataBanner error={live.error} loading={live.loading} mode={live.mode} />}
         {view}
       </div>
-      <button
-        onClick={() => setTweakVisible((v) => !v)}
-        style={{
-          position: "fixed",
-          right: 16,
-          top: 56,
-          padding: "4px 10px",
-          fontSize: 11,
-          color: "var(--ink-3)",
-          background: "var(--bg-1)",
-          border: "1px solid var(--line)",
-          borderRadius: 6,
-          zIndex: 99,
-        }}
-      >
-        {tweakVisible ? "hide tweaks" : "tweaks"}
-      </button>
       {tweakVisible && (
         <TweakPanel state={tweaks} onChange={patchTweaks} onDismiss={() => setTweakVisible(false)} />
       )}

--- a/panel/src/styles/panel/tweaks.css
+++ b/panel/src/styles/panel/tweaks.css
@@ -2,13 +2,17 @@
   position: fixed;
   right: 16px;
   bottom: 16px;
+  top: 176px;
   width: 280px;
+  max-width: calc(100vw - 32px);
   background: var(--bg-1);
   border: 1px solid var(--line-hi);
   border-radius: var(--radius-lg);
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   z-index: 100;
   font-size: 12px;
+  display: flex;
+  flex-direction: column;
 }
 
 .tweaks .t-head {
@@ -29,7 +33,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  max-height: 70vh;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -79,4 +83,14 @@
 }
 .tweaks .swatch.on {
   border-color: var(--ink-0);
+}
+
+@media (max-width: 720px) {
+  .tweaks {
+    top: auto;
+    right: 12px;
+    bottom: 12px;
+    max-height: min(62vh, 420px);
+    max-width: calc(100vw - 24px);
+  }
 }


### PR DESCRIPTION
## Summary
- move the Tweaks toggle into the topbar action group
- constrain the expanded Tweaks panel so it starts below the Skills header actions and scrolls internally
- keep mobile panel sizing bounded near the viewport edge

Fixes #239

## Verification
- make panel-typecheck
- make panel-test
- Chrome headless 1050x576 layout check: Tweaks panel did not overlap Capture or skill add; screenshot saved locally at /private/tmp/loom-pr239/pr239-1050x576.png