### PR TITLE
Fix state write concurrency for audit logs and locks

### DIFF
--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -1,5 +1,11 @@
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+#[cfg(not(unix))]
 use std::io::Write;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -143,11 +149,59 @@ fn append_command_event(ctx: &AppContext, event: &CommandEvent, fault_tags: &[&s
         .open(&path)
         .with_context(|| format!("failed to open command event log {}", path.display()))?;
     let raw = serde_json::to_string(event).context("failed to encode command event")?;
-    writeln!(file, "{raw}")
-        .with_context(|| format!("failed to append command event {}", path.display()))?;
+    append_jsonl_line(&mut file, &path, &raw)?;
     file.sync_all()
         .with_context(|| format!("failed to sync command event {}", path.display()))?;
     Ok(())
+}
+
+fn append_jsonl_line(file: &mut File, path: &Path, raw: &str) -> Result<()> {
+    let mut line = Vec::with_capacity(raw.len() + 1);
+    line.extend_from_slice(raw.as_bytes());
+    line.push(b'\n');
+    append_single_record_write(file, &line)
+        .with_context(|| format!("failed to append command event {}", path.display()))
+}
+
+#[cfg(unix)]
+fn append_single_record_write(file: &mut File, line: &[u8]) -> io::Result<()> {
+    if line.len() > isize::MAX as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "command event line exceeds write size limit",
+        ));
+    }
+
+    loop {
+        // SAFETY: `line` points to a valid immutable byte buffer for `line.len()`
+        // bytes, and `file.as_raw_fd()` is an open descriptor owned by `file`.
+        let written = unsafe { libc::write(file.as_raw_fd(), line.as_ptr().cast(), line.len()) };
+        if written < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+
+        let written = written as usize;
+        if written == line.len() {
+            return Ok(());
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!(
+                "short command event append: wrote {} of {} bytes",
+                written,
+                line.len()
+            ),
+        ));
+    }
+}
+
+#[cfg(not(unix))]
+fn append_single_record_write(file: &mut File, line: &[u8]) -> io::Result<()> {
+    file.write_all(line)
 }
 
 pub(crate) fn prepare_command_event_store(ctx: &AppContext) -> Result<()> {
@@ -404,9 +458,18 @@ fn looks_like_secret(raw: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::sync::Arc;
+
+    use chrono::Utc;
     use serde_json::json;
 
-    use super::{redact_sensitive_string, redact_sensitive_strings, redact_url_userinfo};
+    use super::{
+        COMMAND_EVENT_SCHEMA_VERSION, CommandEvent, append_command_event, redact_sensitive_string,
+        redact_sensitive_strings, redact_url_userinfo,
+    };
+    use crate::state::AppContext;
 
     #[test]
     fn redacts_url_userinfo_without_changing_plain_urls() {
@@ -470,5 +533,66 @@ mod tests {
         assert_eq!(value["api_key"], json!("<redacted>"));
         assert_eq!(value["nested"]["password"], json!("<redacted>"));
         assert_eq!(value["nested"]["plain"], json!("visible"));
+    }
+
+    #[test]
+    fn concurrent_command_event_appends_preserve_jsonl_rows() {
+        let dir = std::env::temp_dir().join(format!(
+            "loom-command-events-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).expect("create temp root");
+        let ctx = Arc::new(AppContext::new(Some(dir.clone())).expect("create context"));
+        let workers = 8usize;
+        let per_worker = 8usize;
+        let payload = "x".repeat(16 * 1024);
+
+        let handles = (0..workers)
+            .map(|worker| {
+                let ctx = Arc::clone(&ctx);
+                let payload = payload.clone();
+                std::thread::spawn(move || {
+                    for index in 0..per_worker {
+                        let event = CommandEvent {
+                            schema_version: COMMAND_EVENT_SCHEMA_VERSION,
+                            event_id: format!("evt_{worker}_{index}"),
+                            request_id: format!("req_{worker}_{index}"),
+                            cmd: "test.concurrent".to_string(),
+                            status: "started".to_string(),
+                            exit_code: None,
+                            input: Some(json!({
+                                "worker": worker,
+                                "index": index,
+                                "payload": payload,
+                            })),
+                            output: None,
+                            error: None,
+                            side_effects: None,
+                            created_at: Utc::now(),
+                        };
+                        append_command_event(&ctx, &event, &[]).expect("append command event");
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().expect("worker must not panic");
+        }
+
+        let raw = fs::read_to_string(dir.join("state/events/commands.jsonl"))
+            .expect("read command events");
+        let lines = raw.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), workers * per_worker);
+
+        let mut ids = BTreeSet::new();
+        for line in lines {
+            let event: serde_json::Value =
+                serde_json::from_str(line).expect("each line must be a JSON event");
+            let event_id = event["event_id"].as_str().expect("event_id must be string");
+            assert!(ids.insert(event_id.to_string()), "duplicate {event_id}");
+        }
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src/state/lock.rs
+++ b/src/state/lock.rs
@@ -1,16 +1,24 @@
-use std::fs;
-use std::path::Path;
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 
 const LOCK_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct LockMetadata {
     pub(super) pid: u32,
+    /// Unique owner token written by the acquiring guard. Release and stale
+    /// reap paths use this to avoid deleting a replacement lock by path.
+    #[serde(default)]
+    pub(super) owner_id: String,
     /// Hostname the lock was written from. Used to gate PID probes: across
     /// hosts (or across PID namespaces sharing the same workspace via a
     /// bind mount) `kill(pid, 0)` is meaningless and would wrongly report
@@ -27,28 +35,187 @@ impl LockMetadata {
     pub(super) fn new() -> Self {
         Self {
             pid: std::process::id(),
+            owner_id: format!("lock_{}", Uuid::new_v4().simple()),
             host: current_hostname(),
             created_at: Utc::now(),
         }
     }
 }
 
-pub(super) fn try_reap_stale_lock(lock_path: &Path) -> Result<bool> {
-    if is_lock_stale(lock_path)? {
-        fs::remove_file(lock_path)
-            .with_context(|| format!("failed to remove stale lock file {}", lock_path.display()))?;
-        return Ok(true);
-    }
-    Ok(false)
+pub(super) struct LockCoordinatorGuard {
+    file: File,
 }
 
+pub(super) fn acquire_lock_coordinator(locks_dir: &Path) -> Result<LockCoordinatorGuard> {
+    fs::create_dir_all(locks_dir).with_context(|| {
+        format!(
+            "failed to create state lock directory {}",
+            locks_dir.display()
+        )
+    })?;
+    let path = locks_dir.join(".coordinator.lock");
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("failed to open lock coordinator {}", path.display()))?;
+    lock_coordinator_file(&file)
+        .with_context(|| format!("failed to acquire lock coordinator {}", path.display()))?;
+    Ok(LockCoordinatorGuard { file })
+}
+
+#[cfg(unix)]
+fn lock_coordinator_file(file: &File) -> Result<()> {
+    loop {
+        // SAFETY: flock operates on a valid open file descriptor and does not
+        // access Rust-managed memory.
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        if err.kind() == std::io::ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(err).context("flock failed");
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_coordinator_file(_file: &File) -> Result<()> {
+    Ok(())
+}
+
+impl Drop for LockCoordinatorGuard {
+    fn drop(&mut self) {
+        unlock_coordinator_file(&self.file);
+    }
+}
+
+#[cfg(unix)]
+fn unlock_coordinator_file(file: &File) {
+    // SAFETY: flock operates on a valid open file descriptor and does not
+    // access Rust-managed memory.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if rc != 0 {
+        eprintln!(
+            "loom: failed to release lock coordinator: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn unlock_coordinator_file(_file: &File) {}
+
+pub(super) fn try_reap_stale_lock(lock_path: &Path) -> Result<bool> {
+    let Some(snapshot) = read_lock_snapshot(lock_path)? else {
+        return Ok(true);
+    };
+    if !snapshot.stale {
+        return Ok(false);
+    }
+
+    let quarantine_path = quarantine_lock_path(lock_path);
+    match fs::rename(lock_path, &quarantine_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("failed to quarantine stale lock {}", lock_path.display())
+            });
+        }
+    }
+
+    finish_quarantined_reap(lock_path, &quarantine_path, &snapshot.raw)
+}
+
+pub(super) fn lock_file_matches_owner(lock_path: &Path, owner_id: &str) -> Result<bool> {
+    if owner_id.is_empty() {
+        return Ok(false);
+    }
+    let raw = match fs::read_to_string(lock_path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err).context("failed to read lock file for owner check"),
+    };
+    let Ok(metadata) = serde_json::from_str::<LockMetadata>(raw.trim()) else {
+        return Ok(false);
+    };
+    Ok(metadata.owner_id == owner_id)
+}
+
+struct LockSnapshot {
+    raw: String,
+    stale: bool,
+}
+
+fn read_lock_snapshot(lock_path: &Path) -> Result<Option<LockSnapshot>> {
+    let raw = match fs::read_to_string(lock_path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).context("failed to read lock file"),
+    };
+    let stale = is_lock_raw_stale(lock_path, &raw)?;
+    Ok(Some(LockSnapshot { raw, stale }))
+}
+
+fn finish_quarantined_reap(
+    lock_path: &Path,
+    quarantine_path: &Path,
+    expected_raw: &str,
+) -> Result<bool> {
+    let raw = match fs::read_to_string(quarantine_path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err).context("failed to read quarantined lock file"),
+    };
+
+    if raw != expected_raw || !is_lock_raw_stale(quarantine_path, &raw)? {
+        restore_quarantined_lock(lock_path, quarantine_path)?;
+        return Ok(false);
+    }
+
+    fs::remove_file(quarantine_path)
+        .with_context(|| format!("failed to remove stale lock file {}", lock_path.display()))?;
+    Ok(true)
+}
+
+fn restore_quarantined_lock(lock_path: &Path, quarantine_path: &Path) -> Result<()> {
+    fs::rename(quarantine_path, lock_path).with_context(|| {
+        format!(
+            "failed to restore quarantined lock {} to {}",
+            quarantine_path.display(),
+            lock_path.display()
+        )
+    })
+}
+
+fn quarantine_lock_path(lock_path: &Path) -> PathBuf {
+    let file_name = lock_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("lock");
+    lock_path.with_file_name(format!(
+        ".{}.reap-{}.quarantine",
+        file_name,
+        Uuid::new_v4().simple()
+    ))
+}
+
+#[cfg(test)]
 fn is_lock_stale(lock_path: &Path) -> Result<bool> {
     let raw = match fs::read_to_string(lock_path) {
         Ok(raw) => raw,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
         Err(err) => return Err(err).context("failed to read lock file"),
     };
+    is_lock_raw_stale(lock_path, &raw)
+}
 
+fn is_lock_raw_stale(lock_path: &Path, raw: &str) -> Result<bool> {
     if let Ok(metadata) = serde_json::from_str::<LockMetadata>(raw.trim()) {
         // PID probes are only meaningful when the lock was written from
         // the current host. Across hosts or PID namespaces (e.g. two
@@ -213,6 +380,7 @@ mod tests {
             // on the *foreign* host it may well be alive. The point is
             // that we MUST NOT probe: cross-host probes are meaningless.
             pid: 999_999_999,
+            owner_id: "foreign-owner".to_string(),
             host: String::from("foreign-host-that-is-not-us"),
             created_at: Utc::now(),
         };
@@ -222,6 +390,75 @@ mod tests {
         assert!(
             !stale,
             "fresh cross-host lock must not be reaped via PID probe"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stale_reap_removes_only_matching_quarantined_snapshot() {
+        use std::fs;
+        let dir = std::env::temp_dir().join(format!(
+            "loom-lock-reap-match-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let lock_path = dir.join("test.lock");
+        let stale = LockMetadata {
+            pid: 999_999_999,
+            owner_id: "stale-owner".to_string(),
+            host: current_hostname(),
+            created_at: Utc::now() - chrono::Duration::hours(2),
+        };
+        fs::write(&lock_path, serde_json::to_string(&stale).unwrap()).unwrap();
+
+        assert!(try_reap_stale_lock(&lock_path).expect("reap stale lock"));
+        assert!(
+            !lock_path.exists(),
+            "matching stale lock must be removed after quarantine"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stale_reap_restores_quarantined_lock_when_identity_changed() {
+        use std::fs;
+        let dir = std::env::temp_dir().join(format!(
+            "loom-lock-reap-mismatch-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let lock_path = dir.join("test.lock");
+        let quarantine_path = dir.join(".test.lock.reap-test.quarantine");
+        let expected_stale = LockMetadata {
+            pid: 999_999_999,
+            owner_id: "stale-owner".to_string(),
+            host: current_hostname(),
+            created_at: Utc::now() - chrono::Duration::hours(2),
+        };
+        let fresh_replacement = LockMetadata {
+            pid: std::process::id(),
+            owner_id: "fresh-owner".to_string(),
+            host: current_hostname(),
+            created_at: Utc::now(),
+        };
+        let expected_raw = serde_json::to_string(&expected_stale).unwrap();
+        let replacement_raw = serde_json::to_string(&fresh_replacement).unwrap();
+        fs::write(&quarantine_path, &replacement_raw).unwrap();
+
+        assert!(
+            !finish_quarantined_reap(&lock_path, &quarantine_path, &expected_raw)
+                .expect("mismatched quarantine must restore")
+        );
+        assert_eq!(
+            fs::read_to_string(&lock_path).unwrap(),
+            replacement_raw,
+            "fresh replacement content must be restored to the live lock path"
+        );
+        assert!(
+            !quarantine_path.exists(),
+            "quarantine path must be gone after restore"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,7 +6,7 @@ pub use ops::{
     synthesize_snapshot_raw_from_segment_bodies,
 };
 
-use lock::{LockMetadata, try_reap_stale_lock};
+use lock::{LockMetadata, acquire_lock_coordinator, lock_file_matches_owner, try_reap_stale_lock};
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;
@@ -22,7 +22,7 @@ use crate::types::PendingOp;
 const OPS_COMPACTION_THRESHOLD: usize = 16;
 pub const DEFAULT_REGISTRY_DIR: &str = ".loom-registry";
 
-type InProcMap = Arc<Mutex<HashMap<String, (PathBuf, std::thread::ThreadId, usize)>>>;
+type InProcMap = Arc<Mutex<HashMap<String, (PathBuf, std::thread::ThreadId, usize, String)>>>;
 
 #[derive(Debug, Clone)]
 pub struct AppContext {
@@ -274,7 +274,7 @@ impl AppContext {
         // block at the filesystem layer rather than bypassing it.
         {
             let mut map = self.in_proc.lock().expect("in_proc mutex poisoned");
-            if let Some((_path, holder, count)) = map.get_mut(name)
+            if let Some((_path, holder, count, _owner_id)) = map.get_mut(name)
                 && *holder == current_thread
             {
                 *count += 1;
@@ -288,6 +288,7 @@ impl AppContext {
         }
 
         // Slow path: first acquire — attempt filesystem lock.
+        let _coordinator = acquire_lock_coordinator(&self.locks_dir)?;
         for _ in 0..2 {
             match OpenOptions::new()
                 .create_new(true)
@@ -296,6 +297,7 @@ impl AppContext {
             {
                 Ok(mut file) => {
                     let metadata = LockMetadata::new();
+                    let owner_id = metadata.owner_id.clone();
                     let payload = serde_json::to_string(&metadata)
                         .context("failed to encode lock metadata")?;
                     writeln!(file, "{}", payload).context("failed to write lock file")?;
@@ -303,7 +305,7 @@ impl AppContext {
                     self.in_proc
                         .lock()
                         .expect("in_proc mutex poisoned")
-                        .insert(name.to_string(), (lock_path, current_thread, 1));
+                        .insert(name.to_string(), (lock_path, current_thread, 1, owner_id));
                     return Ok(LockGuard {
                         name: name.to_string(),
                         in_proc: Arc::clone(&self.in_proc),
@@ -320,7 +322,7 @@ impl AppContext {
                             anyhow::bail!("LOCK_BUSY:{}", name);
                         }
                     }
-                    if try_reap_stale_lock(&self.locks_dir.join(format!("{}.lock", name)))? {
+                    if try_reap_stale_lock(&lock_path)? {
                         continue;
                     }
                     anyhow::bail!("LOCK_BUSY:{}", name);
@@ -402,18 +404,46 @@ impl Drop for LockGuard {
                 return;
             }
         };
-        if let Some((lock_path, _holder, count)) = map.get_mut(&self.name) {
+        if let Some((lock_path, _holder, count, owner_id)) = map.get_mut(&self.name) {
             *count -= 1;
             if *count == 0 {
                 let lock_path = lock_path.clone();
+                let owner_id = owner_id.clone();
                 map.remove(&self.name);
                 drop(map);
-                if let Err(err) = fs::remove_file(&lock_path) {
-                    eprintln!(
-                        "loom: failed to release lock {}: {}",
-                        lock_path.display(),
-                        err
-                    );
+                let Some(locks_dir) = lock_path.parent() else {
+                    eprintln!("loom: lock path has no parent: {}", lock_path.display());
+                    return;
+                };
+                let _coordinator = match acquire_lock_coordinator(locks_dir) {
+                    Ok(coordinator) => coordinator,
+                    Err(err) => {
+                        eprintln!(
+                            "loom: failed to coordinate lock release {}: {}",
+                            lock_path.display(),
+                            err
+                        );
+                        return;
+                    }
+                };
+                match lock_file_matches_owner(&lock_path, &owner_id) {
+                    Ok(true) => {
+                        if let Err(err) = fs::remove_file(&lock_path) {
+                            eprintln!(
+                                "loom: failed to release lock {}: {}",
+                                lock_path.display(),
+                                err
+                            );
+                        }
+                    }
+                    Ok(false) => {}
+                    Err(err) => {
+                        eprintln!(
+                            "loom: failed to verify lock owner {}: {}",
+                            lock_path.display(),
+                            err
+                        );
+                    }
                 }
             }
         }

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -130,3 +130,30 @@ fn cloned_context_different_thread_not_reaped_as_stale() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn lock_drop_does_not_remove_replaced_lock_file() {
+    let dir = std::env::temp_dir().join(format!(
+        "loom-lock-release-owner-{}",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let ctx = AppContext::new(Some(dir.clone())).unwrap();
+    let guard = ctx.lock_workspace().expect("acquire workspace lock");
+    let lock_path = ctx.locks_dir.join("workspace.lock");
+    let replacement = lock::LockMetadata {
+        pid: std::process::id(),
+        owner_id: "replacement-owner".to_string(),
+        host: "replacement-host".to_string(),
+        created_at: chrono::Utc::now(),
+    };
+    std::fs::write(&lock_path, serde_json::to_string(&replacement).unwrap())
+        .expect("replace lock file");
+
+    drop(guard);
+
+    let raw = std::fs::read_to_string(&lock_path).expect("replacement lock must remain");
+    let metadata: lock::LockMetadata = serde_json::from_str(raw.trim()).unwrap();
+    assert_eq!(metadata.owner_id, "replacement-owner");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary
- append each command audit JSONL event as a single newline-terminated buffer under O_APPEND to avoid torn multi-write rows
- add lock owner IDs plus coordinator locking around named-lock acquire/release
- reap stale locks through quarantine and exact snapshot verification, and release only when the lock file still belongs to the guard
- add targeted concurrency, stale-reap identity, and release ownership tests

Fixes #282

## Validation
- `cargo fmt --check`
- `cargo test --locked lock`
- `cargo test --locked event_store`
- `cargo test --locked state`
- `cargo check --locked`