### PR TITLE
[codex] remove legacy Panel API routes

### DIFF
--- a/docs/LOOM_API_CONTRACT.md
+++ b/docs/LOOM_API_CONTRACT.md
@@ -1,51 +1,44 @@
-# Loom Registry API Contract
+# Loom Panel API Contract
 
-Updated: 2026-04-09
-Status: Draft
+Updated: 2026-06-10
+Status: Accepted for v1 Panel surface
 
 ## 1. Purpose
 
-This document defines the read-oriented API contract for Loom Registry.
+This document defines the local HTTP API used by the Loom Panel.
 
-The API contract exists to support:
+The API supports:
 
-1. local panel rendering
+1. local Panel rendering
 2. machine-readable status inspection
-3. consistent read models shared with CLI output
+3. CLI-backed Panel mutations
 
-This API is not a second source of truth.
-It is a projection of registry state and source metadata.
+The API is not a second source of truth. Reads project registry state and CLI
+read models. Writes execute existing CLI command semantics through the Panel
+backend.
 
-## 2. API Principles
+## 2. Base Path
 
-1. API is read-first.
-2. API must not invent semantics not present in CLI or state schema.
-3. API responses must be stable enough for panel consumption.
-4. API must expose bindings, targets, projections, and history explicitly.
-5. API must never require guessing a single default Claude directory.
-
-## 3. Transport Assumptions
-
-Initial assumptions:
-
-1. local HTTP server
-2. loopback bind only
-3. JSON responses only
-
-Base path:
+All Panel API routes are under:
 
 ```text
-/api/registry
+/api/v1
 ```
 
-## 4. Common Response Shape
+Unversioned routes such as `/api/health`, `/api/info`, `/api/pending`, flat
+`/api/ops/*`, flat `/api/sync/*`, `/api/remote/*`, and `/api/registry/*` are not
+part of the API contract.
 
-Read responses should use a stable top-level envelope:
+## 3. Envelope
+
+Read and write responses use the CLI envelope shape:
 
 ```json
 {
   "ok": true,
-  "version": "3.0.0",
+  "cmd": "registry.status",
+  "request_id": "req-id",
+  "version": "0.1.3",
   "data": {},
   "error": null,
   "meta": {
@@ -54,406 +47,89 @@ Read responses should use a stable top-level envelope:
 }
 ```
 
-Rules:
+Errors use the same top-level shape with `ok: false` and a typed `error.code`.
 
-1. read APIs do not require `op_id`
-2. write APIs are intentionally out of scope for this document
-3. every list endpoint should be deterministic and explicitly typed
+## 4. Read Routes
 
-## 5. Error Shape
+```text
+GET /api/v1/health
+GET /api/v1/overview
+GET /api/v1/workspace/status
+GET /api/v1/workspace/info
+GET /api/v1/workspace/doctor
 
-```json
-{
-  "ok": false,
-  "version": "3.0.0",
-  "data": {},
-  "error": {
-    "code": "BINDING_NOT_FOUND",
-    "message": "binding 'bind_x' does not exist",
-    "details": {}
-  },
-  "meta": {
-    "warnings": []
-  }
-}
+GET /api/v1/registry/status
+GET /api/v1/skills
+GET /api/v1/skills/trash
+GET /api/v1/skills/{skill_name}/diagnose
+GET /api/v1/skills/{skill_name}/history
+GET /api/v1/skills/{skill_name}/diff
+
+GET /api/v1/targets
+GET /api/v1/targets/{target_id}
+GET /api/v1/bindings
+GET /api/v1/bindings/{binding_id}
+GET /api/v1/projections
+
+GET /api/v1/ops
+GET /api/v1/ops/diagnose
+GET /api/v1/ops/pending
+GET /api/v1/sync/status
 ```
 
-## 6. Resource Model
+`/api/v1/workspace/info` exposes Panel bootstrap metadata such as registry root,
+state paths, agent directory defaults, and the redacted remote URL.
 
-The API exposes six primary resources:
+`/api/v1/ops/pending` exposes the replayable pending queue read model. It remains
+separate from `/api/v1/ops`, which is the activity/audit read model.
 
-1. `workspace summary`
-2. `bindings`
-3. `targets`
-4. `projections`
-5. `history`
-6. `migration plan`
+## 5. Mutation Routes
 
-## 7. Endpoints
+The complete v1 mutation surface is:
 
-### 7.1 `GET /api/registry/health`
+```text
+POST /api/v1/workspace/init
+POST /api/v1/workspace/remote
 
-Purpose:
+POST /api/v1/targets
+POST /api/v1/targets/{target_id}/remove
+POST /api/v1/bindings
+POST /api/v1/bindings/{binding_id}/remove
 
-1. basic service liveness
+POST /api/v1/skills
+POST /api/v1/skills/import-observed
+POST /api/v1/skills/{skill_name}/save
+POST /api/v1/skills/{skill_name}/snapshot
+POST /api/v1/skills/{skill_name}/release
+POST /api/v1/skills/{skill_name}/rollback
+POST /api/v1/skills/{skill_name}/trash
+POST /api/v1/skills/trash/{trash_id}/restore
+POST /api/v1/skills/trash/{trash_id}/purge
 
-Response:
+POST /api/v1/projections/project
+POST /api/v1/projections/capture
+POST /api/v1/orphans/clean
 
-```json
-{
-  "ok": true,
-  "version": "3.0.0",
-  "data": {
-    "service": "loom-panel",
-    "healthy": true
-  },
-  "error": null,
-  "meta": {
-    "warnings": []
-  }
-}
+POST /api/v1/ops/retry
+POST /api/v1/ops/purge
+POST /api/v1/ops/history/repair
+
+POST /api/v1/sync/push
+POST /api/v1/sync/pull
+POST /api/v1/sync/replay
 ```
 
-### 7.2 `GET /api/registry/workspace`
-
-Purpose:
-
-1. top-level summary for the panel overview
-
-Query params:
-
-1. `binding_id` optional
-2. `all_bindings=true` optional
-
-Response:
-
-```json
-{
-  "ok": true,
-  "version": "3.0.0",
-  "data": {
-    "git": {
-      "branch": "main",
-      "head": "abc123"
-    },
-    "remote": {
-      "configured": false,
-      "sync_state": "LOCAL_ONLY"
-    },
-    "counts": {
-      "skills": 91,
-      "bindings": 3,
-      "targets": 4,
-      "projections": 3,
-      "pending_ops": 1,
-      "drifted_projections": 1
-    }
-  },
-  "error": null,
-  "meta": {
-    "warnings": []
-  }
-}
-```
-
-Field-level tier classification for all fields returned by this endpoint: see `docs/STATUS_FIELD_CLASSIFICATION.md`.
-
-### 7.3 `GET /api/registry/bindings`
-
-Purpose:
-
-1. list all bindings
-2. support bindings page and selectors
-
-Response item shape:
-
-```json
-{
-  "binding_id": "bind_claude_project_a",
-  "agent": "claude",
-  "profile_id": "default",
-  "workspace_matcher": {
-    "kind": "path_prefix",
-    "value": "/Users/foo/code/project-a"
-  },
-  "default_target_id": "target_claude_proj_a",
-  "policy_profile": "safe-capture",
-  "active": true
-}
-```
-
-### 7.4 `GET /api/registry/bindings/{binding_id}`
-
-Purpose:
-
-1. show one binding in detail
-2. include resolved rules and projection summary
-
-Response:
-
-```json
-{
-  "ok": true,
-  "version": "3.0.0",
-  "data": {
-    "binding": {
-      "binding_id": "bind_claude_project_a",
-      "agent": "claude",
-      "profile_id": "default"
-    },
-    "rules": [],
-    "projections": []
-  },
-  "error": null,
-  "meta": {
-    "warnings": []
-  }
-}
-```
-
-### 7.5 `GET /api/registry/targets`
-
-Purpose:
-
-1. list all targets
-2. show ownership and capabilities
-
-Response item shape:
-
-```json
-{
-  "target_id": "target_claude_proj_a",
-  "agent": "claude",
-  "path": "/Users/foo/.claude-profiles/project-a/skills",
-  "ownership": "managed",
-  "capabilities": {
-    "symlink": true,
-    "copy": true,
-    "watch": true
-  }
-}
-```
-
-### 7.6 `GET /api/registry/targets/{target_id}`
-
-Purpose:
-
-1. show one target
-2. include dependent bindings and projections
-
-### 7.7 `GET /api/registry/projections`
-
-Purpose:
-
-1. list projections across all bindings
-2. filter by health, skill, binding, or target
-
-Query params:
-
-1. `binding_id`
-2. `target_id`
-3. `skill_id`
-4. `health`
-
-Response item shape:
-
-```json
-{
-  "instance_id": "inst_model-onboarding_claude_b",
-  "skill_id": "model-onboarding",
-  "binding_id": "bind_claude_project_b",
-  "target_id": "target_claude_proj_b",
-  "materialized_path": "/Users/foo/.claude-profiles/project-b/skills/model-onboarding",
-  "method": "copy",
-  "last_applied_rev": "abc123",
-  "health": "drifted",
-  "observed_drift": true,
-  "updated_at": "2026-04-09T10:06:00Z"
-}
-```
-
-### 7.8 `GET /api/registry/projections/{instance_id}`
-
-Purpose:
-
-1. show one projection instance
-2. support detail panel and capture review
-
-Response:
-
-```json
-{
-  "ok": true,
-  "version": "3.0.0",
-  "data": {
-    "projection": {
-      "instance_id": "inst_model-onboarding_claude_b",
-      "skill_id": "model-onboarding",
-      "binding_id": "bind_claude_project_b",
-      "target_id": "target_claude_proj_b",
-      "health": "drifted"
-    },
-    "recent_observations": [],
-    "source": {
-      "skill_id": "model-onboarding",
-      "head": "abc123"
-    }
-  },
-  "error": null,
-  "meta": {
-    "warnings": []
-  }
-}
-```
-
-### 7.9 `GET /api/registry/history`
-
-Purpose:
-
-1. list operation history for audit and recovery views
-
-Query params:
-
-1. `skill_id`
-2. `binding_id`
-3. `intent`
-4. `status`
-5. `limit`
-
-Response item shape:
-
-```json
-{
-  "op_id": "op_004",
-  "intent": "skill.capture",
-  "status": "blocked",
-  "payload": {
-    "skill_id": "model-onboarding",
-    "binding_id": "bind_claude_project_b"
-  },
-  "effects": {
-    "instance_id": "inst_model-onboarding_claude_b"
-  },
-  "last_error": {
-    "code": "CAPTURE_CONFLICT",
-    "message": "projection drift differs from source head"
-  },
-  "created_at": "2026-04-09T10:07:00Z",
-  "updated_at": "2026-04-09T10:07:00Z"
-}
-```
-
-### 7.10 `GET /api/registry/skills`
-
-Purpose:
-
-1. list source registry skills
-2. support registry page
-
-Response item shape:
-
-```json
-{
-  "skill_id": "model-onboarding",
-  "source_path": "skills/model-onboarding",
-  "head": "abc123",
-  "projection_count": 3
-}
-```
-
-### 7.11 `GET /api/registry/skills/{skill_id}`
-
-Purpose:
-
-1. show one source skill
-2. include revision summary and projection summary
-
-### 7.12 `GET /api/registry/migration/plan`
-
-Purpose:
-
-1. support migration review UI
-2. show unresolved legacy-to-registry ambiguities without writing
-
-Response:
-
-```json
-{
-  "ok": true,
-  "version": "3.0.0",
-  "data": {
-    "candidate_targets": [],
-    "candidate_bindings": [],
-    "unresolved": [
-      {
-        "kind": "binding_ambiguity",
-        "source": "state/targets.json",
-        "message": "one claude_path cannot be mapped to a single registry binding safely"
-      }
-    ]
-  },
-  "error": null,
-  "meta": {
-    "warnings": []
-  }
-}
-```
-
-## 8. Query and Filtering Rules
-
-Rules:
-
-1. list endpoints must support stable ordering
-2. filters must be additive
-3. unknown filters must return `ARG_INVALID`
-4. ambiguous selectors must return typed errors
-
-## 9. Read Model Rules
-
-The API may aggregate state for convenience, but must not create new truth.
-
-Allowed:
-
-1. counts
-2. health summaries
-3. grouped history views
-4. projection summaries per skill
-
-Not allowed:
-
-1. guessed default binding assignment
-2. implicit promotion of observed drift into source change
-3. hidden target resolution not explainable via returned fields
-
-## 10. Panel Mapping
-
-Recommended panel pages:
-
-1. `Overview`
-   backed by `/api/registry/workspace`
-2. `Bindings`
-   backed by `/api/registry/bindings`
-3. `Targets`
-   backed by `/api/registry/targets`
-4. `Projections`
-   backed by `/api/registry/projections`
-5. `History`
-   backed by `/api/registry/history`
-6. `Migration`
-   backed by `/api/registry/migration/plan`
-
-## 11. Compatibility Rules
-
-1. The API must reflect registry state only.
-2. If legacy state still exists, API should expose migration review instead of pretending registry resolution already exists.
-3. Panel should never call write endpoints that have no CLI equivalent.
-
-## 12. API Acceptance Criteria
-
-The API contract is acceptable only if:
-
-1. panel can render multi-workspace state without path guessing
-2. bindings, targets, and projections are all visible as separate resources
-3. drift and capture conflicts are queryable
-4. migration ambiguity is visible before any apply step
-5. the API does not depend on one default Claude directory assumption
+Every mutation must pass through `ensure_mutation_authorized` and
+`run_panel_command`, preserving CLI locking, audit logging, error mapping, and
+envelope semantics.
+
+## 6. Rules
+
+1. Panel routes must not invent semantics absent from CLI or registry state.
+2. Reads must not mutate registry state, Git refs/index, target directories, or
+   the pending queue.
+3. Mutations must remain CLI-backed and must not define a second write model.
+4. Unknown enum-like values in read models must render explicitly instead of
+   being silently coerced to a known value.
+5. New Panel routes must be v1 routes. Do not add unversioned compatibility
+   aliases.

--- a/docs/LOOM_ARCHITECTURE_DECISIONS.md
+++ b/docs/LOOM_ARCHITECTURE_DECISIONS.md
@@ -26,8 +26,8 @@ Authoritative for registry panel activity and audit display:
 Rules:
 
 1. `sync push`, `sync pull`, `sync replay`, `ops retry`, `ops purge`, and `ops history repair` continue to operate on the pending/history model.
-2. `/api/registry/ops` exposes bounded summaries from the registry operation journal for activity history.
-3. `/api/ops/retry` and `/api/ops/purge` are flat pending-queue maintenance endpoints, not registry op-id endpoints.
+2. `/api/v1/ops` exposes bounded summaries from the registry operation journal for activity history.
+3. `/api/v1/ops/retry` and `/api/v1/ops/purge` are pending-queue maintenance endpoints, not registry op-id endpoints.
 4. A future migration may make registry operations authoritative, but that requires a separate migration plan and compatibility story.
 
 Rationale:
@@ -89,7 +89,7 @@ Rules:
 4. Orphaned projections (health = "orphaned", binding_id = null) remain in the control plane until `loom skill orphan clean` is run.
 5. `loom skill orphan clean` removes orphaned projection metadata by default and preserves live paths.
 6. Live path deletion requires `loom skill orphan clean --delete-live-paths` and is limited to validated directories under the projection's registered target.
-7. `GET /api/registry/projections?health=orphaned` lists all orphaned projections for panel display.
+7. `GET /api/v1/projections?health=orphaned` lists all orphaned projections for panel display.
 
 Rationale:
 
@@ -107,8 +107,8 @@ Rules:
 2. Every panel mutation route must use `run_panel_command` or an equivalent wrapper that preserves the CLI envelope, lock acquisition, audit logging, and error mapping.
 3. The panel must hide or disable mutation actions when the backend is not live.
 4. Offline, stale, mock, and read-only modes must not expose a second path to write APIs through shortcuts or command palette actions.
-5. `/api/registry/*` remains read-oriented unless a future decision explicitly adds registry write semantics.
-6. Flat write routes such as `/api/ops/retry`, `/api/ops/purge`, and `/api/sync/replay` are compatibility/control routes backed by CLI command behavior.
+5. All Panel HTTP APIs are under `/api/v1/*`; unversioned compatibility routes are not part of the contract.
+6. Control routes such as `/api/v1/ops/retry`, `/api/v1/ops/purge`, and `/api/v1/sync/replay` are backed by CLI command behavior.
 
 Non-goal:
 
@@ -198,7 +198,7 @@ Rejected because: binding removal is a control-plane operation; silently destroy
 
 On `workspace binding remove`, remove the binding record and its rules. For each projection that belonged to the binding, set `health = "orphaned"` and `binding_id = null`. The projection record and its live filesystem path remain intact. A separate `loom skill orphan clean` command explicitly removes orphaned metadata. Operators may also pass `--delete-live-paths` to delete validated live projection directories under registered targets.
 
-Chosen because: projection records stay visible in the control plane (discoverable via `GET /api/registry/projections?health=orphaned`); operators retain full control over when files are actually deleted; the audit journal records both the orphaning event and the eventual cleanup event; the operation is recoverable (re-project the skill to a binding to restore managed status).
+Chosen because: projection records stay visible in the control plane (discoverable via `GET /api/v1/projections?health=orphaned`); operators retain full control over when files are actually deleted; the audit journal records both the orphaning event and the eventual cleanup event; the operation is recoverable (re-project the skill to a binding to restore managed status).
 
 **Option C — Require operator choice at removal time**
 
@@ -227,7 +227,7 @@ Rejected because: adding a required decision to every binding removal creates fr
 
 ### Panel surface
 
-`GET /api/registry/projections?health=orphaned` returns orphaned projection records so the panel can surface an orphaned-count badge and a "Clean up" action on the Bindings page.
+`GET /api/v1/projections?health=orphaned` returns orphaned projection records so the panel can surface an orphaned-count badge and a "Clean up" action on the Bindings page.
 
 ## Issue Mapping
 

--- a/docs/LOOM_V1_CORE_SPEC.md
+++ b/docs/LOOM_V1_CORE_SPEC.md
@@ -564,43 +564,51 @@ GET  /api/v1/health
 GET  /api/v1/overview
 GET  /api/v1/workspace/status
 POST /api/v1/workspace/init
+GET  /api/v1/workspace/info
 GET  /api/v1/workspace/doctor
+POST /api/v1/workspace/remote
 
 GET  /api/v1/skills
 POST /api/v1/skills
-GET  /api/v1/skills/{skill_id}
+GET  /api/v1/skills/trash
+POST /api/v1/skills/import-observed
+GET  /api/v1/skills/{skill_id}/diagnose
 POST /api/v1/skills/{skill_id}/save
 POST /api/v1/skills/{skill_id}/snapshot
 POST /api/v1/skills/{skill_id}/release
 POST /api/v1/skills/{skill_id}/rollback
 GET  /api/v1/skills/{skill_id}/diff
 GET  /api/v1/skills/{skill_id}/history
+POST /api/v1/skills/{skill_id}/trash
+POST /api/v1/skills/trash/{trash_id}/restore
+POST /api/v1/skills/trash/{trash_id}/purge
 
 GET  /api/v1/targets
 POST /api/v1/targets
 GET  /api/v1/targets/{target_id}
-DELETE /api/v1/targets/{target_id}
+POST /api/v1/targets/{target_id}/remove
 
 GET  /api/v1/bindings
 POST /api/v1/bindings
 GET  /api/v1/bindings/{binding_id}
-DELETE /api/v1/bindings/{binding_id}
+POST /api/v1/bindings/{binding_id}/remove
 
 GET  /api/v1/projections
-POST /api/v1/projections
-GET  /api/v1/projections/{instance_id}
-POST /api/v1/projections/{instance_id}/capture
-POST /api/v1/projections/{instance_id}/reproject
+POST /api/v1/projections/project
+POST /api/v1/projections/capture
+POST /api/v1/orphans/clean
 
 GET  /api/v1/ops
+GET  /api/v1/ops/diagnose
+GET  /api/v1/ops/pending
 POST /api/v1/ops/retry
 POST /api/v1/ops/purge
+POST /api/v1/ops/history/repair
 
 GET  /api/v1/sync/status
 POST /api/v1/sync/pull
 POST /api/v1/sync/push
 POST /api/v1/sync/replay
-POST /api/v1/sync/history/repair
 ```
 
 API rules:

--- a/docs/STATUS_FIELD_CLASSIFICATION.md
+++ b/docs/STATUS_FIELD_CLASSIFICATION.md
@@ -15,7 +15,6 @@ returned by `status_view()`.  Update it whenever `status_view()` changes.
 |------|------------|
 | **Authoritative** | Sourced directly from registry state files or computed exclusively from registered registry entities.  Safe for decision logic. |
 | **Advisory** | Computed or aggregated from a mix of registered state and heuristic comparisons.  Useful as UX hints; must not drive control-plane decisions. |
-| **Compatibility-only** | Retained only for legacy callers; scheduled for removal in a future MAJOR version.  Must not be referenced in new code. |
 
 ---
 
@@ -62,13 +61,6 @@ All fields on `RegistryProjectionInstance` are authoritative unless noted below.
 | `updated_at` | Authoritative | Stored timestamp; optional | [source: src/state_model/mod.rs:155] |
 | `last_applied_rev` | **Advisory** (as of registry model; promotion to authoritative requires a future issue) | Git rev recorded when projection was last applied; represents a historical comparison point, not a live git state | [source: src/state_model/mod.rs:148] |
 | `observed_drift` | **Advisory** | Optional boolean; computed by comparing the stored `last_applied_rev` to the current source head at observation time — not set until a check is performed | [source: src/state_model/mod.rs:150–152] |
-
-### Compatibility-only tier
-
-No fields currently fall in this tier.  It is defined here so follow-up issues can
-promote fields to it explicitly rather than silently deprecating them.
-
----
 
 ## Environment-Based Discovery
 
@@ -125,7 +117,7 @@ deduplicated list of source scan paths.
 influence which skills are *available for registration*, but once a rule or projection
 is registered its `skill_id` is authoritative registered state.
 
-No `/api/registry/status` (or `/api/registry/workspace`) field is computed by scanning the
+No `/api/v1/registry/status` field is computed by scanning the
 filesystem paths that these agent directory variables point to.  Advisory
 skill directory hints appear only in diagnostic or migration endpoints, never in the
 counts returned by `status_view()`.

--- a/docs/plan/skill-diagnose-spec.md
+++ b/docs/plan/skill-diagnose-spec.md
@@ -233,9 +233,9 @@ Response:
 - Non-2xx only when the command cannot run or the skill is completely unknown.
 - The endpoint should avoid durable command-audit writes because the UI fetches diagnosis interactively.
 
-Back-compat route:
+Route compatibility:
 
-- No legacy `/api/registry/...` route is required for MVP.
+- No unversioned or `/api/registry/...` route is required for MVP.
 
 ## Panel UX
 

--- a/docs/pr-20-signal-report.md
+++ b/docs/pr-20-signal-report.md
@@ -17,7 +17,7 @@ Review the existing `feat/panel-state-workflow-honesty` branch against issue #19
 1. `HistoryPage` only refreshes on `live` and local `mutationVersion`.
    Root cause: the page is disconnected from the panel-wide polling signal, so CLI-created or external-session operations do not appear until navigation or a local mutation triggers a fetch.
 
-2. `/api/registry/ops` returns the entire `operations.jsonl` journal with full row payloads.
+2. `/api/v1/ops` returned the entire `operations.jsonl` journal with full row payloads.
    Root cause: the handler serializes `snapshot.operations` directly, which makes response cost grow with registry age and with each row's `payload` / `effects` size.
 
 3. `BindingsPage` clears selection with an unconditional stale callback after delete.
@@ -33,7 +33,7 @@ Review the existing `feat/panel-state-workflow-honesty` branch against issue #19
 ## Planned Fixes
 
 1. Bind `HistoryPage` to the existing panel-wide refresh stamp and keep mutation-triggered refreshes.
-2. Paginate and bound `/api/registry/ops`, returning compact row summaries instead of full operation payload blobs.
+2. Paginate and bound `/api/v1/ops`, returning compact row summaries instead of full operation payload blobs.
 3. Add minimal pager UI in History so the full journal remains reachable.
 4. Guard binding delete completion the same way targets already guard delete completion.
 5. Extend tests around history refresh, ops pagination, and stale-selection races.

--- a/panel/src/lib/api/client.test.ts
+++ b/panel/src/lib/api/client.test.ts
@@ -123,6 +123,33 @@ describe("api v1 routes", () => {
     expect(fetchSpy).toHaveBeenCalledWith("/api/v1/skills", { signal: undefined });
   });
 
+  it("uses v1 endpoints for panel bootstrap reads", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        cmd: "ok",
+        request_id: "req-1",
+        data: {},
+        error: null,
+        meta: { warnings: [] },
+      }),
+    } as unknown as Response);
+
+    await api.health();
+    await api.info();
+    await api.pending();
+
+    const paths = fetchSpy.mock.calls.map((call) => call[0]);
+    expect(paths).toEqual([
+      "/api/v1/health",
+      "/api/v1/workspace/info",
+      "/api/v1/ops/pending",
+    ]);
+  });
+
   it("uses v1 endpoints for registry read routes", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,

--- a/panel/src/lib/api/client.test.ts
+++ b/panel/src/lib/api/client.test.ts
@@ -150,6 +150,24 @@ describe("api v1 routes", () => {
     ]);
   });
 
+  it("rejects non-envelope payloads for v1 bootstrap reads", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({ root: "/tmp/loom" }),
+    } as unknown as Response);
+
+    await expect(api.info()).rejects.toEqual(
+      expect.objectContaining<ApiError>({
+        name: "ApiError",
+        path: "/api/v1/workspace/info",
+        status: 200,
+        message: "GET /api/v1/workspace/info returned non-envelope payload",
+      }),
+    );
+  });
+
   it("uses v1 endpoints for registry read routes", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -444,8 +444,8 @@ export interface DoctorPayload {
 }
 
 export const api = {
-  health: (signal?: AbortSignal) => getJson<HealthPayload>("/api/health", signal),
-  info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/info", signal),
+  health: (signal?: AbortSignal) => getJsonData<HealthPayload>("/api/v1/health", signal),
+  info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/v1/workspace/info", signal),
   workspaceStatus: (signal?: AbortSignal) =>
     getJsonData<WorkspaceStatusPayload>("/api/v1/workspace/status", signal),
   skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/v1/skills", signal),
@@ -473,7 +473,7 @@ export const api = {
         await getJson<unknown>("/api/v1/sync/status", signal),
       ),
     ),
-  pending: (signal?: AbortSignal) => getJsonData<PendingPayload>("/api/pending", signal),
+  pending: (signal?: AbortSignal) => getJsonData<PendingPayload>("/api/v1/ops/pending", signal),
 
   opsRetry: () => postJson("/api/v1/ops/retry", {}),
   opsPurge: () => postJson("/api/v1/ops/purge", {}),

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -154,17 +154,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function unwrapReadData<T>(path: string, body: unknown): T {
   if (
-    isRecord(body) &&
-    body.ok === true &&
-    typeof body.cmd === "string" &&
-    typeof body.request_id === "string"
+    !isRecord(body) ||
+    body.ok !== true ||
+    typeof body.cmd !== "string" ||
+    typeof body.request_id !== "string"
   ) {
-    if (!("data" in body)) {
-      throw new ApiError(path, 200, `GET ${path} envelope is missing data`);
-    }
-    return body.data as T;
+    throw new ApiError(path, 200, `GET ${path} returned non-envelope payload`);
   }
-  return body as T;
+  if (!("data" in body)) {
+    throw new ApiError(path, 200, `GET ${path} envelope is missing data`);
+  }
+  return body.data as T;
 }
 
 function parseRemoteStatusResponse(path: string, body: unknown): RemoteStatusResponse {

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -22,9 +22,6 @@ export type KnownAgent =
 // name instead of being relabelled. `string & {}` keeps editor hints.
 export type AgentSlug = KnownAgent | (string & {});
 
-// Back-compat alias for older call sites that still import AgentKind.
-export type AgentKind = AgentSlug;
-
 export type Ownership = "managed" | "observed" | "external" | "unknown";
 export type ProjectionMethod = "symlink" | "copy" | "materialize" | "unknown";
 export type OpStatus = "ok" | "pending" | "err";
@@ -36,7 +33,7 @@ export interface Target {
   profile: string;
   path: string;
   ownership: Ownership;
-  /** Back-compat display count. Prefer `observedSkills` / `projectedSkills` for labels. */
+  /** Display count. Prefer `observedSkills` / `projectedSkills` for precise labels. */
   skills: number;
   observedSkills?: number;
   projectedSkills?: number;

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -25,10 +25,28 @@ function installFetchMock(failingPath: string, failingResponse: Response) {
   fetchMock.mockImplementation((input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     switch (url) {
-      case "/api/health":
-        return Promise.resolve(jsonResponse({ ok: true }));
-      case "/api/info":
-        return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
+      case "/api/v1/health":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "panel.health",
+            request_id: "req-health",
+            data: { service: "loom-panel" },
+            error: null,
+            meta: { warnings: [] },
+          }),
+        );
+      case "/api/v1/workspace/info":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "panel.info",
+            request_id: "req-info",
+            data: { root: "/tmp/loom-registry" },
+            error: null,
+            meta: { warnings: [] },
+          }),
+        );
       case "/api/v1/workspace/status":
         return Promise.resolve(
           jsonResponse({
@@ -82,8 +100,19 @@ function installFetchMock(failingPath: string, failingResponse: Response) {
                 meta: { warnings: [] },
               }),
         );
-      case "/api/pending":
-        return Promise.resolve(url === failingPath ? failingResponse : jsonResponse({ count: 0, ops: [] }));
+      case "/api/v1/ops/pending":
+        return Promise.resolve(
+          url === failingPath
+            ? failingResponse
+            : jsonResponse({
+                ok: true,
+                cmd: "pending.list",
+                request_id: "req-pending",
+                data: { count: 0, ops: [] },
+                error: null,
+                meta: { warnings: [] },
+              }),
+        );
       case "/api/v1/ops?limit=30":
         return Promise.resolve(
           jsonResponse({
@@ -154,9 +183,9 @@ describe("PanelApp status failure UI", () => {
     expect(screen.getByText(/failed to read pending_ops\.jsonl/i)).toBeTruthy();
   });
 
-  it("shows registry error state when /api/pending returns a structured backend failure", async () => {
+  it("shows registry error state when /api/v1/ops/pending returns a structured backend failure", async () => {
     installFetchMock(
-      "/api/pending",
+      "/api/v1/ops/pending",
       errorResponse(500, {
         ok: false,
         error: { code: "IO_ERROR", message: "failed to read pending queue" },
@@ -176,10 +205,28 @@ describe("PanelApp status failure UI", () => {
     fetchMock.mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       switch (url) {
-        case "/api/health":
-          return Promise.resolve(jsonResponse({ ok: true }));
-        case "/api/info":
-          return Promise.resolve(jsonResponse({ root: "/tmp/loom-registry" }));
+        case "/api/v1/health":
+          return Promise.resolve(
+            jsonResponse({
+              ok: true,
+              cmd: "panel.health",
+              request_id: "req-health",
+              data: { service: "loom-panel" },
+              error: null,
+              meta: { warnings: [] },
+            }),
+          );
+        case "/api/v1/workspace/info":
+          return Promise.resolve(
+            jsonResponse({
+              ok: true,
+              cmd: "panel.info",
+              request_id: "req-info",
+              data: { root: "/tmp/loom-registry" },
+              error: null,
+              meta: { warnings: [] },
+            }),
+          );
         case "/api/v1/workspace/status":
           return Promise.resolve(
             jsonResponse({

--- a/panel/src/pages/panel/OpsPage.tsx
+++ b/panel/src/pages/panel/OpsPage.tsx
@@ -93,7 +93,7 @@ export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
         <div className="ops-summary-grid">
           <div
             className="card"
-            title="Visible Activity rows. Queued writes come from /api/pending; audit rows come from /api/ops."
+            title="Visible Activity rows. Queued writes come from /api/v1/ops/pending; audit rows come from /api/v1/ops."
           >
             <div className="card-body">
               <div style={section_label}>{COUNT_TERMS.activityRows}</div>

--- a/panel/src/pages/panel/SettingsPage.tsx
+++ b/panel/src/pages/panel/SettingsPage.tsx
@@ -108,7 +108,7 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
         <div className="title-block">
           <h1>Settings</h1>
           <div className="subtitle">
-            Where Loom keeps its state. These paths come from <span className="mono">/api/info</span> and mirror the CLI
+            Where Loom keeps its state. These paths come from <span className="mono">/api/v1/workspace/info</span> and mirror the CLI
             output of <span className="mono">loom workspace status</span>.
           </div>
         </div>

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,7 +34,7 @@ use crate::state::{AppContext, home_dir};
 use crate::types::ErrorCode;
 
 pub(crate) use event_store::redact_sensitive_string;
-pub use helpers::{collect_skill_inventory, remote_status_payload};
+pub use helpers::collect_skill_inventory;
 
 use event_store::{
     append_command_audit_failure, append_command_finished, append_command_started,

--- a/src/panel/handlers/ops.rs
+++ b/src/panel/handlers/ops.rs
@@ -223,58 +223,6 @@ fn json_string_field(value: &serde_json::Value, keys: &[&str]) -> Option<String>
         .map(ToString::to_string)
 }
 
-/// Return a bounded, newest-first page of the operations journal
-/// (`.loom/registry/operations.jsonl`). History only needs row summaries, so omit
-/// per-op payload/effects blobs here and keep the response cost bounded even
-/// for long-lived registries.
-pub(in crate::panel) async fn registry_ops(
-    Query(query): Query<OpsQuery>,
-    State(state): State<PanelState>,
-) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx, "registry.ops") {
-        Ok(snapshot) => {
-            let total = snapshot.operations.len();
-            let limit = query
-                .limit
-                .unwrap_or(DEFAULT_OPS_PAGE_SIZE)
-                .clamp(1, MAX_OPS_PAGE_SIZE);
-            let offset = query.offset.unwrap_or(0);
-            let end = total.saturating_sub(offset);
-            let start = end.saturating_sub(limit);
-            let operations = snapshot.operations[start..end]
-                .iter()
-                .rev()
-                .map(|op| {
-                    json!({
-                        "op_id": op.op_id,
-                        "intent": op.intent,
-                        "status": op.status,
-                        "ack": op.ack,
-                        "last_error": op.last_error,
-                        "created_at": op.created_at,
-                        "updated_at": op.updated_at,
-                    })
-                })
-                .collect::<Vec<_>>();
-
-            registry_ok(
-                "registry.ops",
-                json!({
-                    "state_model": "registry",
-                    "count": total,
-                    "loaded_count": operations.len(),
-                    "offset": offset,
-                    "limit": limit,
-                    "has_more": start > 0,
-                    "operations": operations,
-                    "checkpoint": snapshot.checkpoint,
-                }),
-            )
-        }
-        Err(err) => err,
-    }
-}
-
 pub(in crate::panel) async fn ops_retry(
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
@@ -358,7 +306,7 @@ pub(in crate::panel) async fn registry_ops_diagnose(
     }
 }
 
-pub(in crate::panel) async fn pending(
+pub(in crate::panel) async fn v1_pending(
     State(state): State<PanelState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     match state.ctx.read_pending_report() {

--- a/src/panel/handlers/registry_read.rs
+++ b/src/panel/handlers/registry_read.rs
@@ -83,47 +83,6 @@ pub(in crate::panel) async fn registry_status(
     }
 }
 
-pub(in crate::panel) async fn registry_projections(
-    Query(query): Query<ProjectionsQuery>,
-    State(state): State<PanelState>,
-) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx, "registry.projections") {
-        Ok(snapshot) => {
-            let projections: Vec<_> = snapshot
-                .projections
-                .projections
-                .iter()
-                .filter(|p| query.health.as_deref().is_none_or(|h| p.health == h))
-                .collect();
-            registry_ok(
-                "registry.projections",
-                json!({
-                    "state_model": "registry",
-                    "count": projections.len(),
-                    "projections": projections,
-                }),
-            )
-        }
-        Err(err) => err,
-    }
-}
-
-pub(in crate::panel) async fn registry_bindings(
-    State(state): State<PanelState>,
-) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx, "registry.bindings") {
-        Ok(snapshot) => registry_ok(
-            "registry.bindings",
-            json!({
-                "state_model": "registry",
-                "count": snapshot.bindings.bindings.len(),
-                "bindings": snapshot.bindings.bindings
-            }),
-        ),
-        Err(err) => err,
-    }
-}
-
 pub(in crate::panel) async fn registry_binding_show(
     AxumPath(binding_id): AxumPath<String>,
     State(state): State<PanelState>,
@@ -153,22 +112,6 @@ pub(in crate::panel) async fn registry_binding_show(
             "projections": snapshot.binding_projections(&binding.binding_id)
         }),
     )
-}
-
-pub(in crate::panel) async fn registry_targets(
-    State(state): State<PanelState>,
-) -> Json<serde_json::Value> {
-    match load_registry_snapshot(&state.ctx, "registry.targets") {
-        Ok(snapshot) => registry_ok(
-            "registry.targets",
-            json!({
-                "state_model": "registry",
-                "count": snapshot.targets.targets.len(),
-                "targets": snapshot.targets.targets
-            }),
-        ),
-        Err(err) => err,
-    }
 }
 
 pub(in crate::panel) async fn registry_target_show(

--- a/src/panel/handlers/skills.rs
+++ b/src/panel/handlers/skills.rs
@@ -7,14 +7,12 @@ use serde_json::json;
 
 use crate::cli::SkillOnlyArgs;
 use crate::commands::App;
-use crate::commands::collect_skill_inventory;
 use crate::envelope::Envelope;
 use crate::gitops;
 use crate::state_model::{RegistrySnapshot, RegistryStatePaths};
 use crate::types::ErrorCode;
 
 use super::super::PanelState;
-use super::super::auth::registry_ok;
 use super::common::panel_command_envelope;
 
 #[derive(Debug, Default)]
@@ -449,21 +447,4 @@ fn skill_row_to_json(row: SkillReadRow) -> serde_json::Value {
         "observed_imported": row.observed_imported,
         "sources": row.sources.into_iter().collect::<Vec<_>>(),
     })
-}
-
-pub(in crate::panel) async fn skills(State(state): State<PanelState>) -> Json<serde_json::Value> {
-    let inventory = collect_skill_inventory(&state.ctx);
-    registry_ok(
-        "panel.skills",
-        json!({
-            "skills": inventory.source_skills,
-            "backup_skills": inventory.backup_skills,
-            "source_dirs": inventory
-                .source_dirs
-                .iter()
-                .map(|path: &std::path::PathBuf| path.display().to_string())
-                .collect::<Vec<_>>(),
-            "warnings": inventory.warnings
-        }),
-    )
 }

--- a/src/panel/handlers/workspace.rs
+++ b/src/panel/handlers/workspace.rs
@@ -8,20 +8,15 @@ use axum::{
 use serde_json::json;
 
 use crate::cli::{Command, RemoteCommand, SyncCommand, WorkspaceCommand, WorkspaceInitArgs};
-use crate::commands::{App, redact_sensitive_string, remote_status_payload};
+use crate::commands::{App, redact_sensitive_string};
 use crate::state::resolve_agent_skill_dirs;
 use crate::state_model::RegistryStatePaths;
 
 use super::super::auth::{
-    ensure_mutation_authorized, error_envelope, registry_error, registry_ok,
-    registry_ok_with_warnings, run_panel_command, status_for_error_code,
+    ensure_mutation_authorized, error_envelope, registry_ok_with_warnings, run_panel_command,
 };
 use super::super::{PanelState, RemoteSetRequest, WorkspaceInitRequest};
 use super::common::{panel_command_envelope, panel_v1_ok};
-
-pub(in crate::panel) async fn health() -> Json<serde_json::Value> {
-    Json(json!({"ok": true, "service": "loom-panel"}))
-}
 
 pub(in crate::panel) async fn v1_health() -> (StatusCode, Json<serde_json::Value>) {
     panel_v1_ok("panel.health", json!({"service": "loom-panel"}))
@@ -96,7 +91,7 @@ pub(in crate::panel) async fn v1_sync_status(
     )
 }
 
-pub(in crate::panel) async fn info(State(state): State<PanelState>) -> Json<serde_json::Value> {
+pub(in crate::panel) async fn v1_info(State(state): State<PanelState>) -> Json<serde_json::Value> {
     let target_dirs = resolve_agent_skill_dirs(&state.ctx.root);
     let registry_paths = RegistryStatePaths::from_app_context(&state.ctx);
 
@@ -243,22 +238,4 @@ pub(in crate::panel) async fn remote_set(
             },
         },
     )
-}
-
-pub(in crate::panel) async fn remote_status(
-    State(state): State<PanelState>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    match remote_status_payload(&state.ctx) {
-        Ok((remote, meta)) => (
-            StatusCode::OK,
-            registry_ok(
-                "remote.status",
-                json!({"remote": remote, "warnings": meta.warnings}),
-            ),
-        ),
-        Err(err) => (
-            status_for_error_code(Some(err.code.as_str())),
-            registry_error("remote.status", err.code.as_str(), err.message),
-        ),
-    }
 }

--- a/src/panel/mod.rs
+++ b/src/panel/mod.rs
@@ -149,11 +149,11 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
 
     let app = Router::new()
         .route("/", get(frontend_index))
-        .route("/api/health", get(health))
         .route("/api/v1/health", get(v1_health))
         .route("/api/v1/overview", get(v1_overview))
         .route("/api/v1/workspace/status", get(v1_workspace_status))
         .route("/api/v1/workspace/init", post(v1_workspace_init))
+        .route("/api/v1/workspace/info", get(v1_info))
         .route("/api/v1/workspace/doctor", get(v1_workspace_doctor))
         .route("/api/v1/workspace/remote", post(remote_set))
         .route("/api/v1/registry/status", get(registry_status))
@@ -224,6 +224,7 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v1/orphans/clean", post(registry_orphan_clean))
         .route("/api/v1/ops", get(v1_registry_ops))
         .route("/api/v1/ops/diagnose", get(registry_ops_diagnose))
+        .route("/api/v1/ops/pending", get(v1_pending))
         .route("/api/v1/ops/retry", post(ops_retry))
         .route("/api/v1/ops/purge", post(ops_purge))
         .route("/api/v1/ops/history/repair", post(ops_history_repair))
@@ -231,53 +232,6 @@ pub async fn run_panel(ctx: AppContext, port: u16) -> Result<()> {
         .route("/api/v1/sync/push", post(sync_push))
         .route("/api/v1/sync/pull", post(sync_pull))
         .route("/api/v1/sync/replay", post(sync_replay))
-        .route("/api/info", get(info))
-        .route("/api/skills", get(skills))
-        .route("/api/registry/status", get(registry_status))
-        .route("/api/registry/ops", get(registry_ops))
-        .route("/api/registry/ops/diagnose", get(registry_ops_diagnose))
-        .route("/api/registry/projections", get(registry_projections))
-        .route("/api/registry/bindings", get(registry_bindings))
-        .route(
-            "/api/registry/bindings/{binding_id}",
-            get(registry_binding_show),
-        )
-        .route("/api/registry/targets", get(registry_targets))
-        .route(
-            "/api/registry/targets/{target_id}",
-            get(registry_target_show),
-        )
-        .route("/api/registry/targets", post(registry_target_add))
-        .route(
-            "/api/registry/targets/{target_id}/remove",
-            post(registry_target_remove),
-        )
-        .route("/api/registry/bindings", post(registry_binding_add))
-        .route(
-            "/api/registry/bindings/{binding_id}/remove",
-            post(registry_binding_remove),
-        )
-        .route("/api/registry/skills", post(registry_skill_add))
-        .route("/api/registry/project", post(registry_project))
-        .route("/api/registry/capture", post(registry_capture))
-        .route("/api/registry/orphans/clean", post(registry_orphan_clean))
-        .route(
-            "/api/registry/skills/{skill_name}/diff",
-            get(registry_skill_diff),
-        )
-        .route(
-            "/api/registry/skills/{skill_name}/history",
-            get(registry_skill_history),
-        )
-        .route("/api/remote/status", get(remote_status))
-        .route("/api/remote/set", post(remote_set))
-        .route("/api/pending", get(pending))
-        .route("/api/ops/retry", post(ops_retry))
-        .route("/api/ops/purge", post(ops_purge))
-        .route("/api/ops/history/repair", post(ops_history_repair))
-        .route("/api/sync/push", post(sync_push))
-        .route("/api/sync/pull", post(sync_pull))
-        .route("/api/sync/replay", post(sync_replay))
         .route("/{*path}", get(frontend_static_asset))
         .layer(DefaultBodyLimit::max(MAX_PANEL_BODY_BYTES))
         .with_state(state);

--- a/src/panel/tests/handlers.rs
+++ b/src/panel/tests/handlers.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::panel::TrashRestoreRequest;
 use crate::panel::handlers::{
-    OpsQuery, info, pending, registry_ops, registry_orphan_clean, registry_skill_trash_add,
-    registry_skill_trash_purge, registry_skill_trash_restore, remote_set, remote_status, v1_health,
-    v1_overview, v1_registry_ops, v1_registry_targets, v1_skill_diagnose, v1_skill_trash,
-    v1_skills, v1_workspace_status,
+    OpsQuery, registry_orphan_clean, registry_skill_trash_add, registry_skill_trash_purge,
+    registry_skill_trash_restore, remote_set, v1_health, v1_info, v1_overview, v1_pending,
+    v1_registry_ops, v1_registry_targets, v1_skill_diagnose, v1_skill_trash, v1_skills,
+    v1_workspace_status,
 };
 use crate::state_model::{
     REGISTRY_SCHEMA_VERSION, RegistryBindingRule, RegistryOperationRecord,
@@ -50,7 +50,7 @@ fn panel_headers() -> HeaderMap {
 }
 
 #[test]
-fn registry_ops_returns_bounded_newest_first_rows() {
+fn v1_registry_ops_returns_bounded_newest_first_rows() {
     let (root, state) = make_test_state();
     let paths = RegistryStatePaths::from_app_context(state.ctx.as_ref());
     paths.ensure_layout().expect("ensure registry layout");
@@ -77,7 +77,7 @@ fn registry_ops_returns_bounded_newest_first_rows() {
         .build()
         .expect("runtime")
         .block_on(async {
-            let Json(payload) = registry_ops(
+            let (status, Json(payload)) = v1_registry_ops(
                 Query(OpsQuery {
                     limit: Some(2),
                     offset: Some(0),
@@ -85,6 +85,7 @@ fn registry_ops_returns_bounded_newest_first_rows() {
                 State(state.clone()),
             )
             .await;
+            assert_eq!(status, StatusCode::OK);
             payload
         });
 
@@ -375,43 +376,6 @@ async fn registry_status_returns_ok_when_snapshot_loads() {
 }
 
 #[tokio::test]
-async fn remote_status_returns_non_2xx_with_structured_error_body_on_failure() {
-    let (root, state) = make_test_state();
-    state
-        .ctx
-        .ensure_state_layout()
-        .expect("create pending ops layout");
-    fs::remove_file(&state.ctx.pending_ops_file).expect("remove pending ops file");
-    fs::create_dir_all(&state.ctx.pending_ops_file).expect("replace pending ops file with dir");
-
-    let (status, Json(payload)) = remote_status(State(state)).await;
-
-    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    assert_eq!(payload["ok"], json!(false));
-    assert_eq!(payload["error"]["code"], json!("IO_ERROR"));
-    assert!(payload["error"]["message"].as_str().is_some());
-
-    let _ = fs::remove_dir_all(root);
-}
-
-#[tokio::test]
-async fn remote_status_returns_success_payload_when_remote_is_not_configured() {
-    let (root, state) = make_test_state();
-
-    let (status, Json(payload)) = remote_status(State(state)).await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["ok"], json!(true));
-    assert_eq!(payload["cmd"], json!("remote.status"));
-    assert!(payload["request_id"].as_str().is_some());
-    assert_eq!(payload["data"]["remote"]["configured"], json!(false));
-    assert!(payload["data"]["remote"].is_object());
-    assert!(payload["data"]["warnings"].is_array());
-
-    let _ = fs::remove_dir_all(root);
-}
-
-#[tokio::test]
 async fn remote_set_rejects_empty_url() {
     let (root, state) = make_test_state();
     let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000);
@@ -460,10 +424,12 @@ async fn remote_set_configures_origin_from_authorized_panel_request() {
     assert_eq!(payload["data"]["remote"], json!("origin"));
     assert_eq!(payload["data"]["url"], json!(url));
 
-    let (remote_status_code, Json(remote_payload)) = remote_status(State(state)).await;
-    assert_eq!(remote_status_code, StatusCode::OK);
-    assert_eq!(remote_payload["data"]["remote"]["configured"], json!(true));
-    assert_eq!(remote_payload["data"]["remote"]["url"], json!(url));
+    assert_eq!(
+        crate::gitops::remote_url(&state.ctx)
+            .expect("read remote")
+            .as_deref(),
+        Some(url)
+    );
 
     cleanup_root(root);
 }
@@ -520,14 +486,14 @@ async fn registry_orphan_clean_uses_cli_envelope_and_records_operation() {
 }
 
 #[tokio::test]
-async fn info_and_remote_status_redact_remote_credentials() {
+async fn v1_info_redacts_remote_credentials() {
     let (root, state) = make_test_state();
     let url =
         "https://user:pass@example.com/loom-registry.git?token=ghp_secret&ref=main#ghp_fragment";
     crate::gitops::ensure_repo_initialized(&state.ctx).expect("init repo");
     crate::gitops::set_remote_origin(&state.ctx, url).expect("set remote");
 
-    let Json(info_payload) = info(State(state.clone())).await;
+    let Json(info_payload) = v1_info(State(state)).await;
     let info_url = info_payload["data"]["remote_url"]
         .as_str()
         .expect("info remote url");
@@ -541,15 +507,6 @@ async fn info_and_remote_status_redact_remote_credentials() {
         &Vec::<serde_json::Value>::new()
     );
 
-    let (status, Json(remote_payload)) = remote_status(State(state)).await;
-    assert_eq!(status, StatusCode::OK);
-    let status_url = remote_payload["data"]["remote"]["url"]
-        .as_str()
-        .expect("status remote url");
-    assert!(!status_url.contains("user:pass"));
-    assert!(!status_url.contains("ghp_secret"));
-    assert!(status_url.contains("<redacted>"));
-
     cleanup_root(root);
 }
 
@@ -561,7 +518,7 @@ async fn info_surfaces_warning_when_root_is_not_a_git_repository() {
     // repository" — currently mapped to Ok(None) inside gitops::remote_url.
     // The handler should probe the repo and surface the misconfiguration.
 
-    let Json(payload) = info(State(state)).await;
+    let Json(payload) = v1_info(State(state)).await;
 
     assert_eq!(payload["ok"], json!(true));
     assert_eq!(payload["data"]["remote_url"], json!(""));
@@ -583,7 +540,7 @@ async fn info_omits_warning_when_repo_initialized_but_no_remote_configured() {
     let (root, state) = make_test_state();
     crate::gitops::ensure_repo_initialized(&state.ctx).expect("init repo");
 
-    let Json(payload) = info(State(state)).await;
+    let Json(payload) = v1_info(State(state)).await;
 
     assert_eq!(payload["ok"], json!(true));
     assert_eq!(payload["data"]["remote_url"], json!(""));
@@ -604,7 +561,7 @@ async fn info_surfaces_warning_when_git_remote_lookup_fails() {
     // fail at spawn time (current_dir does not exist).
     fs::remove_dir_all(&root).expect("remove root");
 
-    let Json(payload) = info(State(state)).await;
+    let Json(payload) = v1_info(State(state)).await;
 
     assert_eq!(payload["ok"], json!(true));
     assert_eq!(payload["data"]["remote_url"], json!(""));
@@ -629,7 +586,7 @@ async fn pending_returns_non_2xx_with_structured_error_body_on_failure() {
     fs::remove_file(&state.ctx.pending_ops_file).expect("remove pending ops file");
     fs::create_dir_all(&state.ctx.pending_ops_file).expect("replace pending ops file with dir");
 
-    let (status, Json(payload)) = pending(State(state)).await;
+    let (status, Json(payload)) = v1_pending(State(state)).await;
 
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
     assert_eq!(payload["ok"], json!(false));
@@ -647,7 +604,7 @@ async fn pending_returns_ok_with_empty_report_on_success() {
         .ensure_state_layout()
         .expect("create pending ops layout");
 
-    let (status, Json(payload)) = pending(State(state)).await;
+    let (status, Json(payload)) = v1_pending(State(state)).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["ok"], json!(true));

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -42,7 +42,10 @@ const MUTATION_COMMANDS: &[&str] = &[
 ];
 
 const V1_REGISTRY_READ_ROUTES: &[&str] = &[
+    "/api/v1/health",
+    "/api/v1/workspace/info",
     "/api/v1/registry/status",
+    "/api/v1/ops/pending",
     "/api/v1/ops/diagnose",
     "/api/v1/bindings/{binding_id}",
     "/api/v1/targets/{target_id}",
@@ -50,7 +53,19 @@ const V1_REGISTRY_READ_ROUTES: &[&str] = &[
     "/api/v1/skills/{skill_name}/diff",
 ];
 
-const LEGACY_REGISTRY_READ_ROUTES: &[&str] = &[
+const LEGACY_PANEL_ROUTES: &[&str] = &[
+    "/api/health",
+    "/api/info",
+    "/api/skills",
+    "/api/pending",
+    "/api/remote/status",
+    "/api/remote/set",
+    "/api/ops/retry",
+    "/api/ops/purge",
+    "/api/ops/history/repair",
+    "/api/sync/push",
+    "/api/sync/pull",
+    "/api/sync/replay",
     "/api/registry/status",
     "/api/registry/ops/diagnose",
     "/api/registry/bindings/{binding_id}",
@@ -65,7 +80,7 @@ fn mutation_commands_count_is_twenty_two() {
 }
 
 #[test]
-fn panel_registry_reads_prefer_v1_routes_with_legacy_compatibility() {
+fn panel_routes_are_v1_only_without_legacy_api_compatibility() {
     let client_source = include_str!("../../../panel/src/lib/api/client.ts");
     let panel_routes = include_str!("../mod.rs");
 
@@ -76,16 +91,22 @@ fn panel_registry_reads_prefer_v1_routes_with_legacy_compatibility() {
         );
     }
 
-    for route in LEGACY_REGISTRY_READ_ROUTES {
+    for route in LEGACY_PANEL_ROUTES {
         assert!(
-            panel_routes.contains(route),
-            "missing legacy compatibility route {route}"
+            !panel_routes.contains(route),
+            "legacy panel API route must be removed: {route}"
         );
     }
 
     assert!(
-        !client_source.contains("/api/registry/"),
-        "frontend registry reads must use /api/v1 aliases"
+        !client_source.contains("\"/api/health")
+            && !client_source.contains("\"/api/info")
+            && !client_source.contains("\"/api/pending")
+            && !client_source.contains("\"/api/registry/")
+            && !client_source.contains("\"/api/remote/")
+            && !client_source.contains("\"/api/ops/")
+            && !client_source.contains("\"/api/sync/"),
+        "frontend must not call legacy panel API routes"
     );
 }
 

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -67,11 +67,21 @@ const LEGACY_PANEL_ROUTES: &[&str] = &[
     "/api/sync/pull",
     "/api/sync/replay",
     "/api/registry/status",
+    "/api/registry/ops",
     "/api/registry/ops/diagnose",
+    "/api/registry/projections",
+    "/api/registry/bindings",
     "/api/registry/bindings/{binding_id}",
+    "/api/registry/bindings/{binding_id}/remove",
+    "/api/registry/targets",
     "/api/registry/targets/{target_id}",
+    "/api/registry/targets/{target_id}/remove",
+    "/api/registry/skills",
     "/api/registry/skills/{skill_name}/history",
     "/api/registry/skills/{skill_name}/diff",
+    "/api/registry/project",
+    "/api/registry/capture",
+    "/api/registry/orphans/clean",
 ];
 
 #[test]


### PR DESCRIPTION
## Summary

- remove legacy/unversioned Panel API route registrations
- move the remaining Panel bootstrap reads to v1 routes: `/api/v1/workspace/info` and `/api/v1/ops/pending`
- update Panel client/tests and API docs to assert v1-only behavior

## Why

The Panel had two HTTP surfaces: the v1 API and legacy aliases such as `/api/info`, `/api/pending`, flat `/api/ops/*`, flat `/api/sync/*`, `/api/remote/*`, and `/api/registry/*`. Keeping both makes audits and future API changes harder, and can hide whether the Panel is really using the v1 contract.

Fixes #274.

## Validation

- `cargo fmt --check && cargo check --locked && cargo test --locked`
- `cd panel && bun run typecheck && bun run test && bun run build`
