### PR TITLE
Fix trashing untracked skill sources

### DIFF
--- a/src/commands/trash_cmds.rs
+++ b/src/commands/trash_cmds.rs
@@ -562,7 +562,9 @@ fn stage_trash_commit_paths(
     paths: &[&str],
 ) -> std::result::Result<(), CommandFailure> {
     for path in paths {
-        gitops::run_git(ctx, &["add", "-A", "--", path]).map_err(map_git)?;
+        if gitops::path_exists_or_is_tracked(ctx, path).map_err(map_git)? {
+            gitops::run_git(ctx, &["add", "-A", "--", path]).map_err(map_git)?;
+        }
     }
     gitops::run_git(ctx, &["add", "-A", "--", "state/registry"]).map_err(map_git)?;
     let legacy_v3_tracked =
@@ -583,8 +585,12 @@ fn commit_trash_paths(
 ) -> Result<String> {
     let mut commit_paths = paths
         .iter()
-        .map(|path| (*path).to_string())
-        .collect::<Vec<_>>();
+        .filter_map(|path| match gitops::path_exists_or_is_tracked(ctx, path) {
+            Ok(true) => Some(Ok((*path).to_string())),
+            Ok(false) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .collect::<Result<Vec<_>>>()?;
     commit_paths.push("state/registry".to_string());
     let legacy_v3_tracked =
         gitops::run_git_allow_failure(ctx, &["ls-files", "--error-unmatch", "--", "state/v3"])?

--- a/src/commands/trash_cmds.rs
+++ b/src/commands/trash_cmds.rs
@@ -585,7 +585,7 @@ fn commit_trash_paths(
 ) -> Result<String> {
     let mut commit_paths = paths
         .iter()
-        .filter_map(|path| match gitops::path_exists_or_is_tracked(ctx, path) {
+        .filter_map(|path| match trash_path_should_be_committed(ctx, path) {
             Ok(true) => Some(Ok((*path).to_string())),
             Ok(false) => None,
             Err(err) => Some(Err(err)),
@@ -610,6 +610,13 @@ fn commit_trash_paths(
     let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
     gitops::run_git(ctx, &refs)?;
     gitops::head(ctx)
+}
+
+fn trash_path_should_be_committed(ctx: &crate::state::AppContext, path: &str) -> Result<bool> {
+    if gitops::path_exists_or_is_tracked(ctx, path)? {
+        return Ok(true);
+    }
+    gitops::has_staged_changes_for_path(ctx, Path::new(path))
 }
 
 fn unstage_trash_paths(ctx: &crate::state::AppContext, paths: &[&str]) {

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -173,7 +173,18 @@ pub fn repo_is_initialized(ctx: &AppContext) -> Result<bool> {
 pub fn has_staged_changes_for_path(ctx: &AppContext, path: &Path) -> Result<bool> {
     let path_str = path.to_string_lossy();
     let output = run_git_allow_failure(ctx, &["diff", "--cached", "--quiet", "--", &path_str])?;
-    Ok(!output.status.success())
+    if output.status.success() {
+        return Ok(false);
+    }
+    if output.status.code() == Some(1) {
+        return Ok(true);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Err(anyhow!(
+        "git {:?} failed: {}",
+        ["diff", "--cached", "--quiet", "--", &path_str],
+        stderr
+    ))
 }
 
 /// Captured registry index used to restore staging after a failed mutation.

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -314,7 +314,7 @@ pub fn commit_paths_if_changed(
     head(ctx).map(Some)
 }
 
-fn path_exists_or_is_tracked(ctx: &AppContext, path: &str) -> Result<bool> {
+pub(crate) fn path_exists_or_is_tracked(ctx: &AppContext, path: &str) -> Result<bool> {
     if ctx.root.join(path).exists() {
         return Ok(true);
     }

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -134,6 +134,44 @@ fn skill_trash_add_preserves_unrelated_staged_changes() {
 }
 
 #[test]
+fn skill_trash_add_accepts_untracked_skill_and_preserves_unrelated_staged_changes() {
+    let root = TestDir::new("skill-trash-untracked-source");
+    let (init_output, _) = run_loom(root.path(), &["workspace", "init"]);
+    assert_success(&init_output, "workspace init");
+    write_skill(root.path(), "manual", "# Manual\n\nnever committed\n");
+
+    write_file(&root.path().join("README.md"), "staged but unrelated\n");
+    git_success(root.path(), &["add", "README.md"]);
+
+    let (trash_output, trash_env) = run_loom(root.path(), &["skill", "trash", "add", "manual"]);
+    assert_success(&trash_output, "trash add");
+    assert_eq!(trash_env["ok"], Value::Bool(true));
+    let trash_id = match trash_env["data"]["trash_id"].as_str() {
+        Some(trash_id) => trash_id,
+        None => panic!("trash add did not return a trash id: {trash_env}"),
+    };
+    assert!(!root.path().join("skills/manual").exists());
+    assert!(
+        root.path()
+            .join("trash")
+            .join(trash_id)
+            .join("skill/SKILL.md")
+            .exists()
+    );
+
+    let committed_paths = git_success(root.path(), &["show", "--name-only", "--pretty=", "HEAD"]);
+    assert!(committed_paths.contains("trash/"));
+    assert!(
+        !committed_paths.contains("README.md"),
+        "trash commit included unrelated staged path: {committed_paths}"
+    );
+    assert_eq!(
+        git_success(root.path(), &["status", "--porcelain", "--", "README.md"]),
+        "A  README.md"
+    );
+}
+
+#[test]
 fn skill_trash_restore_refuses_to_overwrite_existing_skill() {
     let root = TestDir::new("skill-trash-restore-conflict");
     write_skill(root.path(), "demo", "# Demo\n\nv1\n");

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -104,6 +104,18 @@ fn skill_trash_add_lists_and_restores_latest_entry() {
     assert_eq!(restore_env["ok"], Value::Bool(true));
     assert!(root.path().join("skills/demo/SKILL.md").exists());
     assert!(!root.path().join("trash").join(&trash_id).exists());
+    let restored_paths = git_success(root.path(), &["show", "--name-only", "--pretty=", "HEAD"]);
+    assert!(
+        restored_paths.contains("trash/"),
+        "restore commit omitted trash deletion: {restored_paths}"
+    );
+    assert_eq!(
+        git_success(
+            root.path(),
+            &["status", "--porcelain", "--", &format!("trash/{trash_id}")]
+        ),
+        ""
+    );
     let operations = operations_log(root.path());
     assert!(operations.contains(r#""intent":"skill.trash.add""#));
     assert!(operations.contains(r#""intent":"skill.trash.restore""#));
@@ -122,10 +134,20 @@ fn skill_trash_add_preserves_unrelated_staged_changes() {
     assert_success(&trash_output, "trash add");
 
     let committed_paths = git_success(root.path(), &["show", "--name-only", "--pretty=", "HEAD"]);
+    let committed_status =
+        git_success(root.path(), &["show", "--name-status", "--pretty=", "HEAD"]);
+    assert!(
+        committed_status.contains("skills/demo/SKILL.md"),
+        "trash commit omitted source deletion: {committed_status}"
+    );
     assert!(committed_paths.contains("trash/"));
     assert!(
         !committed_paths.contains("README.md"),
         "trash commit included unrelated staged path: {committed_paths}"
+    );
+    assert_eq!(
+        git_success(root.path(), &["status", "--porcelain", "--", "skills/demo"]),
+        ""
     );
     assert_eq!(
         git_success(root.path(), &["status", "--porcelain", "--", "README.md"]),
@@ -210,5 +232,17 @@ fn skill_trash_purge_removes_one_trash_entry() {
     assert_success(&purge_output, "trash purge");
     assert_eq!(purge_env["ok"], Value::Bool(true));
     assert!(!root.path().join("trash").join(trash_id).exists());
+    let purged_paths = git_success(root.path(), &["show", "--name-only", "--pretty=", "HEAD"]);
+    assert!(
+        purged_paths.contains("trash/"),
+        "purge commit omitted trash deletion: {purged_paths}"
+    );
+    assert_eq!(
+        git_success(
+            root.path(),
+            &["status", "--porcelain", "--", &format!("trash/{trash_id}")]
+        ),
+        ""
+    );
     assert!(operations_log(root.path()).contains(r#""intent":"skill.trash.purge""#));
 }


### PR DESCRIPTION
## Summary
- Skip missing, untracked trash pathspecs during trash staging and commit path construction.
- Add a regression test for trashing a manually-created, never-committed skill while preserving unrelated staged changes.

Closes #251

## Validation
- cargo fmt --all
- cargo test --test trash -- --nocapture
- cargo check
- cargo test
- cargo fmt --all --check
- manual disposable-registry repro for untracked skill trash add
- git diff --check
- cargo clippy --all-targets --all-features -- -D warnings