### PR TITLE
Fix binding remove dependency contract

### DIFF
--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -279,14 +279,15 @@ Read-only.
 ### 9.5 `workspace binding remove`
 
 ```bash
-loom --json --root <root> workspace binding remove <binding-id>
+loom --json --root <root> workspace binding remove <binding-id> [--orphan-projections]
 ```
 
 Write command.
 
 Rules:
 
-1. must fail if live projections still depend on the binding unless `--force` is explicitly supported
+1. without `--orphan-projections`, must fail with `DEPENDENCY_CONFLICT` if non-orphan projections still depend on the binding
+2. with `--orphan-projections`, removes the binding and rules, marks dependent projections `orphaned`, and leaves live projection paths in place
 
 ## 10. Target Commands
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,7 +164,7 @@ pub enum WorkspaceBindingCommand {
     #[command(about = "Show one binding with rules and projections")]
     Show(BindingShowArgs),
     #[command(about = "Remove a workspace binding")]
-    Remove(BindingShowArgs),
+    Remove(BindingRemoveArgs),
 }
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
@@ -523,6 +523,15 @@ pub struct PanelArgs {
 #[derive(Debug, Clone, Args, Serialize)]
 pub struct BindingShowArgs {
     pub binding_id: String,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct BindingRemoveArgs {
+    pub binding_id: String,
+
+    /// Remove the binding and mark dependent projections orphaned.
+    #[arg(long)]
+    pub orphan_projections: bool,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]

--- a/src/commands/workspace_cmds/binding.rs
+++ b/src/commands/workspace_cmds/binding.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use chrono::Utc;
 use serde_json::json;
 
-use crate::cli::{BindingAddArgs, WorkspaceBindingCommand};
+use crate::cli::{BindingAddArgs, BindingRemoveArgs, WorkspaceBindingCommand};
 use crate::envelope::Meta;
 use crate::state_model::{RegistryWorkspaceBinding, RegistryWorkspaceMatcher};
 use crate::types::ErrorCode;
@@ -179,7 +179,7 @@ impl App {
 
     pub(super) fn cmd_workspace_binding_remove(
         &self,
-        args: &crate::cli::BindingShowArgs,
+        args: &BindingRemoveArgs,
         request_id: &str,
     ) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
         let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
@@ -198,6 +198,28 @@ impl App {
 
         let removed_rules = snapshot.binding_rules(&args.binding_id);
         let removed_projections = snapshot.binding_projections(&args.binding_id);
+        let active_projections: Vec<_> = removed_projections
+            .iter()
+            .filter(|projection| projection.health != "orphaned")
+            .collect();
+        if !args.orphan_projections && !active_projections.is_empty() {
+            let mut failure = CommandFailure::new(
+                ErrorCode::DependencyConflict,
+                format!(
+                    "binding '{}' is still referenced; remove dependent projections first or rerun with --orphan-projections",
+                    args.binding_id
+                ),
+            );
+            failure.details = json!({
+                "binding_id": args.binding_id,
+                "projection_ids": active_projections
+                    .iter()
+                    .map(|projection| projection.instance_id.clone())
+                    .collect::<Vec<_>>(),
+                "orphan_flag": "--orphan-projections",
+            });
+            return Err(failure);
+        }
         let orphaned_paths = removed_projections
             .iter()
             .map(|projection| projection.materialized_path.clone())
@@ -240,6 +262,7 @@ impl App {
                 "binding_id": binding.binding_id,
                 "removed_rules": removed_rules.iter().map(|rule| rule.skill_id.clone()).collect::<Vec<_>>(),
                 "orphaned_projection_ids": orphaned_projection_ids,
+                "orphan_projections": args.orphan_projections,
             }),
         ) {
             Ok(op_id) => op_id,
@@ -278,7 +301,7 @@ impl App {
         }
         if !orphaned_projection_ids.is_empty() {
             meta.warnings.push(format!(
-                "binding removed; {} projection(s) marked orphaned — run `loom skill orphan clean` to remove metadata",
+                "binding removed; {} projection(s) marked orphaned - run `loom skill orphan clean` to remove metadata",
                 orphaned_projection_ids.len()
             ));
         }
@@ -291,6 +314,7 @@ impl App {
                 "orphaned_projection_ids": orphaned_projection_ids,
                 "orphaned_paths": orphaned_paths,
                 "orphaned_count": orphaned_projection_ids.len(),
+                "orphan_projections": args.orphan_projections,
                 "commit": commit,
                 "noop": false
             }),

--- a/src/commands/workspace_cmds/orphan.rs
+++ b/src/commands/workspace_cmds/orphan.rs
@@ -369,6 +369,13 @@ mod orphan_tests {
         }
     }
 
+    fn binding_remove_orphan_args(binding_id: &str) -> crate::cli::BindingRemoveArgs {
+        crate::cli::BindingRemoveArgs {
+            binding_id: binding_id.to_string(),
+            orphan_projections: true,
+        }
+    }
+
     fn setup_with_binding_and_projection(
         root: &Path,
         mat_path: &str,
@@ -407,13 +414,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req-test",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req-test")
+            .unwrap();
 
         let paths = RegistryStatePaths::from_root(&root);
         let snapshot = paths.load_snapshot().unwrap();
@@ -438,12 +440,7 @@ mod orphan_tests {
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
         let (data, _meta) = app
-            .cmd_workspace_binding_remove(
-                &crate::cli::BindingShowArgs {
-                    binding_id: "bind1".into(),
-                },
-                "req-test",
-            )
+            .cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req-test")
             .unwrap();
 
         let ids = data["orphaned_projection_ids"]
@@ -467,13 +464,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req-test",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req-test")
+            .unwrap();
 
         let paths = RegistryStatePaths::from_root(&root);
         let snapshot = paths.load_snapshot().unwrap();
@@ -492,13 +484,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req-test",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req-test")
+            .unwrap();
 
         let paths = RegistryStatePaths::from_root(&root);
         let snapshot = paths.load_snapshot().unwrap();
@@ -521,13 +508,8 @@ mod orphan_tests {
         // First orphan the projection via binding removal
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req1",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req1")
+            .unwrap();
 
         // Now clean orphans
         let ctx2 = AppContext::new(Some(root.clone())).unwrap();
@@ -563,13 +545,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req1",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req1")
+            .unwrap();
 
         let ctx2 = AppContext::new(Some(root.clone())).unwrap();
         let app2 = crate::commands::App { ctx: ctx2 };
@@ -596,13 +573,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req1",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req1")
+            .unwrap();
 
         let ctx2 = AppContext::new(Some(root.clone())).unwrap();
         let app2 = crate::commands::App { ctx: ctx2 };
@@ -629,13 +601,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req1",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req1")
+            .unwrap();
 
         let ctx2 = AppContext::new(Some(root.clone())).unwrap();
         let app2 = crate::commands::App { ctx: ctx2 };
@@ -692,13 +659,8 @@ mod orphan_tests {
 
         let ctx = AppContext::new(Some(root.clone())).unwrap();
         let app = crate::commands::App { ctx };
-        app.cmd_workspace_binding_remove(
-            &crate::cli::BindingShowArgs {
-                binding_id: "bind1".into(),
-            },
-            "req-test",
-        )
-        .unwrap();
+        app.cmd_workspace_binding_remove(&binding_remove_orphan_args("bind1"), "req-test")
+            .unwrap();
 
         let snap = RegistryStatePaths::from_root(&root)
             .load_snapshot()

--- a/src/panel/handlers/mutations.rs
+++ b/src/panel/handlers/mutations.rs
@@ -130,8 +130,9 @@ pub(in crate::panel) async fn registry_binding_remove(
         StatusCode::OK,
         Command::Workspace {
             command: WorkspaceCommand::Binding {
-                command: WorkspaceBindingCommand::Remove(crate::cli::BindingShowArgs {
+                command: WorkspaceBindingCommand::Remove(crate::cli::BindingRemoveArgs {
                     binding_id,
+                    orphan_projections: false,
                 }),
             },
         },

--- a/src/panel/tests/security.rs
+++ b/src/panel/tests/security.rs
@@ -477,8 +477,9 @@ fn run_panel_command_returns_non_2xx_for_logical_failures_across_mutations() {
             StatusCode::OK,
             Command::Workspace {
                 command: WorkspaceCommand::Binding {
-                    command: WorkspaceBindingCommand::Remove(crate::cli::BindingShowArgs {
+                    command: WorkspaceBindingCommand::Remove(crate::cli::BindingRemoveArgs {
                         binding_id: "missing-binding".to_string(),
+                        orphan_projections: false,
                     }),
                 },
             },

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -41,7 +41,48 @@ fn bootstrap_projected_skill(root: &Path) -> (String, String, String) {
 }
 
 #[test]
-fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
+fn binding_remove_rejects_live_projection_by_default() {
+    let root = TestDir::new("registry-binding-remove-default-blocked");
+    let (_target_id, binding_id, instance_id) = bootstrap_projected_skill(root.path());
+
+    let live_projection = root.path().join("live/claude-a/demo/SKILL.md");
+    assert!(
+        live_projection.exists(),
+        "projection should exist before remove"
+    );
+
+    let (output, env) = run_loom(
+        root.path(),
+        &["workspace", "binding", "remove", &binding_id],
+    );
+    assert!(
+        !output.status.success(),
+        "binding remove unexpectedly succeeded"
+    );
+    assert_eq!(env["ok"], Value::Bool(false));
+    assert_eq!(
+        env["error"]["code"],
+        Value::String("DEPENDENCY_CONFLICT".to_string())
+    );
+    assert_eq!(
+        env["error"]["details"]["projection_ids"][0],
+        Value::String(instance_id)
+    );
+    assert_eq!(
+        env["error"]["details"]["orphan_flag"],
+        Value::String("--orphan-projections".to_string())
+    );
+    assert!(
+        live_projection.exists(),
+        "failed remove must leave live projection in place"
+    );
+
+    let (_, binding_list_env) = run_loom(root.path(), &["workspace", "binding", "list"]);
+    assert_eq!(binding_list_env["data"]["count"], Value::from(1));
+}
+
+#[test]
+fn binding_remove_orphan_projections_flag_cascades_metadata_and_leaves_live_projection_in_place() {
     let root = TestDir::new("registry-binding-remove");
     let (target_id, binding_id, instance_id) = bootstrap_projected_skill(root.path());
 
@@ -58,7 +99,13 @@ fn binding_remove_cascades_metadata_and_leaves_live_projection_in_place() {
 
     let (output, env) = run_loom(
         root.path(),
-        &["workspace", "binding", "remove", &binding_id],
+        &[
+            "workspace",
+            "binding",
+            "remove",
+            &binding_id,
+            "--orphan-projections",
+        ],
     );
     assert!(
         output.status.success(),
@@ -154,7 +201,13 @@ fn orphan_clean_after_live_delete_audit_failure_does_not_restore_removed_project
 
     let (binding_remove_output, _) = run_loom(
         root.path(),
-        &["workspace", "binding", "remove", &binding_id],
+        &[
+            "workspace",
+            "binding",
+            "remove",
+            &binding_id,
+            "--orphan-projections",
+        ],
     );
     assert!(
         binding_remove_output.status.success(),
@@ -238,7 +291,13 @@ fn target_remove_succeeds_after_binding_metadata_is_cleared() {
 
     let (binding_remove_output, _) = run_loom(
         root.path(),
-        &["workspace", "binding", "remove", &binding_id],
+        &[
+            "workspace",
+            "binding",
+            "remove",
+            &binding_id,
+            "--orphan-projections",
+        ],
     );
     assert!(
         binding_remove_output.status.success(),


### PR DESCRIPTION
## Summary
- make `workspace binding remove` fail with `DEPENDENCY_CONFLICT` when non-orphan projections still depend on the binding
- add explicit `--orphan-projections` behavior to preserve the previous orphaning path
- update remove tests and CLI contract docs

Fixes #286

## Validation
- `cargo fmt --check && cargo test --locked remove && cargo check --locked`