### PR TITLE
Harden panel skill diff edge cases

### DIFF
--- a/src/panel/skill_diff.rs
+++ b/src/panel/skill_diff.rs
@@ -16,6 +16,8 @@ pub(super) fn is_safe_git_ref(rev: &str) -> bool {
     !rev.is_empty()
         && len <= 256
         && !rev.starts_with('-')
+        && !rev.starts_with('.')
+        && !rev.ends_with('.')
         && !rev.contains("..")
         && rev.bytes().all(|b| {
             matches!(
@@ -172,10 +174,10 @@ fn parse_diff_git_path(line: &str) -> Option<String> {
 /// The cap is intentionally per file (not per hunk): a single multi-hunk file
 /// cannot exceed `MAX_HUNK_LINES` retained lines combined. Once the budget
 /// is exhausted, additional `+` / `-` lines still update the per-file
-/// `added` / `removed` counts so totals remain accurate, but their text is
-/// dropped and surfaced via `truncated: true` + `truncated_lines: N` so the
-/// client never confuses "we have all the lines" with "we counted all of
-/// them but only kept some" (see U-29 silent-degradation rule).
+/// `added` / `removed` counts so totals remain accurate, and any omitted
+/// hunk line is surfaced via `truncated: true` + `truncated_lines: N` so the
+/// client never confuses "we have all the lines" with "we kept only part of
+/// the hunk" (see U-29 silent-degradation rule).
 pub(crate) const MAX_HUNK_LINES: usize = 500;
 
 /// Mutable accumulator for one file block while parsing a unified diff.
@@ -196,8 +198,8 @@ struct FileBuf {
     /// Combined retained-line count across every hunk in this file. Used to
     /// enforce the per-file `MAX_HUNK_LINES` budget.
     retained: usize,
-    /// Total `+` / `-` lines we observed but dropped because the per-file
-    /// cap was exhausted. Surfaced as `truncated_lines` in the response.
+    /// Total hunk lines we observed but dropped because the per-file cap was
+    /// exhausted. Surfaced as `truncated_lines` in the response.
     dropped: usize,
 }
 
@@ -226,6 +228,15 @@ impl FileBuf {
             if remaining > 0 {
                 self.h_lines = Vec::with_capacity(remaining);
             }
+        }
+    }
+
+    fn push_hunk_line_or_count_drop(&mut self, line: &str) {
+        if self.retained < MAX_HUNK_LINES {
+            self.h_lines.push(line.to_string());
+            self.retained += 1;
+        } else {
+            self.dropped += 1;
         }
     }
 
@@ -290,28 +301,14 @@ pub(super) fn parse_unified_diff(diff_text: &str) -> Vec<serde_json::Value> {
             // string match, which historically dropped content lines such
             // as `++ i;` (encoded as `+++ i;` in unified diff).
             file.added += 1;
-            if file.retained < MAX_HUNK_LINES {
-                file.h_lines.push(line.to_string());
-                file.retained += 1;
-            } else {
-                file.dropped += 1;
-            }
+            file.push_hunk_line_or_count_drop(line);
         } else if !file.h_hdr.is_empty() && line.starts_with('-') {
             file.removed += 1;
-            if file.retained < MAX_HUNK_LINES {
-                file.h_lines.push(line.to_string());
-                file.retained += 1;
-            } else {
-                file.dropped += 1;
-            }
-        } else if !file.h_hdr.is_empty()
-            && (line.starts_with(' ') || line.is_empty())
-            && file.retained < MAX_HUNK_LINES
-        {
+            file.push_hunk_line_or_count_drop(line);
+        } else if !file.h_hdr.is_empty() && (line.starts_with(' ') || line.is_empty()) {
             // Context lines never bump `added` / `removed`, so we only need
-            // to keep them while the retention budget allows.
-            file.h_lines.push(line.to_string());
-            file.retained += 1;
+            // to retain or count-drop them against the hunk-line budget.
+            file.push_hunk_line_or_count_drop(line);
         }
     }
 

--- a/src/panel/skill_diff/tests.rs
+++ b/src/panel/skill_diff/tests.rs
@@ -131,6 +131,45 @@ fn parse_unified_diff_marks_truncated_when_exceeding_per_file_cap() {
 }
 
 #[test]
+fn parse_unified_diff_marks_truncated_when_context_lines_exceed_cap() {
+    let extra: usize = 25;
+    let total: usize = MAX_HUNK_LINES + extra;
+
+    let mut diff = String::with_capacity(total * 24);
+    diff.push_str("diff --git a/skills/context/context.md b/skills/context/context.md\n");
+    diff.push_str("index abc1234..def5678 100644\n");
+    diff.push_str("--- a/skills/context/context.md\n");
+    diff.push_str("+++ b/skills/context/context.md\n");
+    diff.push_str(&format!("@@ -1,{0} +1,{0} @@\n", total));
+    for i in 0..total {
+        diff.push_str(&format!(" line {}\n", i));
+    }
+
+    let files = parse_unified_diff(&diff);
+    assert_eq!(files.len(), 1, "single file expected");
+    assert_eq!(files[0]["added"], json!(0));
+    assert_eq!(files[0]["removed"], json!(0));
+    assert_eq!(
+        files[0]["truncated"],
+        json!(true),
+        "dropping context-only hunk lines must still be reported"
+    );
+    assert_eq!(
+        files[0]["truncated_lines"],
+        json!(extra),
+        "truncated_lines must count dropped context lines"
+    );
+
+    let kept: usize = files[0]["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["lines"].as_array().unwrap().len())
+        .sum();
+    assert_eq!(kept, MAX_HUNK_LINES);
+}
+
+#[test]
 fn parse_unified_diff_truncation_spans_multiple_hunks_in_one_file() {
     // Two hunks in one file: first hunk retains lines until the budget is
     // half spent, second hunk should still respect the per-file cap and
@@ -278,6 +317,8 @@ fn git_ref_validation_rejects_option_like_ranges_and_pathspecs() {
         "",
         "--help",
         "main..other",
+        "main.",
+        ".feature",
         "main other",
         "main:skills/foo",
         "feature/*",
@@ -350,6 +391,51 @@ async fn registry_skill_diff_rejects_malformed_rev_a() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(payload["ok"], json!(false));
     assert_eq!(payload["error"]["code"], json!("GIT_DIFF_FAILED"));
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[tokio::test]
+async fn registry_skill_diff_rejects_dot_boundary_refs_before_building_range() {
+    let root = std::env::temp_dir().join(format!("loom-diff-dot-range-{}", Uuid::new_v4()));
+    fs::create_dir_all(root.join("skills/foo")).unwrap();
+
+    let git = |args: &[&str]| git_ok(&root, args);
+
+    git(&["init"]);
+    git(&["checkout", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+
+    fs::write(root.join("skills/foo/foo.md"), "line one\n").unwrap();
+    git(&["add", "-A"]);
+    git(&["commit", "-m", "initial"]);
+
+    git(&["checkout", "-b", "feature"]);
+    fs::write(root.join("skills/foo/foo.md"), "line one\nline two\n").unwrap();
+    git(&["add", "-A"]);
+    git(&["commit", "-m", "add line two"]);
+
+    for (rev_a, rev_b) in [("main.", "feature"), ("main", ".feature")] {
+        let state = make_state(&root);
+        let (status, Json(payload)) = registry_skill_diff(
+            AxumPath("foo".to_string()),
+            Query(super::super::DiffParams {
+                rev_a: Some(rev_a.to_string()),
+                rev_b: Some(rev_b.to_string()),
+            }),
+            State(state),
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{rev_a:?}..{rev_b:?} must be rejected before git diff"
+        );
+        assert_eq!(payload["ok"], json!(false));
+        assert_eq!(payload["error"]["code"], json!("GIT_DIFF_FAILED"));
+    }
 
     let _ = fs::remove_dir_all(&root);
 }


### PR DESCRIPTION
## Summary
- count omitted context-only hunk lines as diff truncation
- reject leading/trailing dot refs before composing git diff ranges
- add focused regression coverage for issue #247

Fixes #247

## Validation
- cargo test parse_unified_diff_marks_truncated_when_context_lines_exceed_cap
- cargo test registry_skill_diff_rejects_dot_boundary_refs_before_building_range
- cargo check
- cargo test
- git diff --check
- cargo fmt --all --check