### PR TITLE
Fix watch and trash rollback reliability

### DIFF
--- a/src/commands/trash_cmds.rs
+++ b/src/commands/trash_cmds.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::cli::{SkillOnlyArgs, TrashPurgeArgs, TrashRestoreArgs};
@@ -15,9 +15,10 @@ use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
 use super::helpers::{
-    backup_path_if_exists, map_arg, map_git, map_io, map_lock, map_registry_state,
-    maybe_autosync_or_queue, record_registry_operation, restore_path_from_backup,
-    restore_registry_audit_state, slugify, snapshot_registry_audit_state, validate_skill_name,
+    RegistryAuditStateBackup, backup_path_if_exists, map_arg, map_git, map_io, map_lock,
+    map_registry_state, maybe_autosync_or_queue, record_registry_operation,
+    restore_path_from_backup, restore_registry_audit_state, slugify, snapshot_registry_audit_state,
+    validate_skill_name,
 };
 use super::{App, CommandFailure};
 
@@ -103,9 +104,10 @@ impl App {
             Ok(op_id) => op_id,
             Err(err) => {
                 rollback_trash_add(&skill_path, &trash_skill_path, &entry_path);
-                let _ = restore_registry_audit_state(&paths, &registry_backup);
+                let rollback_errors =
+                    restore_registry_audit_state_best_effort(&paths, &registry_backup);
                 unstage_trash_paths(&self.ctx, &[&skill_rel, &format!("trash/{}", trash_id)]);
-                return Err(map_registry_state(err));
+                return Err(map_registry_state(err).with_rollback_errors(rollback_errors));
             }
         };
 
@@ -113,9 +115,10 @@ impl App {
             stage_trash_commit_paths(&self.ctx, &[&skill_rel, &format!("trash/{}", trash_id)])
         {
             rollback_trash_add(&skill_path, &trash_skill_path, &entry_path);
-            let _ = super::projections::restore_registry_audit_state(&paths, &registry_backup);
+            let rollback_errors =
+                restore_registry_audit_state_best_effort(&paths, &registry_backup);
             unstage_trash_paths(&self.ctx, &[&skill_rel, &format!("trash/{}", trash_id)]);
-            return Err(err);
+            return Err(err.with_rollback_errors(rollback_errors));
         }
 
         let commit = match commit_trash_paths(
@@ -126,9 +129,10 @@ impl App {
             Ok(commit) => commit,
             Err(err) => {
                 rollback_trash_add(&skill_path, &trash_skill_path, &entry_path);
-                let _ = restore_registry_audit_state(&paths, &registry_backup);
+                let rollback_errors =
+                    restore_registry_audit_state_best_effort(&paths, &registry_backup);
                 unstage_trash_paths(&self.ctx, &[&skill_rel, &format!("trash/{}", trash_id)]);
-                return Err(map_git(err));
+                return Err(map_git(err).with_rollback_errors(rollback_errors));
             }
         };
 
@@ -254,18 +258,20 @@ impl App {
             Err(err) => {
                 rollback_restore_from_backup(&skill_path, &entry.entry_path, trash_backup.as_ref());
                 remove_temp_backup_best_effort(trash_backup.as_ref());
-                let _ = restore_registry_audit_state(&paths, &registry_backup);
+                let rollback_errors =
+                    restore_registry_audit_state_best_effort(&paths, &registry_backup);
                 unstage_trash_paths(&self.ctx, &[&skill_rel, &trash_rel]);
-                return Err(map_registry_state(err));
+                return Err(map_registry_state(err).with_rollback_errors(rollback_errors));
             }
         };
 
         if let Err(err) = stage_trash_commit_paths(&self.ctx, &[&skill_rel, &trash_rel]) {
             rollback_restore_from_backup(&skill_path, &entry.entry_path, trash_backup.as_ref());
             remove_temp_backup_best_effort(trash_backup.as_ref());
-            let _ = restore_registry_audit_state(&paths, &registry_backup);
+            let rollback_errors =
+                restore_registry_audit_state_best_effort(&paths, &registry_backup);
             unstage_trash_paths(&self.ctx, &[&skill_rel, &trash_rel]);
-            return Err(err);
+            return Err(err.with_rollback_errors(rollback_errors));
         }
 
         let commit = match commit_trash_paths(
@@ -277,9 +283,10 @@ impl App {
             Err(err) => {
                 rollback_restore_from_backup(&skill_path, &entry.entry_path, trash_backup.as_ref());
                 remove_temp_backup_best_effort(trash_backup.as_ref());
-                let _ = restore_registry_audit_state(&paths, &registry_backup);
+                let rollback_errors =
+                    restore_registry_audit_state_best_effort(&paths, &registry_backup);
                 unstage_trash_paths(&self.ctx, &[&skill_rel, &trash_rel]);
-                return Err(map_git(err));
+                return Err(map_git(err).with_rollback_errors(rollback_errors));
             }
         };
         remove_temp_backup_best_effort(trash_backup.as_ref());
@@ -354,18 +361,20 @@ impl App {
             Err(err) => {
                 restore_temp_backup_best_effort(&entry_path, trash_backup.as_ref());
                 remove_temp_backup_best_effort(trash_backup.as_ref());
-                let _ = restore_registry_audit_state(&paths, &registry_backup);
+                let rollback_errors =
+                    restore_registry_audit_state_best_effort(&paths, &registry_backup);
                 unstage_trash_paths(&self.ctx, &[&trash_rel]);
-                return Err(map_registry_state(err));
+                return Err(map_registry_state(err).with_rollback_errors(rollback_errors));
             }
         };
 
         if let Err(err) = stage_trash_commit_paths(&self.ctx, &[&trash_rel]) {
             restore_temp_backup_best_effort(&entry_path, trash_backup.as_ref());
             remove_temp_backup_best_effort(trash_backup.as_ref());
-            let _ = restore_registry_audit_state(&paths, &registry_backup);
+            let rollback_errors =
+                restore_registry_audit_state_best_effort(&paths, &registry_backup);
             unstage_trash_paths(&self.ctx, &[&trash_rel]);
-            return Err(err);
+            return Err(err.with_rollback_errors(rollback_errors));
         }
 
         let commit = match commit_trash_paths(
@@ -377,9 +386,10 @@ impl App {
             Err(err) => {
                 restore_temp_backup_best_effort(&entry_path, trash_backup.as_ref());
                 remove_temp_backup_best_effort(trash_backup.as_ref());
-                let _ = restore_registry_audit_state(&paths, &registry_backup);
+                let rollback_errors =
+                    restore_registry_audit_state_best_effort(&paths, &registry_backup);
                 unstage_trash_paths(&self.ctx, &[&trash_rel]);
-                return Err(map_git(err));
+                return Err(map_git(err).with_rollback_errors(rollback_errors));
             }
         };
         remove_temp_backup_best_effort(trash_backup.as_ref());
@@ -667,4 +677,18 @@ fn remove_temp_backup_best_effort(backup: Option<&serde_json::Value>) {
             let _ = fs::remove_dir(grandparent);
         }
     }
+}
+
+fn restore_registry_audit_state_best_effort(
+    paths: &RegistryStatePaths,
+    registry_backup: &RegistryAuditStateBackup,
+) -> Vec<Value> {
+    let step = "restore_registry_audit_state";
+    if std::env::var("LOOM_ROLLBACK_FAULT_INJECT").ok().as_deref() == Some(step) {
+        return vec![json!({"step": step, "message": format!("fault injected at {}", step)})];
+    }
+    restore_registry_audit_state(paths, registry_backup)
+        .err()
+        .map(|err| vec![json!({"step": step, "message": err.to_string()})])
+        .unwrap_or_default()
 }

--- a/src/commands/watch_cmds.rs
+++ b/src/commands/watch_cmds.rs
@@ -80,7 +80,7 @@ impl App {
         }
 
         if args.once {
-            return self.watch_once(args, request_id);
+            return self.watch_once(args, request_id, false);
         }
 
         let mut cycles = 0_u64;
@@ -90,7 +90,35 @@ impl App {
         let mut meta = Meta::default();
 
         loop {
-            let (cycle, cycle_meta) = self.watch_once(args, request_id)?;
+            let (cycle, cycle_meta) = match self.watch_once(args, request_id, true) {
+                Ok(result) => result,
+                Err(err)
+                    if matches!(err.code, ErrorCode::LockBusy | ErrorCode::CaptureConflict) =>
+                {
+                    let code = err.code.as_str();
+                    let reason = match err.code {
+                        ErrorCode::LockBusy => "lock-busy",
+                        ErrorCode::CaptureConflict => "capture-conflict",
+                        _ => unreachable!(),
+                    };
+                    let mut cycle_meta = Meta::default();
+                    cycle_meta.warnings.push(format!(
+                        "watch cycle skipped after transient {}: {}",
+                        code, err.message
+                    ));
+                    (
+                        json!({
+                            "changed_skills": [],
+                            "saved_skills": [],
+                            "skipped": [{"reason": reason, "error": {"code": code, "message": err.message, "details": err.details}}],
+                            "dry_run": false,
+                            "noop": true,
+                        }),
+                        cycle_meta,
+                    )
+                }
+                Err(err) => return Err(err),
+            };
             cycles += 1;
             saved_total += cycle["saved_skills"].as_array().map(Vec::len).unwrap_or(0);
             skipped_total += cycle["skipped"].as_array().map(Vec::len).unwrap_or(0);
@@ -119,6 +147,7 @@ impl App {
         &self,
         args: &WatchArgs,
         request_id: &str,
+        continue_on_skill_error: bool,
     ) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
         validate_watch_scope(self, args)?;
         if args.dry_run {
@@ -155,13 +184,14 @@ impl App {
             ));
         }
 
-        self.autosave_watch_plan(plan, request_id)
+        self.autosave_watch_plan(plan, request_id, continue_on_skill_error)
     }
 
     fn autosave_watch_plan(
         &self,
         plan: WatchPlan,
         request_id: &str,
+        continue_on_skill_error: bool,
     ) -> std::result::Result<(serde_json::Value, Meta), CommandFailure> {
         let mut saved = Vec::new();
         let mut skipped = Vec::new();
@@ -185,8 +215,26 @@ impl App {
                 }
             };
 
-            let saved_skill = self.autosave_skill(&skill, request_id)?;
+            let autosave_result = self.autosave_skill(&skill, request_id);
             drop(lock);
+            let saved_skill = match autosave_result {
+                Ok(saved_skill) => saved_skill,
+                Err(err) if continue_on_skill_error => {
+                    let code = err.code.as_str();
+                    meta.warnings.push(format!(
+                        "skill '{}' autosave failed; skipped this cycle: {}: {}",
+                        skill.skill, code, err.message
+                    ));
+                    skipped.push(json!({
+                        "skill": skill.skill,
+                        "paths": skill.paths,
+                        "reason": "autosave-error",
+                        "error": {"code": code, "message": err.message, "details": err.details},
+                    }));
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
             if !saved_skill["noop"].as_bool().unwrap_or(false) {
                 if let Some(op_id) = saved_skill["op_id"].as_str() {
                     meta.op_id = Some(op_id.to_string());
@@ -243,27 +291,27 @@ impl App {
             Ok(op_id) => op_id,
             Err(err) => {
                 unstage_watch_paths(&self.ctx, &skill.paths);
-                rollback_autosave_registry_audit_after_failure(
+                let rollback_errors = rollback_autosave_registry_audit_after_failure(
                     &self.ctx,
                     &paths,
                     &registry_backup,
                     had_registry_layout,
                     had_legacy_layout,
                 );
-                return Err(map_registry_state(err));
+                return Err(map_registry_state(err).with_rollback_errors(rollback_errors));
             }
         };
 
         if let Err(err) = stage_autosave_registry_state(&self.ctx, &paths) {
             unstage_watch_paths(&self.ctx, &skill.paths);
-            rollback_autosave_registry_audit_after_failure(
+            let rollback_errors = rollback_autosave_registry_audit_after_failure(
                 &self.ctx,
                 &paths,
                 &registry_backup,
                 had_registry_layout,
                 had_legacy_layout,
             );
-            return Err(err);
+            return Err(err.with_rollback_errors(rollback_errors));
         }
 
         let message = format!("autosave({}): captured local edits", skill.skill);
@@ -271,14 +319,14 @@ impl App {
             Ok(commit) => commit,
             Err(err) => {
                 unstage_watch_paths(&self.ctx, &skill.paths);
-                rollback_autosave_registry_audit_after_failure(
+                let rollback_errors = rollback_autosave_registry_audit_after_failure(
                     &self.ctx,
                     &paths,
                     &registry_backup,
                     had_registry_layout,
                     had_legacy_layout,
                 );
-                return Err(map_git(err));
+                return Err(map_git(err).with_rollback_errors(rollback_errors));
             }
         };
 
@@ -707,12 +755,13 @@ fn rollback_autosave_registry_audit_after_failure(
     registry_backup: &RegistryAuditStateBackup,
     had_registry_layout: bool,
     had_legacy_layout: bool,
-) {
-    let _ = restore_registry_audit_state(paths, registry_backup);
+) -> Vec<Value> {
+    let rollback_errors = restore_registry_audit_state_best_effort(paths, registry_backup);
     if !had_registry_layout && !had_legacy_layout {
         let _ = remove_path_if_exists(&paths.registry_dir);
     }
     unstage_registry_state(ctx);
+    rollback_errors
 }
 
 fn unstage_registry_state(ctx: &AppContext) {
@@ -728,4 +777,18 @@ fn merge_watch_meta(target: &mut Meta, source: Meta) {
     if source.op_id.is_some() {
         target.op_id = source.op_id;
     }
+}
+
+fn restore_registry_audit_state_best_effort(
+    paths: &RegistryStatePaths,
+    registry_backup: &RegistryAuditStateBackup,
+) -> Vec<Value> {
+    let step = "restore_registry_audit_state";
+    if std::env::var("LOOM_ROLLBACK_FAULT_INJECT").ok().as_deref() == Some(step) {
+        return vec![json!({"step": step, "message": format!("fault injected at {}", step)})];
+    }
+    restore_registry_audit_state(paths, registry_backup)
+        .err()
+        .map(|err| vec![json!({"step": step, "message": err.to_string()})])
+        .unwrap_or_default()
 }

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 mod common;
 
 use common::actions::save_skill;
-use common::{TestDir, operations_log, run_loom, write_file, write_skill};
+use common::{TestDir, operations_log, run_loom, run_loom_with_env, write_file, write_skill};
 
 fn assert_success(output: &std::process::Output, context: &str) {
     assert!(
@@ -35,6 +35,15 @@ fn git_success(root: &Path, args: &[&str]) -> String {
         String::from_utf8_lossy(&output.stdout)
     );
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn rollback_error_steps(env: &Value) -> Vec<String> {
+    env["error"]["details"]["rollback_errors"]
+        .as_array()
+        .expect("rollback errors array")
+        .iter()
+        .filter_map(|error| error["step"].as_str().map(ToString::to_string))
+        .collect()
 }
 
 #[test]
@@ -245,4 +254,30 @@ fn skill_trash_purge_removes_one_trash_entry() {
         ""
     );
     assert!(operations_log(root.path()).contains(r#""intent":"skill.trash.purge""#));
+}
+
+#[test]
+fn skill_trash_add_reports_audit_restore_rollback_errors() {
+    let root = TestDir::new("skill-trash-rollback-errors");
+    write_skill(root.path(), "demo", "# Demo\n\nv1\n");
+    assert_success(&save_skill(root.path(), "demo").0, "save");
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[
+            ("LOOM_FAULT_INJECT", "record_v3_operation_after_checkpoint"),
+            ("LOOM_ROLLBACK_FAULT_INJECT", "restore_registry_audit_state"),
+        ],
+        &["skill", "trash", "add", "demo"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "faulted trash add unexpectedly succeeded"
+    );
+    assert!(
+        rollback_error_steps(&env).contains(&"restore_registry_audit_state".to_string()),
+        "missing rollback error details: {env}"
+    );
+    assert!(root.path().join("skills/demo/SKILL.md").exists());
 }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -3,9 +3,11 @@ mod common;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use common::actions::save_skill;
-use common::{TestDir, run_loom, write_file, write_skill};
+use common::{TestDir, run_loom, run_loom_with_env, write_file, write_skill};
 use serde_json::Value;
 
 fn run_watch_git(root: &Path, args: &[&str]) -> String {
@@ -29,6 +31,21 @@ fn run_watch_git(root: &Path, args: &[&str]) -> String {
 
 fn read_watch_operations(root: &Path) -> String {
     fs::read_to_string(root.join("state/registry/ops/operations.jsonl")).unwrap_or_default()
+}
+
+fn rollback_error_steps(env: &Value) -> Vec<String> {
+    env["error"]["details"]["rollback_errors"]
+        .as_array()
+        .expect("rollback errors array")
+        .iter()
+        .filter_map(|error| error["step"].as_str().map(ToString::to_string))
+        .collect()
+}
+
+fn write_live_workspace_lock(root: &Path) {
+    let locks = root.join("state/locks");
+    fs::create_dir_all(&locks).expect("create locks dir");
+    fs::write(locks.join("workspace.lock"), "busy\n").expect("write workspace lock");
 }
 
 #[test]
@@ -312,4 +329,175 @@ fn skill_watch_refuses_batches_over_max_batch() {
         head_before
     );
     assert!(!read_watch_operations(root.path()).contains(r#""intent":"skill.autosave""#));
+}
+
+#[test]
+fn skill_watch_long_running_skips_lock_busy_cycles() {
+    let root = TestDir::new("skill-watch-lock-busy-continue");
+    write_skill(root.path(), "demo", "# demo\n\nv1\n");
+    assert!(save_skill(root.path(), "demo").0.status.success());
+    write_skill(root.path(), "demo", "# demo\n\nv2\n");
+    write_live_workspace_lock(root.path());
+
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "skill",
+            "watch",
+            "demo",
+            "--debounce-ms",
+            "1",
+            "--max-cycles",
+            "2",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "watch exited on LOCK_BUSY: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(env["data"]["cycles"], Value::from(2));
+    assert_eq!(env["data"]["skipped_total"], Value::from(2));
+    assert_eq!(
+        env["data"]["last_cycle"]["skipped"][0]["error"]["code"],
+        Value::String("LOCK_BUSY".to_string())
+    );
+    assert!(
+        env["meta"]["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning.as_str().unwrap_or_default().contains("LOCK_BUSY"))
+    );
+}
+
+#[test]
+fn skill_watch_long_running_skips_capture_conflict_cycles() {
+    let root = TestDir::new("skill-watch-capture-conflict-continue");
+    write_skill(root.path(), "demo", "# demo\n\nv1\n");
+    assert!(save_skill(root.path(), "demo").0.status.success());
+    write_skill(root.path(), "demo", "# demo\n\nv2\n");
+
+    let root_path = root.path().to_path_buf();
+    let mutator = thread::spawn(move || {
+        for index in 0..80 {
+            thread::sleep(Duration::from_millis(20));
+            write_file(
+                &root_path.join(format!("skills/demo/race-{index}.md")),
+                &format!("{index}\n"),
+            );
+        }
+    });
+    let (output, env) = run_loom(
+        root.path(),
+        &[
+            "skill",
+            "watch",
+            "demo",
+            "--debounce-ms",
+            "100",
+            "--max-cycles",
+            "2",
+        ],
+    );
+    mutator.join().expect("mutator thread");
+
+    assert!(
+        output.status.success(),
+        "watch exited on CAPTURE_CONFLICT: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        env["data"]["skipped_total"].as_u64().unwrap_or(0) >= 1,
+        "expected at least one skipped conflict cycle: {env}"
+    );
+    assert!(
+        env["meta"]["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .unwrap_or_default()
+                .contains("CAPTURE_CONFLICT")),
+        "missing capture conflict warning: {env}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_watch_long_running_preserves_saved_results_when_one_skill_fails() {
+    let root = TestDir::new("skill-watch-partial-failure");
+    write_skill(root.path(), "alpha", "# alpha\n\nv1\n");
+    write_skill(root.path(), "beta", "# beta\n\nv1\n");
+    assert!(save_skill(root.path(), "alpha").0.status.success());
+    assert!(save_skill(root.path(), "beta").0.status.success());
+
+    let hook = root.path().join(".git/hooks/pre-commit");
+    fs::create_dir_all(hook.parent().unwrap()).expect("create hooks dir");
+    fs::write(
+        &hook,
+        "#!/bin/sh\nif git diff --cached --name-only | grep -q '^skills/beta/'; then\n  echo beta blocked >&2\n  exit 1\nfi\nexit 0\n",
+    )
+    .expect("write pre-commit hook");
+    #[allow(clippy::permissions_set_readonly_false)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&hook).expect("hook metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&hook, perms).expect("set hook executable");
+    }
+
+    write_skill(root.path(), "alpha", "# alpha\n\nv2\n");
+    write_skill(root.path(), "beta", "# beta\n\nv2\n");
+    let (output, env) = run_loom(
+        root.path(),
+        &["skill", "watch", "--debounce-ms", "1", "--max-cycles", "1"],
+    );
+
+    assert!(
+        output.status.success(),
+        "watch should keep saved results after one skill fails: stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(env["data"]["saved_total"], Value::from(1));
+    assert_eq!(env["data"]["skipped_total"], Value::from(1));
+    assert_eq!(
+        env["data"]["last_cycle"]["saved_skills"][0]["skill"],
+        Value::String("alpha".to_string())
+    );
+    assert_eq!(
+        env["data"]["last_cycle"]["skipped"][0]["skill"],
+        Value::String("beta".to_string())
+    );
+}
+
+#[test]
+fn skill_watch_once_reports_audit_restore_rollback_errors() {
+    let root = TestDir::new("skill-watch-rollback-errors");
+    write_skill(root.path(), "demo", "# demo\n\nv1\n");
+    assert!(save_skill(root.path(), "demo").0.status.success());
+    write_skill(root.path(), "demo", "# demo\n\nv2\n");
+
+    let (output, env) = run_loom_with_env(
+        root.path(),
+        &[
+            ("LOOM_FAULT_INJECT", "record_v3_operation_after_checkpoint"),
+            ("LOOM_ROLLBACK_FAULT_INJECT", "restore_registry_audit_state"),
+        ],
+        &["skill", "watch", "demo", "--once", "--debounce-ms", "0"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "faulted watch unexpectedly succeeded"
+    );
+    assert!(
+        rollback_error_steps(&env).contains(&"restore_registry_audit_state".to_string()),
+        "missing rollback error details: {env}"
+    );
 }


### PR DESCRIPTION
## Summary
- Keep long-running `skill watch` alive across transient `LOCK_BUSY` and `CAPTURE_CONFLICT` cycles with warnings and skipped cycle metadata.
- Preserve successful watch autosaves when a later skill in the same long-running batch fails.
- Surface audit-state restore rollback failures in watch and trash rollback paths via `rollback_errors`.

## Validation
- `cargo fmt --check`
- `cargo test --locked --test watch`
- `cargo test --locked --test trash`
- `cargo test --locked watch`
- `cargo test --locked trash`
- `cargo check --locked`

Fixes #281
Fixes #283