### PR TITLE
Fix backup export workspace locking

### DIFF
--- a/src/commands/backup_cmds.rs
+++ b/src/commands/backup_cmds.rs
@@ -20,7 +20,7 @@ use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
 use super::file_ops::copy_dir_recursive_preserving_symlinks;
-use super::helpers::{map_git, map_io, map_registry_state};
+use super::helpers::{map_git, map_io, map_lock, map_registry_state};
 use super::{App, CommandFailure};
 
 const BACKUP_SCHEMA_VERSION: u32 = 1;
@@ -113,6 +113,7 @@ impl App {
             ));
         }
 
+        let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
         let snapshot = self.require_backup_source_ready()?;
         let created_at = Utc::now();
         let stamp = created_at.format("%Y%m%dT%H%M%SZ").to_string();
@@ -257,16 +258,20 @@ fn export_tar(
     create_full_bundle(&ctx.root, &bundle_path).map_err(map_git)?;
     verify_bundle_file(&bundle_path).map_err(map_git)?;
 
-    if let Some(parent) = output
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        fs::create_dir_all(parent).map_err(map_io)?;
+    let output_parent = parent_or_cwd(output);
+    fs::create_dir_all(output_parent).map_err(map_io)?;
+    if output.try_exists().map_err(map_io)? {
+        return Err(map_io(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("backup artifact already exists: {}", output.display()),
+        )));
     }
+    let output_temp = TempPath::new_in(output_parent, ".loom-backup-output").map_err(map_io)?;
+    let temp_output = output_temp.path().join("artifact.tar");
     let file = OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(output)
+        .open(&temp_output)
         .map_err(map_io)?;
     let mut builder = Builder::new(file);
     let mtime = manifest.created_at.timestamp().max(0) as u64;
@@ -319,6 +324,14 @@ fn export_tar(
         }
     }
     builder.finish().map_err(map_io)?;
+    if output.try_exists().map_err(map_io)? {
+        return Err(map_io(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("backup artifact already exists: {}", output.display()),
+        )));
+    }
+    fs::hard_link(&temp_output, output).map_err(map_io)?;
+    fs::remove_file(&temp_output).map_err(map_io)?;
     Ok(())
 }
 

--- a/tests/backup.rs
+++ b/tests/backup.rs
@@ -132,6 +132,43 @@ fn backup_export_inspect_restore_round_trips_registry_snapshot() {
 }
 
 #[test]
+fn backup_export_refuses_when_workspace_lock_is_held() {
+    let root = TestDir::new("backup-workspace-lock");
+    let (init_output, _) = run_loom(root.path(), &["workspace", "init"]);
+    assert!(
+        init_output.status.success(),
+        "workspace init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init_output.stdout),
+        String::from_utf8_lossy(&init_output.stderr)
+    );
+    write_fresh_workspace_lock(root.path());
+
+    let artifact = root.path().join("blocked-backup.tar");
+    let artifact_arg = artifact.to_string_lossy().into_owned();
+    let (export_output, export_env) = run_loom(
+        root.path(),
+        &["backup", "export", "--output", &artifact_arg],
+    );
+
+    assert!(!export_output.status.success());
+    assert_eq!(
+        export_env["error"]["code"],
+        Value::String("LOCK_BUSY".to_string())
+    );
+    assert!(
+        export_env["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("LOCK_BUSY:workspace")),
+        "unexpected lock error: {}",
+        export_env
+    );
+    assert!(
+        !artifact.exists(),
+        "backup export must not create an artifact while workspace is locked"
+    );
+}
+
+#[test]
 fn backup_restore_refuses_non_empty_destination() {
     let root = TestDir::new("backup-nonempty-source");
     let (init_output, _) = run_loom(root.path(), &["workspace", "init"]);
@@ -169,6 +206,19 @@ fn backup_inspect_rejects_malformed_artifact() {
     let (inspect_output, inspect_env) = run_loom(root.path(), &["backup", "inspect", &bad_arg]);
     assert!(!inspect_output.status.success());
     assert_eq!(inspect_env["ok"], Value::Bool(false));
+}
+
+fn write_fresh_workspace_lock(root: &Path) {
+    let lock_path = root.join("state/locks/workspace.lock");
+    fs::create_dir_all(lock_path.parent().expect("lock path parent")).expect("create locks dir");
+    fs::write(
+        lock_path,
+        format!(
+            "{{\"pid\":{},\"host\":\"\",\"created_at\":\"2999-01-01T00:00:00Z\"}}\n",
+            std::process::id()
+        ),
+    )
+    .expect("write workspace lock");
 }
 
 fn git_text(root: &Path, args: &[&str]) -> String {


### PR DESCRIPTION
## Summary
- Acquire the workspace lock before backup export reads registry and Git state.
- Write backup tar output through a temporary artifact in the output parent and atomically rename it into place.
- Add regression coverage that export fails with `LOCK_BUSY` while the workspace lock is held.

## Validation
- `cargo fmt --check`
- `cargo test --locked backup`
- `cargo check --locked`

Fixes #278