### PR TITLE
Fix init when HOME is unavailable

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,7 +28,7 @@ use crate::cli::{
     WorkspaceCommand, WorkspaceInitArgs,
 };
 use crate::envelope::{Envelope, Meta};
-use crate::state::AppContext;
+use crate::state::{AppContext, home_dir};
 use crate::types::ErrorCode;
 
 pub(crate) use event_store::redact_sensitive_string;
@@ -160,7 +160,7 @@ impl App {
         let result = match &cli.command {
             Command::Init => {
                 let args = WorkspaceInitArgs {
-                    scan_existing: true,
+                    scan_existing: home_dir().is_some(),
                 };
                 self.cmd_workspace_init(&args, &request_id)
             }

--- a/src/commands/workspace_cmds/doctor.rs
+++ b/src/commands/workspace_cmds/doctor.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::envelope::Meta;
 use crate::gitops;
-use crate::state::AppContext;
+use crate::state::{AppContext, home_dir};
 use crate::state_model::{RegistrySnapshot, RegistryStatePaths};
 
 use super::super::helpers::{agent_kind_as_str, map_git, map_io, map_registry_state};
@@ -34,7 +34,7 @@ impl App {
             .iter()
             .all(|check| check.get("ok").and_then(|v| v.as_bool()).unwrap_or(false));
 
-        let home_opt = std::env::var("HOME").ok().filter(|h| !h.is_empty());
+        let home_opt = home_dir();
         let agent_inventory =
             build_agent_skill_inventory(home_opt.as_deref(), registry_snapshot.as_ref());
         let agent_inventory_message = agent_inventory["message"]
@@ -97,7 +97,7 @@ impl App {
     }
 }
 
-fn build_agent_skill_inventory(home: Option<&str>, snapshot: Option<&RegistrySnapshot>) -> Value {
+fn build_agent_skill_inventory(home: Option<&Path>, snapshot: Option<&RegistrySnapshot>) -> Value {
     let mut agents: Vec<Value> = Vec::new();
     if let Some(h) = home {
         for agent in DEFAULT_SCAN_AGENTS {

--- a/src/commands/workspace_cmds/init.rs
+++ b/src/commands/workspace_cmds/init.rs
@@ -2,6 +2,7 @@ use serde_json::json;
 
 use crate::cli::{TargetAddArgs, TargetCommand, TargetOwnership, WorkspaceInitArgs};
 use crate::envelope::Meta;
+use crate::state::home_dir;
 use crate::types::ErrorCode;
 
 use super::super::helpers::{
@@ -27,14 +28,14 @@ impl App {
         let mut skipped: Vec<serde_json::Value> = Vec::new();
 
         if args.scan_existing {
-            let home = std::env::var("HOME").map_err(|_| {
+            let home = home_dir().ok_or_else(|| {
                 CommandFailure::new(
                     ErrorCode::ArgInvalid,
-                    "--scan-existing requires HOME to be set",
+                    "--scan-existing requires HOME or USERPROFILE to be set",
                 )
             })?;
             for agent in DEFAULT_SCAN_AGENTS {
-                let path = default_skill_dir(agent, &home);
+                let path = default_skill_dir(agent, home.as_path());
                 let path_str = path.display().to_string();
                 let p = path.as_path();
                 if !p.exists() {

--- a/src/commands/workspace_cmds/shared.rs
+++ b/src/commands/workspace_cmds/shared.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::cli::AgentKind;
 
@@ -15,17 +15,17 @@ pub(super) const DEFAULT_SCAN_AGENTS: [AgentKind; 10] = [
     AgentKind::Goose,
 ];
 
-pub(super) fn default_skill_dir(agent: AgentKind, home: &str) -> PathBuf {
+pub(super) fn default_skill_dir(agent: AgentKind, home: &Path) -> PathBuf {
     match agent {
-        AgentKind::Claude => PathBuf::from(format!("{home}/.claude/skills")),
-        AgentKind::Codex => PathBuf::from(format!("{home}/.codex/skills")),
-        AgentKind::Cursor => PathBuf::from(format!("{home}/.cursor/skills")),
-        AgentKind::Windsurf => PathBuf::from(format!("{home}/.windsurf/skills")),
-        AgentKind::Cline => PathBuf::from(format!("{home}/.cline/skills")),
-        AgentKind::Copilot => PathBuf::from(format!("{home}/.github/copilot/skills")),
-        AgentKind::Aider => PathBuf::from(format!("{home}/.aider/skills")),
-        AgentKind::Opencode => PathBuf::from(format!("{home}/.opencode/skills")),
-        AgentKind::GeminiCli => PathBuf::from(format!("{home}/.gemini/skills")),
-        AgentKind::Goose => PathBuf::from(format!("{home}/.config/goose/skills")),
+        AgentKind::Claude => home.join(".claude/skills"),
+        AgentKind::Codex => home.join(".codex/skills"),
+        AgentKind::Cursor => home.join(".cursor/skills"),
+        AgentKind::Windsurf => home.join(".windsurf/skills"),
+        AgentKind::Cline => home.join(".cline/skills"),
+        AgentKind::Copilot => home.join(".github/copilot/skills"),
+        AgentKind::Aider => home.join(".aider/skills"),
+        AgentKind::Opencode => home.join(".opencode/skills"),
+        AgentKind::GeminiCli => home.join(".gemini/skills"),
+        AgentKind::Goose => home.join(".config/goose/skills"),
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -370,7 +370,7 @@ pub fn default_registry_root() -> Result<PathBuf> {
         .context("HOME is not set; pass --root <registry>")
 }
 
-fn home_dir() -> Option<PathBuf> {
+pub(crate) fn home_dir() -> Option<PathBuf> {
     non_empty_env_path("HOME").or_else(|| non_empty_env_path("USERPROFILE"))
 }
 

--- a/tests/workspace_init.rs
+++ b/tests/workspace_init.rs
@@ -6,6 +6,22 @@ use std::process::{Command, Stdio};
 use common::{TestDir, run_loom, run_loom_with_env};
 use serde_json::Value;
 
+fn run_loom_with_removed_home(
+    root: &std::path::Path,
+    envs: &[(&str, &str)],
+    args: &[&str],
+) -> (std::process::Output, Value) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_loom"));
+    cmd.arg("--json").arg("--root").arg(root).args(args);
+    cmd.env_remove("HOME").env_remove("USERPROFILE");
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("run loom");
+    let env = serde_json::from_slice(&output.stdout).expect("parse loom json");
+    (output, env)
+}
+
 // Exercises the reentrant-lock production path: cmd_workspace_init holds the
 // workspace lock at line 159 and then calls cmd_target_add (line 200) which
 // re-acquires the same lock.  If reentrancy is broken this hangs or panics.
@@ -76,6 +92,56 @@ fn workspace_init_scan_existing_skips_absent_dirs() {
         env["data"]["skipped"][0]["reason"],
         Value::String("does-not-exist".to_string())
     );
+}
+
+#[test]
+fn top_level_init_with_explicit_root_without_home_initializes_without_scan() {
+    let root = TestDir::new("ws-init-no-home");
+
+    let (output, env) = run_loom_with_removed_home(root.path(), &[], &["init"]);
+
+    assert!(
+        output.status.success(),
+        "top-level init without HOME failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert_eq!(env["data"]["initialized"], Value::Bool(true));
+    assert_eq!(env["data"]["scanned"], Value::Bool(false));
+    assert_eq!(env["data"]["imported"].as_array().map(|a| a.len()), Some(0));
+    assert_eq!(env["data"]["skipped"].as_array().map(|a| a.len()), Some(0));
+
+    let (list_output, list_env) = run_loom(root.path(), &["target", "list"]);
+    assert!(list_output.status.success());
+    assert_eq!(list_env["data"]["count"], Value::from(0));
+}
+
+#[test]
+fn workspace_init_scan_existing_uses_userprofile_when_home_is_missing() {
+    let root = TestDir::new("ws-init-userprofile");
+    let fake_profile = TestDir::new("ws-init-userprofile-home");
+
+    fs::create_dir_all(fake_profile.path().join(".claude/skills")).expect("create .claude/skills");
+    fs::create_dir_all(fake_profile.path().join(".codex/skills")).expect("create .codex/skills");
+
+    let profile_str = fake_profile.path().to_string_lossy().into_owned();
+    let (output, env) = run_loom_with_removed_home(
+        root.path(),
+        &[("USERPROFILE", &profile_str)],
+        &["workspace", "init", "--scan-existing"],
+    );
+
+    assert!(
+        output.status.success(),
+        "workspace init --scan-existing with USERPROFILE failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert_eq!(env["data"]["scanned"], Value::Bool(true));
+    assert_eq!(env["data"]["imported"].as_array().map(|a| a.len()), Some(2));
+    assert_eq!(env["data"]["skipped"].as_array().map(|a| a.len()), Some(8));
 }
 
 // Two processes race to `workspace init --scan-existing` on the same root.


### PR DESCRIPTION
Summary:
- Allow top-level `loom init` with explicit `--root` to initialize when neither `HOME` nor `USERPROFILE` is available by skipping automatic scan.
- Reuse the existing HOME/USERPROFILE resolver for scan-existing paths and workspace doctor inventory.
- Add workspace init regressions for no-home top-level init and USERPROFILE scan fallback.

Tests:
- cargo fmt --all --check
- cargo check
- cargo test --test workspace_init
- cargo test
- env -u HOME -u USERPROFILE target/debug/loom --json --root <tmp> init

Closes #253