### PR TITLE
fix(panel): surface read warnings and gate history repair

### DIFF
--- a/panel/src/lib/api/client.test.ts
+++ b/panel/src/lib/api/client.test.ts
@@ -150,6 +150,75 @@ describe("api v1 routes", () => {
     ]);
   });
 
+  it("preserves envelope warnings for the skills read model", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        cmd: "registry.skills",
+        request_id: "req-1",
+        data: { skills: [] },
+        error: null,
+        meta: { warnings: ["skipped malformed skill metadata"] },
+      }),
+    } as unknown as Response);
+
+    await expect(api.skillsWithWarnings()).resolves.toEqual({
+      data: { skills: [] },
+      warnings: ["skipped malformed skill metadata"],
+    });
+  });
+
+  it("preserves envelope warnings for registry payload reads", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        cmd: "registry.status",
+        request_id: "req-1",
+        data: { counts: {}, projections: [], rules: [], targets: [], bindings: [] },
+        error: null,
+        meta: { warnings: ["ignored malformed operation audit row"] },
+      }),
+    } as unknown as Response);
+
+    const result = await api.registryStatusWithWarnings();
+
+    expect(result.warnings).toEqual(["ignored malformed operation audit row"]);
+    expect(result.data.data?.counts).toEqual({});
+  });
+
+  it("combines sync status envelope and payload warnings", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        cmd: "sync.status",
+        request_id: "req-1",
+        data: {
+          remote: { sync_state: "CLEAN" },
+          warnings: ["pending queue had parse warnings"],
+        },
+        error: null,
+        meta: { warnings: ["failed to read remote tracking ref"] },
+      }),
+    } as unknown as Response);
+
+    await expect(api.remoteStatusWithWarnings()).resolves.toEqual({
+      data: {
+        remote: { sync_state: "CLEAN" },
+        warnings: ["pending queue had parse warnings"],
+      },
+      warnings: ["failed to read remote tracking ref", "pending queue had parse warnings"],
+    });
+  });
+
   it("rejects non-envelope payloads for v1 bootstrap reads", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -141,6 +141,11 @@ export interface CommandEnvelope {
   meta?: { warnings?: string[] };
 }
 
+export interface ReadResult<T> {
+  data: T;
+  warnings: string[];
+}
+
 export class ApiError extends Error {
   constructor(public readonly path: string, public readonly status: number, message: string) {
     super(message);
@@ -152,7 +157,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function unwrapReadData<T>(path: string, body: unknown): T {
+function warningStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((warning): warning is string => typeof warning === "string" && warning.length > 0);
+}
+
+function envelopeWarnings(body: unknown): string[] {
+  if (!isRecord(body) || !isRecord(body.meta)) return [];
+  return warningStrings(body.meta.warnings);
+}
+
+function payloadWarnings(body: unknown): string[] {
+  if (!isRecord(body)) return [];
+  return warningStrings(body.warnings);
+}
+
+function uniqueWarnings(warnings: string[]): string[] {
+  return Array.from(new Set(warnings));
+}
+
+function unwrapReadResult<T>(path: string, body: unknown): ReadResult<T> {
   if (
     !isRecord(body) ||
     body.ok !== true ||
@@ -164,7 +188,14 @@ function unwrapReadData<T>(path: string, body: unknown): T {
   if (!("data" in body)) {
     throw new ApiError(path, 200, `GET ${path} envelope is missing data`);
   }
-  return body.data as T;
+  return {
+    data: body.data as T,
+    warnings: uniqueWarnings([...envelopeWarnings(body), ...payloadWarnings(body.data)]),
+  };
+}
+
+function unwrapReadData<T>(path: string, body: unknown): T {
+  return unwrapReadResult<T>(path, body).data;
 }
 
 function parseRemoteStatusResponse(path: string, body: unknown): RemoteStatusResponse {
@@ -229,6 +260,15 @@ async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
 
 async function getJsonData<T>(path: string, signal?: AbortSignal): Promise<T> {
   return unwrapReadData<T>(path, await getJson<unknown>(path, signal));
+}
+
+async function getJsonWithWarnings<T>(path: string, signal?: AbortSignal): Promise<ReadResult<T>> {
+  const body = await getJson<unknown>(path, signal);
+  return { data: body as T, warnings: uniqueWarnings([...envelopeWarnings(body), ...payloadWarnings(body)]) };
+}
+
+async function getJsonDataWithWarnings<T>(path: string, signal?: AbortSignal): Promise<ReadResult<T>> {
+  return unwrapReadResult<T>(path, await getJson<unknown>(path, signal));
 }
 
 async function postJson(path: string, body: unknown): Promise<CommandEnvelope> {
@@ -443,13 +483,28 @@ export interface DoctorPayload {
   checks?: Record<string, unknown>;
 }
 
+async function remoteStatusWithWarnings(signal?: AbortSignal): Promise<ReadResult<RemoteStatusResponse>> {
+  const path = "/api/v1/sync/status";
+  const result = unwrapReadResult<RemoteStatusResponse>(path, await getJson<unknown>(path, signal));
+  const data = parseRemoteStatusResponse(path, result.data);
+  return { data, warnings: uniqueWarnings([...result.warnings, ...payloadWarnings(data)]) };
+}
+
 export const api = {
   health: (signal?: AbortSignal) => getJsonData<HealthPayload>("/api/v1/health", signal),
   info: (signal?: AbortSignal) => getJsonData<InfoPayload>("/api/v1/workspace/info", signal),
+  infoWithWarnings: (signal?: AbortSignal) =>
+    getJsonDataWithWarnings<InfoPayload>("/api/v1/workspace/info", signal),
   workspaceStatus: (signal?: AbortSignal) =>
     getJsonData<WorkspaceStatusPayload>("/api/v1/workspace/status", signal),
+  workspaceStatusWithWarnings: (signal?: AbortSignal) =>
+    getJsonDataWithWarnings<WorkspaceStatusPayload>("/api/v1/workspace/status", signal),
   skills: (signal?: AbortSignal) => getJsonData<SkillsPayload>("/api/v1/skills", signal),
+  skillsWithWarnings: (signal?: AbortSignal) =>
+    getJsonDataWithWarnings<SkillsPayload>("/api/v1/skills", signal),
   registryStatus: (signal?: AbortSignal) => getJson<RegistryPayload>("/api/v1/registry/status", signal),
+  registryStatusWithWarnings: (signal?: AbortSignal) =>
+    getJsonWithWarnings<RegistryPayload>("/api/v1/registry/status", signal),
   workspaceDoctor: (signal?: AbortSignal) =>
     getJsonData<DoctorPayload>("/api/v1/workspace/doctor", signal),
   opsHistoryDiagnose: (signal?: AbortSignal) =>
@@ -461,19 +516,23 @@ export const api = {
     const qs = params.size > 0 ? `?${params.toString()}` : "";
     return getJson<OpsPayload>(`/api/v1/ops${qs}`, signal);
   },
+  opsWithWarnings: (options?: { limit?: number; offset?: number }, signal?: AbortSignal) => {
+    const params = new URLSearchParams();
+    if (typeof options?.limit === "number") params.set("limit", String(options.limit));
+    if (typeof options?.offset === "number") params.set("offset", String(options.offset));
+    const qs = params.size > 0 ? `?${params.toString()}` : "";
+    return getJsonWithWarnings<OpsPayload>(`/api/v1/ops${qs}`, signal);
+  },
   bindingShow: (id: string, signal?: AbortSignal) =>
     getJson<BindingShowPayload>(`/api/v1/bindings/${encodeURIComponent(id)}`, signal),
   targetShow: (id: string, signal?: AbortSignal) =>
     getJson<TargetShowPayload>(`/api/v1/targets/${encodeURIComponent(id)}`, signal),
   remoteStatus: async (signal?: AbortSignal) =>
-    parseRemoteStatusResponse(
-      "/api/v1/sync/status",
-      unwrapReadData<RemoteStatusResponse>(
-        "/api/v1/sync/status",
-        await getJson<unknown>("/api/v1/sync/status", signal),
-      ),
-    ),
+    (await remoteStatusWithWarnings(signal)).data,
+  remoteStatusWithWarnings,
   pending: (signal?: AbortSignal) => getJsonData<PendingPayload>("/api/v1/ops/pending", signal),
+  pendingWithWarnings: (signal?: AbortSignal) =>
+    getJsonDataWithWarnings<PendingPayload>("/api/v1/ops/pending", signal),
 
   opsRetry: () => postJson("/api/v1/ops/retry", {}),
   opsPurge: () => postJson("/api/v1/ops/purge", {}),

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -27,6 +27,7 @@ export interface PanelLiveData {
   lastUpdated: string | null;
   registryRoot: string | null;
   remote: RemotePayload | null;
+  warnings: string[];
   health: HealthPayload | null;
   counts: RegistryCounts;
   skills: Skill[];
@@ -56,6 +57,7 @@ const INITIAL_STATE: LiveState = {
   lastUpdated: null,
   registryRoot: null,
   remote: null,
+  warnings: [],
   health: null,
   counts: EMPTY_COUNTS,
   skills: [],
@@ -84,6 +86,15 @@ function modeForState(state: Omit<LiveState, "mode">): PanelDataMode {
   if (state.setupRequired) return "first-run";
   if (state.live) return "live";
   return hasLastKnownData(state as LiveState) ? "offline-stale" : "offline-empty";
+}
+
+function warningStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((warning): warning is string => typeof warning === "string" && warning.length > 0);
+}
+
+function uniqueWarnings(warnings: string[]): string[] {
+  return Array.from(new Set(warnings));
 }
 
 export function usePanelData(): PanelLiveData {
@@ -126,13 +137,14 @@ export function usePanelData(): PanelLiveData {
     try {
       const [health, info, workspaceStatus] = await Promise.all([
         api.health(controller.signal),
-        api.info(controller.signal),
-        api.workspaceStatus(controller.signal),
+        api.infoWithWarnings(controller.signal),
+        api.workspaceStatusWithWarnings(controller.signal),
       ]);
       if (controller.signal.aborted || generation !== generationRef.current) return;
       apiReachable = true;
+      const baseWarnings = uniqueWarnings([...info.warnings, ...workspaceStatus.warnings]);
 
-      if (workspaceStatus.registry?.available === false) {
+      if (workspaceStatus.data.registry?.available === false) {
         setState(
           markSuccess({
             live: true,
@@ -141,8 +153,9 @@ export function usePanelData(): PanelLiveData {
             loading: false,
             error: null,
             lastUpdated: new Date().toISOString(),
-            registryRoot: info.root ?? null,
+            registryRoot: info.data.root ?? null,
             remote: null,
+            warnings: baseWarnings,
             health,
             counts: EMPTY_COUNTS,
             skills: [],
@@ -157,22 +170,22 @@ export function usePanelData(): PanelLiveData {
       }
 
       const [skillsPayload, registry, remote, pending, activity] = await Promise.all([
-        api.skills(controller.signal),
-        api.registryStatus(controller.signal),
-        api.remoteStatus(controller.signal),
-        api.pending(controller.signal),
-        api.ops({ limit: 30 }, controller.signal),
+        api.skillsWithWarnings(controller.signal),
+        api.registryStatusWithWarnings(controller.signal),
+        api.remoteStatusWithWarnings(controller.signal),
+        api.pendingWithWarnings(controller.signal),
+        api.opsWithWarnings({ limit: 30 }, controller.signal),
       ]);
       if (controller.signal.aborted || generation !== generationRef.current) return;
 
-      const registryData = registry.data ?? {};
+      const registryData = registry.data.data ?? {};
       const projections = registryData.projections ?? [];
       const rules = registryData.rules ?? [];
       const registryTargets = registryData.targets ?? [];
       const registryBindings = registryData.bindings ?? [];
 
       const index = buildAdapterIndex(registryTargets, projections);
-      const skillItems = skillsPayload.skills ?? [];
+      const skillItems = skillsPayload.data.skills ?? [];
       const skills = skillItems.map((item) =>
         typeof item === "string" ? adaptSkill(item, index, rules) : adaptSkillSummary(item),
       );
@@ -185,9 +198,19 @@ export function usePanelData(): PanelLiveData {
       const targets = registryTargets.map((t) => adaptTarget(t, index, observedSkillCounts));
       const bindings = registryBindings.map((b) => adaptBinding(b, rules));
 
-      const pendingOps: Op[] = (pending.ops ?? []).map(adaptPendingOp);
-      const activityOps: Op[] = (activity.data?.operations ?? []).map(adaptRegistryOperation);
+      const pendingOps: Op[] = (pending.data.ops ?? []).map(adaptPendingOp);
+      const activityOps: Op[] = (activity.data.data?.operations ?? []).map(adaptRegistryOperation);
       const ops = [...pendingOps, ...activityOps].slice(0, 30);
+      const warnings = uniqueWarnings([
+        ...baseWarnings,
+        ...skillsPayload.warnings,
+        ...registry.warnings,
+        ...remote.warnings,
+        ...pending.warnings,
+        ...activity.warnings,
+        ...warningStrings(remote.data.warnings),
+        ...warningStrings(pending.data.warnings),
+      ]);
 
       setState(
         markSuccess({
@@ -197,8 +220,9 @@ export function usePanelData(): PanelLiveData {
           loading: false,
           error: null,
           lastUpdated: new Date().toISOString(),
-          registryRoot: info.root ?? null,
-          remote: remote.remote ?? null,
+          registryRoot: info.data.root ?? null,
+          remote: remote.data.remote ?? null,
+          warnings,
           health,
           counts: registryData.counts ?? EMPTY_COUNTS,
           skills,
@@ -206,7 +230,7 @@ export function usePanelData(): PanelLiveData {
           bindings,
           ops,
           projections,
-          queuedWriteCount: pending.count ?? 0,
+          queuedWriteCount: pending.data.count ?? 0,
         }),
       );
     } catch (err) {

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -21,9 +21,18 @@ function errorResponse(status: number, body: unknown): Response {
   } as unknown as Response;
 }
 
-function installFetchMock(failingPath: string | null = null, failingResponse?: Response) {
+interface FetchMockOptions {
+  skillsWarnings?: string[];
+  pendingCount?: number;
+  pendingWarnings?: string[];
+  opsWarnings?: string[];
+  diagnoseConflict?: boolean;
+}
+
+function installFetchMock(failingPath: string | null = null, failingResponse?: Response, options: FetchMockOptions = {}) {
   fetchMock.mockImplementation((input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const failedResponse = url === failingPath ? failingResponse : undefined;
     switch (url) {
       case "/api/v1/health":
         return Promise.resolve(
@@ -78,19 +87,19 @@ function installFetchMock(failingPath: string | null = null, failingResponse?: R
               ],
             },
             error: null,
-            meta: { warnings: [] },
+            meta: { warnings: options.skillsWarnings ?? [] },
           }),
         );
       case "/api/v1/registry/status":
         return Promise.resolve(
-          url === failingPath && failingResponse
-            ? failingResponse
+          failedResponse
+            ? failedResponse
             : jsonResponse({ ok: true, data: { counts: {}, projections: [], rules: [], targets: [], bindings: [] } }),
         );
       case "/api/v1/sync/status":
         return Promise.resolve(
-          url === failingPath && failingResponse
-            ? failingResponse
+          failedResponse
+            ? failedResponse
             : jsonResponse({
                 ok: true,
                 cmd: "sync.status",
@@ -102,16 +111,49 @@ function installFetchMock(failingPath: string | null = null, failingResponse?: R
         );
       case "/api/v1/ops/pending":
         return Promise.resolve(
-          url === failingPath && failingResponse
-            ? failingResponse
+          failedResponse
+            ? failedResponse
             : jsonResponse({
                 ok: true,
                 cmd: "pending.list",
                 request_id: "req-pending",
-                data: { count: 0, ops: [] },
+                data: { count: options.pendingCount ?? 0, ops: [], warnings: options.pendingWarnings ?? [] },
                 error: null,
                 meta: { warnings: [] },
               }),
+        );
+      case "/api/v1/ops/diagnose":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            data: {
+              local_branch: true,
+              remote_tracking: true,
+              ahead: 0,
+              behind: 0,
+              local_segments: 1,
+              local_archives: 0,
+              remote_segments: 1,
+              remote_archives: 0,
+              local_snapshot: true,
+              remote_snapshot: true,
+              compact_after_segments: 8,
+              retain_recent_segments: 4,
+              retain_archives: 4,
+              conflicts: options.diagnoseConflict
+                ? [
+                    {
+                      scope: "segment",
+                      path: "pending_ops_history/conflict.jsonl",
+                      local_blob: "local",
+                      remote_blob: "remote",
+                      local_rename_path: "pending_ops_history/conflict-local.jsonl",
+                      remote_rename_path: "pending_ops_history/conflict-remote.jsonl",
+                    },
+                  ]
+                : [],
+            },
+          }),
         );
       case "/api/v1/ops?limit=30":
         return Promise.resolve(
@@ -120,6 +162,17 @@ function installFetchMock(failingPath: string | null = null, failingResponse?: R
             cmd: "registry.ops",
             request_id: "req-ops",
             data: { count: 0, loaded_count: 0, offset: 0, limit: 30, has_more: false, operations: [] },
+            error: null,
+            meta: { warnings: options.opsWarnings ?? [] },
+          }),
+        );
+      case "/api/v1/ops?limit=100&offset=0":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "registry.ops",
+            request_id: "req-history",
+            data: { count: 0, loaded_count: 0, offset: 0, limit: 100, has_more: false, operations: [] },
             error: null,
             meta: { warnings: [] },
           }),
@@ -203,6 +256,47 @@ describe("PanelApp status failure UI", () => {
     });
 
     expect(screen.getByText(/failed to read pending queue/i)).toBeTruthy();
+  });
+
+  it("shows backend warnings returned by panel read paths", async () => {
+    installFetchMock(undefined, undefined, {
+      skillsWarnings: ["skipped malformed skill metadata"],
+      pendingWarnings: ["pending queue had parse warnings"],
+      opsWarnings: ["ignored malformed operation audit row"],
+    });
+
+    render(<PanelApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Backend warnings/i)).toBeTruthy();
+    });
+
+    expect(screen.getByText(/skipped malformed skill metadata/i)).toBeTruthy();
+    expect(screen.getByText(/pending queue had parse warnings/i)).toBeTruthy();
+    expect(screen.getByText(/ignored malformed operation audit row/i)).toBeTruthy();
+  });
+
+  it("disables history repair while queued writes exist", async () => {
+    localStorage.setItem("loom.page", "history");
+    installFetchMock(null, undefined, {
+      pendingCount: 2,
+      diagnoseConflict: true,
+    });
+
+    render(<PanelApp />);
+
+    const repairLocal = (await screen.findByRole("button", {
+      name: /Repair from local/i,
+    })) as HTMLButtonElement;
+    const repairRemote = (await screen.findByRole("button", {
+      name: /Repair from remote/i,
+    })) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(repairLocal.disabled).toBe(true);
+      expect(repairRemote.disabled).toBe(true);
+    });
+    expect(repairLocal.title).toBe("pending operations must be replayed or purged first");
+    expect(repairRemote.title).toBe("pending operations must be replayed or purged first");
   });
 
   it("shows first-run mode when workspace status reports missing registry state", async () => {

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -154,6 +154,9 @@ export function PanelApp() {
   // Future shortcuts, command palette, and hotkey handlers must check readOnly
   // before calling any /api/v1/* mutation route.
   const readOnly = live.mode !== "live";
+  const historyReadOnly = readOnly || live.queuedWriteCount > 0;
+  const historyReadOnlyReason =
+    live.queuedWriteCount > 0 ? "pending operations must be replayed or purged first" : undefined;
   const onMutation = () => {
     setMutationVersion((cur) => cur + 1);
     live.refetch();
@@ -257,6 +260,8 @@ export function PanelApp() {
             mode={live.mode}
             mutationVersion={mutationVersion}
             refreshKey={live.lastUpdated}
+            readOnly={historyReadOnly}
+            readOnlyReason={historyReadOnlyReason}
             onMutation={onMutation}
           />
         );
@@ -314,12 +319,41 @@ export function PanelApp() {
         registryRoot={live.registryRoot}
       />
       <div className="main">
+        <PanelWarningsBanner warnings={live.warnings} />
         {live.mode !== "live" && <LiveDataBanner error={live.error} loading={live.loading} mode={live.mode} />}
         {view}
       </div>
       {tweakVisible && (
         <TweakPanel state={tweaks} onChange={patchTweaks} onDismiss={() => setTweakVisible(false)} />
       )}
+    </div>
+  );
+}
+
+export function PanelWarningsBanner({ warnings }: { warnings: string[] }) {
+  if (warnings.length === 0) return null;
+
+  const visible = warnings.slice(0, 3);
+  const extra = warnings.length - visible.length;
+
+  return (
+    <div
+      role="status"
+      aria-label="Backend warnings"
+      style={{
+        padding: "8px 28px",
+        background: "rgba(230,180,80,0.08)",
+        borderBottom: "1px solid rgba(230,180,80,0.25)",
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color: "var(--warn)",
+      }}
+    >
+      <span style={{ marginRight: 6 }}>{warnings.length === 1 ? "Backend warning" : "Backend warnings"}:</span>
+      <span style={{ color: "var(--ink-2)" }}>
+        {visible.join(" · ")}
+        {extra > 0 ? ` · ${extra} more` : ""}
+      </span>
     </div>
   );
 }

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -25,10 +25,20 @@ interface HistoryPageProps {
   mode: PanelDataMode;
   mutationVersion: number;
   refreshKey?: string | null;
+  readOnly?: boolean;
+  readOnlyReason?: string;
   onMutation?: () => void;
 }
 
-export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutation }: HistoryPageProps) {
+export function HistoryPage({
+  live,
+  mode,
+  mutationVersion,
+  refreshKey,
+  readOnly = false,
+  readOnlyReason,
+  onMutation,
+}: HistoryPageProps) {
   const [state, setState] = useState<LoadState>({ kind: "idle" });
   const [diagnose, setDiagnose] = useState<DiagnoseData | null>(null);
   const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
@@ -83,6 +93,7 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
   }, [live, mutationVersion, refreshKey, offset, repairVersion]);
 
   const runRepair = (strategy: "local" | "remote") => {
+    if (readOnly || repair.busy) return;
     repair.run(`history repair ${strategy}`, () => api.opsHistoryRepair({ strategy }), () => {
       setRepairVersion((value) => value + 1);
       onMutation?.();
@@ -117,6 +128,12 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
   );
 
   const checkpoint = payload?.checkpoint;
+  const repairDisabled = readOnly || repair.busy;
+  const repairTitle = readOnly
+    ? readOnlyReason ?? "registry offline"
+    : repair.busy
+    ? "history repair already running"
+    : "repair conflicting history files";
   const historySummary =
     payload && payload.count > payload.loaded_count
       ? `Showing ${payload.loaded_count} of ${payload.count} audit changes.`
@@ -192,10 +209,20 @@ export function HistoryPage({ live, mode, mutationVersion, refreshKey, onMutatio
                   {diagnose.conflicts.length} conflict{diagnose.conflicts.length === 1 ? "" : "s"}
                 </span>
                 <span style={{ color: "var(--ink-2)" }}>{diagnose.conflicts[0]?.path}</span>
-                <button className="btn sm" onClick={() => runRepair("local")} disabled={repair.busy}>
+                <button
+                  className="btn sm"
+                  onClick={() => runRepair("local")}
+                  disabled={repairDisabled}
+                  title={repairTitle}
+                >
                   Repair from local
                 </button>
-                <button className="btn sm" onClick={() => runRepair("remote")} disabled={repair.busy}>
+                <button
+                  className="btn sm"
+                  onClick={() => runRepair("remote")}
+                  disabled={repairDisabled}
+                  title={repairTitle}
+                >
                   Repair from remote
                 </button>
               </>

--- a/panel/src/pages/panel/PanelOperationLoop.test.tsx
+++ b/panel/src/pages/panel/PanelOperationLoop.test.tsx
@@ -212,6 +212,54 @@ test("HistoryPage repairs diagnosed history conflicts from the panel", async () 
   }
 });
 
+test("HistoryPage disables history repair actions in read-only mode", async () => {
+  const originalOps = api.ops;
+  const originalDiagnose = api.opsHistoryDiagnose;
+  const originalRepair = api.opsHistoryRepair;
+  const repairs: Array<{ strategy: "local" | "remote" }> = [];
+  let mutations = 0;
+  api.ops = async () => opsPayload(makeOperation("failed", false, "op-failed", "sync.pull"));
+  api.opsHistoryDiagnose = async () => historyDiagnosePayload(1);
+  api.opsHistoryRepair = async (body) => {
+    repairs.push(body);
+    return { ok: true, cmd: "ops.history.repair", request_id: "req-repair", data: { repaired_conflicts: 1 } };
+  };
+
+  try {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <HistoryPage
+          live={true}
+          mode="live"
+          mutationVersion={0}
+          readOnly={true}
+          onMutation={() => {
+            mutations += 1;
+          }}
+        />,
+      );
+    });
+    await flush();
+
+    const repairFromLocal = buttonByLabel(renderer!, "Repair from local");
+    expect(repairFromLocal.props.disabled).toBe(true);
+    expect(repairFromLocal.props.title).toBe("registry offline");
+
+    await act(async () => {
+      repairFromLocal.props.onClick();
+    });
+    await flush();
+
+    expect(repairs).toEqual([]);
+    expect(mutations).toBe(0);
+  } finally {
+    api.ops = originalOps;
+    api.opsHistoryDiagnose = originalDiagnose;
+    api.opsHistoryRepair = originalRepair;
+  }
+});
+
 test("SyncPage surfaces history repair actions", async () => {
   const originalDiagnose = api.opsHistoryDiagnose;
   const originalRepair = api.opsHistoryRepair;


### PR DESCRIPTION
## Summary

- preserve backend warnings from Panel read envelopes and render them in the Panel UI
- keep `ops history repair` disabled while pending operations are present
- add focused client and Panel tests for warning propagation and read-only repair gating

Fixes #277.
Fixes #284.

## Validation

- `cd panel && bun run typecheck`
- `cd panel && bun run test -- --run`
- `cd panel && bun run build`
