### PR TITLE
fix: reject escaping projection symlinks

### DIFF
--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -26,6 +26,9 @@ use super::file_ops::{
 use super::helpers::{map_git, map_io, map_push_rejected, map_queue, map_remote_unreachable};
 use crate::state::remove_path_if_exists;
 
+mod symlink_guard;
+use symlink_guard::ensure_projection_symlinks_contained;
+
 // ---------------------------------------------------------------------------
 // Registry state mutators
 // ---------------------------------------------------------------------------
@@ -77,6 +80,7 @@ pub(crate) fn project_skill_to_target(
     match method {
         ProjectionMethod::Symlink => create_symlink_dir(src, dst),
         ProjectionMethod::Copy => {
+            ensure_projection_symlinks_contained(src, true)?;
             let parent = dst
                 .parent()
                 .context("projection target has no parent directory")?;
@@ -92,6 +96,7 @@ pub(crate) fn project_skill_to_target(
             Ok(())
         }
         ProjectionMethod::Materialize => {
+            ensure_projection_symlinks_contained(src, false)?;
             let parent = dst
                 .parent()
                 .context("projection target has no parent directory")?;

--- a/src/commands/projections/project_skill_tests.rs
+++ b/src/commands/projections/project_skill_tests.rs
@@ -41,10 +41,10 @@ fn materialize_method_materializes_files() {
 
 #[cfg(unix)]
 #[test]
-fn copy_preserves_symlink_but_materialize_resolves_it() {
+fn copy_preserves_internal_symlink_but_materialize_resolves_it() {
     let base = scratch_dir("copy-vs-materialize-symlink");
     let src = make_skill_src(&base);
-    let secret = base.join("secret.txt");
+    let secret = src.join("secret.txt");
     stdfs::write(&secret, "secret contents\n").expect("secret file");
     std::os::unix::fs::symlink(&secret, src.join("secret-link")).expect("source symlink");
 
@@ -70,6 +70,86 @@ fn copy_preserves_symlink_but_materialize_resolves_it() {
         stdfs::read_to_string(mat_dst.join("secret-link")).expect("materialized content"),
         "secret contents\n"
     );
+
+    let _ = stdfs::remove_dir_all(&base);
+}
+
+#[cfg(unix)]
+#[test]
+fn copy_preserves_dangling_relative_symlink_inside_source() {
+    let base = scratch_dir("copy-dangling-symlink");
+    let src = make_skill_src(&base);
+    std::os::unix::fs::symlink("future.txt", src.join("current")).expect("dangling symlink");
+
+    let copy_dst = base.join("dst-copy");
+    project_skill_to_target(&src, &copy_dst, ProjectionMethod::Copy).expect("copy ok");
+    assert!(
+        stdfs::symlink_metadata(copy_dst.join("current"))
+            .expect("copy link metadata")
+            .file_type()
+            .is_symlink(),
+        "copy must preserve dangling symlinks that remain inside the source tree"
+    );
+    assert_eq!(
+        stdfs::read_link(copy_dst.join("current")).expect("copied link target"),
+        PathBuf::from("future.txt")
+    );
+
+    let mat_dst = base.join("dst-mat");
+    let err = project_skill_to_target(&src, &mat_dst, ProjectionMethod::Materialize)
+        .expect_err("materialize cannot dereference dangling symlinks");
+    assert!(
+        err.to_string().contains("unsafe symlink") && err.to_string().contains("unresolved target"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !mat_dst.exists(),
+        "failed projection must not create target"
+    );
+
+    let _ = stdfs::remove_dir_all(&base);
+}
+
+#[cfg(unix)]
+#[test]
+fn copy_rejects_symlink_resolving_outside_source() {
+    let base = scratch_dir("copy-escaping-symlink");
+    let src = make_skill_src(&base);
+    let secret = base.join("secret.txt");
+    stdfs::write(&secret, "secret contents\n").expect("secret file");
+    std::os::unix::fs::symlink(&secret, src.join("secret-link")).expect("source symlink");
+
+    let dst = base.join("dst-copy");
+    let err = project_skill_to_target(&src, &dst, ProjectionMethod::Copy)
+        .expect_err("escaping symlink must be rejected");
+    assert!(
+        err.to_string().contains("unsafe symlink")
+            && err.to_string().contains("outside source directory"),
+        "unexpected error: {err}"
+    );
+    assert!(!dst.exists(), "failed projection must not create target");
+
+    let _ = stdfs::remove_dir_all(&base);
+}
+
+#[cfg(unix)]
+#[test]
+fn materialize_rejects_symlink_resolving_outside_source() {
+    let base = scratch_dir("materialize-escaping-symlink");
+    let src = make_skill_src(&base);
+    let secret = base.join("secret.txt");
+    stdfs::write(&secret, "secret contents\n").expect("secret file");
+    std::os::unix::fs::symlink(&secret, src.join("secret-link")).expect("source symlink");
+
+    let dst = base.join("dst-mat");
+    let err = project_skill_to_target(&src, &dst, ProjectionMethod::Materialize)
+        .expect_err("escaping symlink must be rejected");
+    assert!(
+        err.to_string().contains("unsafe symlink")
+            && err.to_string().contains("outside source directory"),
+        "unexpected error: {err}"
+    );
+    assert!(!dst.exists(), "failed projection must not create target");
 
     let _ = stdfs::remove_dir_all(&base);
 }

--- a/src/commands/projections/symlink_guard.rs
+++ b/src/commands/projections/symlink_guard.rs
@@ -1,0 +1,85 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+use walkdir::WalkDir;
+
+pub(super) fn ensure_projection_symlinks_contained(
+    src: &Path,
+    allow_dangling_in_tree: bool,
+) -> Result<()> {
+    let source_root = fs::canonicalize(src)
+        .with_context(|| format!("failed to canonicalize projection source {}", src.display()))?;
+
+    for entry in WalkDir::new(&source_root).follow_links(false).into_iter() {
+        let entry =
+            entry.with_context(|| format!("failed to walk projection source {}", src.display()))?;
+        if !entry.file_type().is_symlink() {
+            continue;
+        }
+
+        let rel = entry
+            .path()
+            .strip_prefix(&source_root)
+            .unwrap_or(entry.path());
+        let link_target = fs::read_link(entry.path())
+            .with_context(|| format!("failed to read symlink {}", entry.path().display()))?;
+        let resolved_target =
+            resolve_symlink_target(entry.path(), &link_target, allow_dangling_in_tree)
+                .with_context(|| {
+                    format!(
+                        "unsafe symlink '{}' has unresolved target '{}'",
+                        rel.display(),
+                        link_target.display()
+                    )
+                })?;
+
+        if !resolved_target.starts_with(&source_root) {
+            return Err(anyhow!(
+                "unsafe symlink '{}' resolves outside source directory '{}' to '{}'",
+                rel.display(),
+                source_root.display(),
+                resolved_target.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_symlink_target(
+    link_path: &Path,
+    link_target: &Path,
+    allow_dangling_in_tree: bool,
+) -> Result<PathBuf> {
+    let target = if link_target.is_absolute() {
+        link_target.to_path_buf()
+    } else {
+        let parent = link_path
+            .parent()
+            .context("symlink path has no parent directory")?;
+        parent.join(link_target)
+    };
+    match fs::canonicalize(&target) {
+        Ok(target) => Ok(target),
+        Err(err) if allow_dangling_in_tree && err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(normalize_dangling_symlink_target(&target))
+        }
+        Err(err) => Err(err)
+            .with_context(|| format!("failed to canonicalize symlink target {}", target.display())),
+    }
+}
+
+fn normalize_dangling_symlink_target(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}


### PR DESCRIPTION
## Summary

- reject Copy/Materialize projections when a source symlink resolves outside the skill source directory
- keep internal symlinks supported for Copy and materialized for Materialize
- add regression coverage for escaping symlinks in both projection modes

Fixes #279.

## Validation

- `cargo fmt --check`
- `cargo test --locked projection`
- `cargo check --locked`
