### PR TITLE
[codex] fix panel trash read-only confirmations

### DIFF
--- a/panel/src/pages/panel/SkillTrashPanel.tsx
+++ b/panel/src/pages/panel/SkillTrashPanel.tsx
@@ -148,6 +148,7 @@ export function TrashSkillAction({ skill, readOnly, onSuccess }: TrashSkillActio
       : undefined;
 
   const moveToTrash = () => {
+    if (disabled) return;
     trash.run(`trash ${skill.name}`, () => api.skillTrashAdd(skill.name), () => {
       setConfirmOpen(false);
       onSuccess();
@@ -184,7 +185,7 @@ export function TrashSkillAction({ skill, readOnly, onSuccess }: TrashSkillActio
             <button className="btn ghost" onClick={() => setConfirmOpen(false)} disabled={trash.busy}>
               Cancel
             </button>
-            <button className="btn ghost danger" onClick={moveToTrash} disabled={trash.busy}>
+            <button className="btn ghost danger" onClick={moveToTrash} disabled={disabled} title={title}>
               Move to trash
             </button>
           </div>
@@ -209,8 +210,11 @@ function TrashEntryDetail({
   const [confirmPurge, setConfirmPurge] = useState(false);
   const restore = useMutation();
   const purge = useMutation();
+  const mutationDisabled = readOnly || restore.busy || purge.busy;
+  const mutationTitle = readOnly ? "registry offline" : undefined;
 
   const runRestore = () => {
+    if (mutationDisabled) return;
     restore.run(
       `restore ${entry.skill}`,
       () => api.skillTrashRestore(entry.trash_id, { skill: entry.skill }),
@@ -219,6 +223,7 @@ function TrashEntryDetail({
   };
 
   const runPurge = () => {
+    if (mutationDisabled) return;
     purge.run(`purge ${entry.trash_id}`, () => api.skillTrashPurge(entry.trash_id), () => {
       setConfirmPurge(false);
       onSuccess();
@@ -245,16 +250,16 @@ function TrashEntryDetail({
           <button
             className="btn primary"
             onClick={runRestore}
-            disabled={readOnly || restore.busy || purge.busy}
-            title={readOnly ? "registry offline" : undefined}
+            disabled={mutationDisabled}
+            title={mutationTitle}
           >
             {restore.busy ? "restoring..." : "Restore"}
           </button>
           <button
             className="btn ghost danger"
             onClick={() => setConfirmPurge((value) => !value)}
-            disabled={readOnly || restore.busy || purge.busy}
-            title={readOnly ? "registry offline" : undefined}
+            disabled={mutationDisabled}
+            title={mutationTitle}
           >
             Purge
           </button>
@@ -271,7 +276,12 @@ function TrashEntryDetail({
               <button className="btn ghost" onClick={() => setConfirmPurge(false)} disabled={purge.busy}>
                 Cancel
               </button>
-              <button className="btn ghost danger" onClick={runPurge} disabled={purge.busy}>
+              <button
+                className="btn ghost danger"
+                onClick={runPurge}
+                disabled={mutationDisabled}
+                title={mutationTitle}
+              >
                 {purge.busy ? "purging..." : "Purge forever"}
               </button>
             </div>

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -50,17 +50,17 @@ const mockBinding: Binding = {
   policy: "auto",
 };
 
-function renderPage(
-  overrides: {
-    onMutation?: () => void;
-    bindings?: Binding[];
-    targets?: Target[];
-    projections?: RegistryProjection[];
-    readOnly?: boolean;
-    onSelectSkill?: (id: string | null) => void;
-  } = {},
-) {
-  return render(
+type SkillsPageOverrides = {
+  onMutation?: () => void;
+  bindings?: Binding[];
+  targets?: Target[];
+  projections?: RegistryProjection[];
+  readOnly?: boolean;
+  onSelectSkill?: (id: string | null) => void;
+};
+
+function skillsPage(overrides: SkillsPageOverrides = {}) {
+  return (
     <SkillsPage
       skills={[mockSkill]}
       targets={overrides.targets ?? []}
@@ -70,8 +70,12 @@ function renderPage(
       onSelectSkill={overrides.onSelectSkill ?? (() => {})}
       onMutation={overrides.onMutation ?? (() => {})}
       readOnly={overrides.readOnly ?? false}
-    />,
+    />
   );
+}
+
+function renderPage(overrides: SkillsPageOverrides = {}) {
+  return render(skillsPage(overrides));
 }
 
 function makeTarget(overrides: Partial<Target> = {}): Target {
@@ -567,6 +571,20 @@ describe("SkillsPage — trash UI", () => {
     });
   });
 
+  it("keeps an open trash confirmation read-only safe", async () => {
+    const view = renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Trash my-skill" }));
+    expect(screen.getByRole("button", { name: "Move to trash" })).not.toBeDisabled();
+
+    view.rerender(skillsPage({ readOnly: true }));
+    const confirmTrash = screen.getByRole("button", { name: "Move to trash" });
+    expect(confirmTrash).toBeDisabled();
+
+    fireEvent.click(confirmTrash);
+    expect(api.skillTrashAdd).not.toHaveBeenCalled();
+  });
+
   it("restores the selected trash entry by trash id", async () => {
     const onMutation = vi.fn();
     renderPage({ onMutation });
@@ -601,6 +619,24 @@ describe("SkillsPage — trash UI", () => {
     await waitFor(() => {
       expect(api.skillTrashPurge).toHaveBeenCalledWith("old-skill-20260604T010203Z-a1b2c3d4");
     });
+  });
+
+  it("keeps an open purge confirmation read-only safe", async () => {
+    const view = renderPage();
+    openTrashView();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Purge" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Purge" }));
+    expect(screen.getByRole("button", { name: "Purge forever" })).not.toBeDisabled();
+
+    view.rerender(skillsPage({ readOnly: true }));
+    const confirmPurge = screen.getByRole("button", { name: "Purge forever" });
+    expect(confirmPurge).toBeDisabled();
+
+    fireEvent.click(confirmPurge);
+    expect(api.skillTrashPurge).not.toHaveBeenCalled();
   });
 
   it("disables trash mutations in read-only mode", async () => {


### PR DESCRIPTION
## Summary
- disable the inline "Move to trash" confirmation whenever live Panel state is read-only
- share the read-only/busy disabled state across Restore, Purge, and "Purge forever" confirmation controls
- add regression tests for read-only state flipping after trash/purge confirmations are already open

## Root Cause
#233 disabled the top-level Trash/Purge buttons in read-only mode, but the already-open confirmation buttons only checked mutation busy state. If read-only state changed while the confirmation was visible, the UI could still submit trash or purge requests.

## Validation
- git diff --check
- cd panel && bun install --frozen-lockfile
- cd panel && bun run typecheck
- cd panel && bun run test -- SkillsPage
- make check

Addresses the post-merge Codex review threads on #233.