### PR TITLE
fix: fail closed on malformed pending ops snapshots

### DIFF
--- a/src/commands/sync_cmds.rs
+++ b/src/commands/sync_cmds.rs
@@ -1,8 +1,12 @@
+use std::fs;
+
+use anyhow::Context;
 use serde_json::json;
 
 use crate::cli::{HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand, SyncCommand};
 use crate::envelope::Meta;
 use crate::gitops;
+use crate::state::{AppContext, synthesize_snapshot_raw_from_segment_bodies};
 use crate::types::ErrorCode;
 
 use super::helpers::{
@@ -138,8 +142,62 @@ impl App {
                     HistoryRepairStrategyArg::Remote => gitops::HistoryRepairStrategy::Remote,
                 };
                 let report = gitops::repair_history_branch(&self.ctx, strategy).map_err(map_git)?;
-                Ok((json!(report), Meta::default()))
+                let snapshot_rebuilt =
+                    rebuild_local_pending_ops_snapshot(&self.ctx).map_err(map_io)?;
+                Ok((
+                    json!({
+                        "result": report.result,
+                        "strategy": report.strategy,
+                        "commit": report.commit,
+                        "repaired_conflicts": report.repaired_conflicts,
+                        "compacted_segments": report.compacted_segments,
+                        "rolled_archives": report.rolled_archives,
+                        "local_segments": report.local_segments,
+                        "local_archives": report.local_archives,
+                        "local_snapshot": report.local_snapshot,
+                        "local_snapshot_rebuilt": snapshot_rebuilt,
+                        "conflicts": report.conflicts,
+                    }),
+                    Meta::default(),
+                ))
             }
         }
     }
+}
+
+fn rebuild_local_pending_ops_snapshot(ctx: &AppContext) -> anyhow::Result<bool> {
+    let bodies = gitops::history_journal_bodies(ctx)?
+        .into_iter()
+        .map(|(_, body)| body)
+        .collect::<Vec<_>>();
+    let snapshot_raw = synthesize_snapshot_raw_from_segment_bodies(&bodies)?;
+    let parent = ctx
+        .pending_ops_snapshot_file
+        .parent()
+        .context("pending ops snapshot path has no parent directory")?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create pending ops snapshot parent {}",
+            parent.display()
+        )
+    })?;
+    let tmp_path = parent.join(format!(
+        ".pending_ops_snapshot.json.repair-{}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::write(&tmp_path, format!("{snapshot_raw}\n")).with_context(|| {
+        format!(
+            "failed to write temporary pending ops snapshot {}",
+            tmp_path.display()
+        )
+    })?;
+    crate::fs_util::rename_atomic(&tmp_path, &ctx.pending_ops_snapshot_file).with_context(
+        || {
+            format!(
+                "failed to replace pending ops snapshot {}",
+                ctx.pending_ops_snapshot_file.display()
+            )
+        },
+    )?;
+    Ok(true)
 }

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -355,11 +355,10 @@ impl AppContext {
                 snapshot.version,
                 OPS_SNAPSHOT_VERSION
             ),
-            Err(err) => Ok(LoadedSnapshot {
-                active_ops: Vec::new(),
-                history_events: 0,
-                warnings: vec![format!("ignored malformed pending ops snapshot: {}", err)],
-            }),
+            Err(err) => anyhow::bail!(
+                "pending ops snapshot is malformed; run `loom ops history repair` to rebuild it: {}",
+                err
+            ),
         }
     }
 
@@ -667,14 +666,20 @@ mod tests {
     use crate::types::PendingOp;
     use serde_json::json;
 
-    #[test]
-    fn pending_snapshot_version_mismatch_fails_closed() {
+    fn test_context(prefix: &str) -> Result<(std::path::PathBuf, AppContext)> {
         let root = std::env::temp_dir().join(format!(
-            "loom-ops-snapshot-version-{}",
+            "loom-ops-{}-{}",
+            prefix,
             uuid::Uuid::new_v4().simple()
         ));
-        let ctx = AppContext::new(Some(root.clone())).expect("ctx");
-        ctx.ensure_state_layout().expect("layout");
+        let ctx = AppContext::new(Some(root.clone()))?;
+        ctx.ensure_state_layout()?;
+        Ok((root, ctx))
+    }
+
+    #[test]
+    fn pending_snapshot_version_mismatch_fails_closed() -> Result<()> {
+        let (root, ctx) = test_context("snapshot-version")?;
         let op = PendingOp::new("sync.push", json!({"commit": "abc"}), "req-1".to_string());
         let snapshot = OpsSnapshot {
             version: OPS_SNAPSHOT_VERSION + 1,
@@ -682,18 +687,93 @@ mod tests {
             history_events: 10,
             active_ops: vec![op],
         };
-        let raw = serde_json::to_string_pretty(&snapshot).expect("snapshot json");
-        fs::write(&ctx.pending_ops_snapshot_file, raw).expect("write snapshot");
+        let raw = serde_json::to_string_pretty(&snapshot)?;
+        fs::write(&ctx.pending_ops_snapshot_file, raw)?;
 
-        let err = ctx
-            .read_pending_report()
-            .expect_err("version mismatch must fail closed");
+        let Err(err) = ctx.read_pending_report() else {
+            anyhow::bail!("version mismatch must fail closed");
+        };
         assert!(
             err.to_string()
                 .contains("pending ops snapshot version mismatch"),
             "unexpected error: {err}"
         );
 
-        let _ = fs::remove_dir_all(root);
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_pending_snapshot_fails_closed_with_repair_guidance() -> Result<()> {
+        let (root, ctx) = test_context("snapshot-malformed")?;
+        fs::write(&ctx.pending_ops_snapshot_file, "{not-json")?;
+        let op = PendingOp::new("sync.push", json!({"commit": "abc"}), "req-1".to_string());
+        ctx.append_journal_events(&[OpJournalEvent::Queued {
+            event_id: "event-1".to_string(),
+            at: Utc::now(),
+            op,
+        }])?;
+
+        let Err(err) = ctx.read_pending_report() else {
+            anyhow::bail!("malformed snapshot must fail closed");
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("pending ops snapshot is malformed"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            message.contains("loom ops history repair"),
+            "missing repair guidance: {err}"
+        );
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_pending_snapshot_blocks_compaction_without_clearing_journal() -> Result<()> {
+        let (root, ctx) = test_context("snapshot-compact")?;
+        fs::write(&ctx.pending_ops_snapshot_file, "{not-json")?;
+        let events = (0..OPS_COMPACTION_THRESHOLD)
+            .map(|index| OpJournalEvent::Queued {
+                event_id: format!("event-{index}"),
+                at: Utc::now(),
+                op: PendingOp::new(
+                    "sync.push",
+                    json!({"commit": format!("abc-{index}")}),
+                    format!("req-{index}"),
+                ),
+            })
+            .collect::<Vec<_>>();
+        ctx.append_journal_events(&events)?;
+        let journal_before = fs::read_to_string(&ctx.pending_ops_file)?;
+
+        let Err(err) = ctx.maybe_compact_ops_journal() else {
+            anyhow::bail!("malformed snapshot must block compaction");
+        };
+        assert!(
+            err.to_string()
+                .contains("pending ops snapshot is malformed"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            fs::read_to_string(&ctx.pending_ops_file)?,
+            journal_before,
+            "failed compaction must not truncate pending_ops.jsonl"
+        );
+        assert_eq!(
+            fs::read_to_string(&ctx.pending_ops_snapshot_file)?,
+            "{not-json",
+            "failed compaction must not overwrite the corrupt snapshot"
+        );
+        assert_eq!(
+            fs::read_dir(&ctx.pending_ops_history_dir)?.count(),
+            0,
+            "failed compaction must not write history segments"
+        );
+
+        fs::remove_dir_all(root)?;
+        Ok(())
     }
 }

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -840,6 +840,44 @@ fn ops_compaction_mirrors_history_into_local_git_branch() {
 }
 
 #[test]
+fn ops_history_repair_rebuilds_corrupt_local_pending_snapshot() {
+    let root = TestDir::new("history-rebuild-local-snapshot");
+    let remote_root = TestDir::new("history-rebuild-local-snapshot-remote");
+    let remote = remote_root.path().join("origin.git");
+    let source = make_skill_source(root.path(), "source-history-rebuild-local-snapshot");
+
+    git_ok(["init", "--bare", remote.to_str().unwrap()]);
+    run_loom_ok(
+        root.path(),
+        &["workspace", "remote", "set", remote.to_str().unwrap()],
+    );
+    run_loom_ok(
+        root.path(),
+        &["skill", "add", source.to_str().unwrap(), "--name", "demo"],
+    );
+    for _ in 0..16 {
+        run_loom_ok(root.path(), &["skill", "snapshot", "demo"]);
+    }
+    assert!(git_branch_exists(root.path(), "loom-history"));
+
+    let snapshot_path = root.path().join("state/pending_ops_snapshot.json");
+    fs::write(&snapshot_path, "{not-json").expect("corrupt local pending snapshot");
+    let (failed, _) = run_loom_with_env(root.path(), &[], &["ops", "list"]);
+    assert!(
+        !failed.status.success(),
+        "corrupt local snapshot must fail closed before repair"
+    );
+
+    let repair = run_loom_ok(
+        root.path(),
+        &["ops", "history", "repair", "--strategy", "local"],
+    );
+    assert_eq!(repair["data"]["local_snapshot_rebuilt"], true);
+    let pending = run_loom_ok(root.path(), &["ops", "list"]);
+    assert!(pending["data"]["history_events"].as_u64().unwrap() >= 16);
+}
+
+#[test]
 fn sync_push_propagates_history_branch_to_remote() {
     let root = TestDir::new("history-push");
     let remote_root = TestDir::new("history-push-remote");


### PR DESCRIPTION
## Summary

- make malformed pending-ops snapshots fail closed instead of returning an empty model with a warning
- include `loom ops history repair` guidance in the error
- add regression coverage proving compaction does not truncate the journal or overwrite a corrupt snapshot

Fixes #276.

## Validation

- `cargo fmt --check`
- `cargo test --locked ops`
- `cargo check --locked`
