### PR TITLE
Fix pre-commit hook for renamed Rust files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ set -e
 
 # Skip the cargo probe when no Rust files are staged — keeps docs/config
 # commits fast.
-if ! git diff --cached --name-only --diff-filter=ACM | grep -qE '\.rs$'; then
+if ! git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$'; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Include renamed files in the pre-commit hook's staged Rust file filter.
- Preserves the existing skip behavior for non-Rust staged changes.

## Validation
- cargo fmt --all -- --check
- custom temp git hook regression: renamed .rs invokes cargo fmt; non-Rust staged file skips cargo
- cargo check
- cargo test

Closes #246