### PR TITLE
Refactor panel mutation banners and query state

### DIFF
--- a/panel/src/components/panel/MutationBanner.tsx
+++ b/panel/src/components/panel/MutationBanner.tsx
@@ -1,0 +1,41 @@
+import type { MutationState } from "../../lib/useMutation";
+
+type MutationBannerTone = "ok" | "err" | "warn" | "muted";
+type MutationBannerVariant = "inline" | "bar";
+type MutationBannerSpacing = "none" | "top" | "bottom";
+
+interface MutationBannerProps {
+  state?: Pick<MutationState, "error" | "success"> | null;
+  error?: string | null;
+  success?: string | null;
+  message?: string | null;
+  tone?: MutationBannerTone;
+  variant?: MutationBannerVariant;
+  spacing?: MutationBannerSpacing;
+  className?: string;
+  prefixSuccess?: boolean;
+}
+
+export function MutationBanner({
+  state,
+  error = state?.error ?? null,
+  success = state?.success ?? null,
+  message,
+  tone,
+  variant = "inline",
+  spacing = "none",
+  className,
+  prefixSuccess = true,
+}: MutationBannerProps) {
+  const content = message ?? error ?? (success ? `${prefixSuccess ? "✓ " : ""}${success}` : null);
+  if (!content) return null;
+
+  const resolvedTone = tone ?? (error ? "err" : "ok");
+  const classes = ["mutation-note", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes} data-tone={resolvedTone} data-variant={variant} data-spacing={spacing}>
+      {content}
+    </div>
+  );
+}

--- a/panel/src/lib/useApiQuery.ts
+++ b/panel/src/lib/useApiQuery.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState, type DependencyList } from "react";
+
+export type ApiQueryState<T> =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; payload: T }
+  | { kind: "error"; message: string };
+
+interface UseApiQueryOptions {
+  enabled?: boolean;
+  getErrorMessage?: (error: unknown) => string;
+}
+
+export function useApiQuery<T>(
+  fetcher: (signal: AbortSignal) => Promise<T>,
+  deps: DependencyList,
+  options: UseApiQueryOptions = {},
+): ApiQueryState<T> {
+  const enabled = options.enabled ?? true;
+  const getErrorMessage = options.getErrorMessage ?? defaultErrorMessage;
+  const [state, setState] = useState<ApiQueryState<T>>({ kind: "idle" });
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ kind: "idle" });
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({ kind: "loading" });
+    fetcher(controller.signal)
+      .then((payload) => {
+        if (controller.signal.aborted) return;
+        setState({ kind: "ready", payload });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setState({ kind: "error", message: getErrorMessage(error) });
+      });
+
+    return () => controller.abort();
+  }, [enabled, ...deps]);
+
+  return state;
+}
+
+function defaultErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/panel/src/pages/panel/BindingsPage.tsx
+++ b/panel/src/pages/panel/BindingsPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import type { Binding, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { BindingIcon, PlusIcon } from "../../components/icons/nav_icons";
 import { EmptyState } from "../../components/panel/EmptyState";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
-import { api, ApiError, type BindingShowPayload } from "../../lib/api/client";
+import { api, type BindingShowPayload } from "../../lib/api/client";
+import { useApiQuery } from "../../lib/useApiQuery";
 import { useMutation } from "../../lib/useMutation";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
 
@@ -251,12 +253,6 @@ export function BindingsPage({
   );
 }
 
-type DetailState =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | { kind: "ready"; payload: NonNullable<BindingShowPayload["data"]> }
-  | { kind: "error"; message: string };
-
 function BindingDetail({
   binding,
   targets,
@@ -272,35 +268,19 @@ function BindingDetail({
   mutationVersion: number;
   onRemoved: (bindingId: string) => void;
 }) {
-  const [state, setState] = useState<DetailState>({ kind: "idle" });
+  const state = useApiQuery<NonNullable<BindingShowPayload["data"]>>(
+    async (signal) => {
+      const res = await api.bindingShow(binding.id, signal);
+      if (!res.ok || !res.data) {
+        throw new Error(res.error?.message ?? "binding fetch returned ok=false");
+      }
+      return res.data;
+    },
+    [binding.id, mutationVersion],
+    { enabled: !readOnly },
+  );
   const project = useMutation();
   const remove = useMutation();
-
-  useEffect(() => {
-    if (readOnly) {
-      setState({ kind: "idle" });
-      return;
-    }
-
-    const controller = new AbortController();
-    setState({ kind: "loading" });
-    api
-      .bindingShow(binding.id, controller.signal)
-      .then((res) => {
-        if (controller.signal.aborted) return;
-        if (!res.ok || !res.data) {
-          setState({ kind: "error", message: res.error?.message ?? "binding fetch returned ok=false" });
-          return;
-        }
-        setState({ kind: "ready", payload: res.data });
-      })
-      .catch((err) => {
-        if (controller.signal.aborted) return;
-        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
-        setState({ kind: "error", message });
-      });
-    return () => controller.abort();
-  }, [binding.id, mutationVersion, readOnly]);
 
   const t = targets.find((x) => x.id === binding.target);
   const rules = state.kind === "ready" ? state.payload.rules ?? [] : [];
@@ -369,23 +349,11 @@ function BindingDetail({
           {remove.busy ? "Deleting…" : "Delete binding"}
         </button>
       </div>
-      {(project.error || project.success || remove.error || remove.success) && (
-        <div
-          style={{
-            marginBottom: 12,
-            padding: "6px 10px",
-            borderRadius: 6,
-            border: "1px solid",
-            borderColor: project.error || remove.error ? "rgba(216,90,90,0.3)" : "rgba(111,183,138,0.25)",
-            background: project.error || remove.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
-            color: project.error || remove.error ? "var(--err)" : "var(--ok)",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-          }}
-        >
-          {project.error ?? remove.error ?? `✓ ${project.success ?? remove.success}`}
-        </div>
-      )}
+      <MutationBanner
+        error={project.error ?? remove.error}
+        success={project.success ?? remove.success}
+        spacing="bottom"
+      />
       <div className="kv">
         <div className="k">Skill</div>
         <div className="v">{binding.skill}</div>

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
-import { api, ApiError, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import { api, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import {
   bucketRegistryOperation,
   describeRegistryOperation,
   registryOperationDisplayId,
 } from "../../lib/operation_labels";
 import { useMutation } from "../../lib/useMutation";
+import { useApiQuery } from "../../lib/useApiQuery";
 import { COUNT_TERMS, filterLabel, summarizeOps } from "../../lib/count_labels";
 import { SearchIcon } from "../../components/icons/nav_icons";
 
@@ -14,11 +16,11 @@ type FilterKey = "all" | "pending" | "ok" | "err";
 type DiagnoseData = NonNullable<OpsHistoryDiagnosePayload["data"]>;
 const HISTORY_PAGE_SIZE = 100;
 
-type LoadState =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | { kind: "ready"; payload: NonNullable<OpsPayload["data"]> }
-  | { kind: "error"; message: string };
+type HistoryQueryPayload = {
+  ops: NonNullable<OpsPayload["data"]>;
+  diagnose: DiagnoseData | null;
+  diagnoseError: string | null;
+};
 
 interface HistoryPageProps {
   live: boolean;
@@ -39,58 +41,44 @@ export function HistoryPage({
   readOnlyReason,
   onMutation,
 }: HistoryPageProps) {
-  const [state, setState] = useState<LoadState>({ kind: "idle" });
-  const [diagnose, setDiagnose] = useState<DiagnoseData | null>(null);
-  const [diagnoseError, setDiagnoseError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
   const [offset, setOffset] = useState(0);
   const [repairVersion, setRepairVersion] = useState(0);
-  const repair = useMutation();
-
-  useEffect(() => {
-    if (!live) {
-      setState({ kind: "idle" });
-      return;
-    }
-
-    const controller = new AbortController();
-    setState({ kind: "loading" });
-    setDiagnose(null);
-    setDiagnoseError(null);
-    Promise.allSettled([
-      api.ops({ limit: HISTORY_PAGE_SIZE, offset }, controller.signal),
-      api.opsHistoryDiagnose(controller.signal),
-    ]).then(([opsResult, diagnoseResult]) => {
-      if (controller.signal.aborted) return;
+  const state = useApiQuery<HistoryQueryPayload>(
+    async (signal) => {
+      const [opsResult, diagnoseResult] = await Promise.allSettled([
+        api.ops({ limit: HISTORY_PAGE_SIZE, offset }, signal),
+        api.opsHistoryDiagnose(signal),
+      ]);
 
       if (opsResult.status === "rejected") {
-        const err = opsResult.reason;
-        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
-        setState({ kind: "error", message });
-        return;
+        throw opsResult.reason;
       }
 
       const res = opsResult.value;
       if (!res.ok || !res.data) {
-        setState({ kind: "error", message: res.error?.message ?? "activity fetch returned ok=false" });
-        return;
+        throw new Error(res.error?.message ?? "activity fetch returned ok=false");
       }
-      setState({ kind: "ready", payload: res.data });
 
+      let diagnose: DiagnoseData | null = null;
+      let diagnoseError: string | null = null;
       if (diagnoseResult.status === "fulfilled") {
         if (diagnoseResult.value.data) {
-          setDiagnose(diagnoseResult.value.data);
+          diagnose = diagnoseResult.value.data;
         } else if (!diagnoseResult.value.ok) {
-          setDiagnoseError(diagnoseResult.value.error?.message ?? "history diagnose returned ok=false");
+          diagnoseError = diagnoseResult.value.error?.message ?? "history diagnose returned ok=false";
         }
       } else {
-        const err = diagnoseResult.reason;
-        setDiagnoseError(err instanceof Error ? err.message : String(err));
+        diagnoseError = diagnoseResult.reason instanceof Error ? diagnoseResult.reason.message : String(diagnoseResult.reason);
       }
-    });
-    return () => controller.abort();
-  }, [live, mutationVersion, refreshKey, offset, repairVersion]);
+
+      return { ops: res.data, diagnose, diagnoseError };
+    },
+    [mutationVersion, refreshKey, offset, repairVersion],
+    { enabled: live },
+  );
+  const repair = useMutation();
 
   const runRepair = (strategy: "local" | "remote") => {
     if (readOnly || repair.busy) return;
@@ -105,7 +93,9 @@ export function HistoryPage({
       ? "Activity history is offline. Showing the last overview snapshot."
       : "Activity history needs the live panel API. Start `loom panel`.";
 
-  const payload = state.kind === "ready" ? state.payload : null;
+  const payload = state.kind === "ready" ? state.payload.ops : null;
+  const diagnose = state.kind === "ready" ? state.payload.diagnose : null;
+  const diagnoseError = state.kind === "ready" ? state.payload.diagnoseError : null;
   const operations = payload?.operations ?? [];
 
   const filtered = useMemo(() => {
@@ -162,34 +152,10 @@ export function HistoryPage({
           </div>
         </div>
       </div>
-      {(repair.error || repair.success) && (
-        <div
-          style={{
-            padding: "6px 28px",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            borderBottom: "1px solid var(--line)",
-            color: repair.error ? "var(--err)" : "var(--ok)",
-            background: repair.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
-          }}
-        >
-          {repair.error ?? `✓ ${repair.success}`}
-        </div>
-      )}
+      <MutationBanner state={repair} variant="bar" />
       <div className="page-body">
         {state.kind === "error" && (
-          <div
-            style={{
-              padding: "6px 28px",
-              fontFamily: "var(--font-mono)",
-              fontSize: 11,
-              borderBottom: "1px solid var(--line)",
-              color: "var(--err)",
-              background: "rgba(216,90,90,0.08)",
-            }}
-          >
-            {state.message}
-          </div>
+          <MutationBanner message={state.message} tone="err" variant="bar" />
         )}
         {!live && <div className="empty" style={{ marginBottom: 18 }}>{offlineHint}</div>}
         {diagnoseError && (

--- a/panel/src/pages/panel/OpsPage.tsx
+++ b/panel/src/pages/panel/OpsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Op, OpStatus } from "../../lib/types";
 import { OpRow } from "../../components/panel/OpRow";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { RefreshIcon } from "../../components/icons/nav_icons";
 import { api } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
@@ -29,6 +30,8 @@ export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
       } → ${oldestPending.target}`
     : "queue empty";
   const actionBusy = retry.busy || purge.busy;
+  const bannerError = retry.error ?? purge.error;
+  const bannerSuccess = retry.success ?? purge.success;
 
   return (
     <>
@@ -70,25 +73,13 @@ export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
           </button>
         </div>
       </div>
-      {(retry.error || retry.success || retry.busy || purge.error || purge.success || purge.busy) && (
-        <div
-          style={{
-            padding: "6px 28px",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            borderBottom: "1px solid var(--line)",
-            color: retry.error || purge.error ? "var(--err)" : retry.busy || purge.busy ? "var(--ink-2)" : "var(--ok)",
-            background:
-              retry.error || purge.error
-                ? "rgba(216,90,90,0.08)"
-                : retry.busy || purge.busy
-                ? "var(--bg-2)"
-                : "rgba(111,183,138,0.08)",
-          }}
-        >
-          {retry.busy || purge.busy ? "…" : retry.error ?? purge.error ?? `✓ ${retry.success ?? purge.success}`}
-        </div>
-      )}
+      <MutationBanner
+        message={actionBusy ? "…" : undefined}
+        error={bannerError}
+        success={bannerSuccess}
+        tone={actionBusy ? "muted" : undefined}
+        variant="bar"
+      />
       <div className="page-body">
         <div className="ops-summary-grid">
           <div

--- a/panel/src/pages/panel/OverviewPage.tsx
+++ b/panel/src/pages/panel/OverviewPage.tsx
@@ -1,6 +1,7 @@
 import type { Op, ProjectionLink, Skill, Target, VizMode } from "../../lib/types";
 import { OpRow } from "../../components/panel/OpRow";
 import { ProjectionGraph } from "../../components/panel/ProjectionGraph";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { PlusIcon, RefreshIcon, ShieldIcon, TargetIcon } from "../../components/icons/nav_icons";
 import { COUNT_TERMS, formatReplayableWrites, summarizeOps } from "../../lib/count_labels";
 import { api } from "../../lib/api/client";
@@ -174,11 +175,7 @@ export function OverviewPage({
             {nextSteps.map((step, index) => (
               <NextStepRow key={step.label} step={step} active={!step.done && nextSteps.findIndex((candidate) => !candidate.done) === index} />
             ))}
-            {(importObserved.error || importObserved.success) && (
-              <div className="mutation-note" data-tone={importObserved.error ? "err" : "ok"}>
-                {importObserved.error ?? `✓ ${importObserved.success}`}
-              </div>
-            )}
+            <MutationBanner state={importObserved} />
           </div>
         </div>
 

--- a/panel/src/pages/panel/SkillLifecycle.tsx
+++ b/panel/src/pages/panel/SkillLifecycle.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type CSSProperties, type FormEvent } from "react";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { api, type RegistryObservationEvent, type SkillDiffFile } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
 
@@ -147,7 +148,7 @@ export function LifecycleActions({
           </button>
         </form>
       </div>
-      {status && <div style={hasError ? errorStyle : okStyle}>{hasError ? status : `✓ ${status}`}</div>}
+      <MutationBanner error={hasError ? status : null} success={hasError ? null : status} spacing="top" />
     </div>
   );
 }
@@ -354,22 +355,4 @@ const formInputStyle: CSSProperties = {
 const fullWidthButtonStyle: CSSProperties = {
   width: "100%",
   justifyContent: "center",
-};
-
-const errorStyle: CSSProperties = {
-  marginTop: 10,
-  padding: "6px 10px",
-  color: "var(--err)",
-  background: "rgba(216,90,90,0.08)",
-  border: "1px solid rgba(216,90,90,0.3)",
-  borderRadius: 6,
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-};
-
-const okStyle: CSSProperties = {
-  ...errorStyle,
-  color: "var(--ok)",
-  background: "rgba(111,183,138,0.08)",
-  border: "1px solid rgba(111,183,138,0.3)",
 };

--- a/panel/src/pages/panel/SkillTrashPanel.tsx
+++ b/panel/src/pages/panel/SkillTrashPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import { api, type SkillTrashEntry } from "../../lib/api/client";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import type { Skill } from "../../lib/types";
 import { useMutation } from "../../lib/useMutation";
 
@@ -176,11 +177,7 @@ export function TrashSkillAction({ skill, readOnly, onSuccess }: TrashSkillActio
           <div className="mono" style={{ color: "var(--ink-3)", fontSize: 11, marginTop: 4 }}>
             It can be restored later from the Trash view.
           </div>
-          {(trash.error || trash.success) && (
-            <div style={trash.error ? errorStyle : okStyle}>
-              {trash.error ?? `✓ ${trash.success}`}
-            </div>
-          )}
+          <MutationBanner state={trash} spacing="top" />
           <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 12 }}>
             <button className="btn ghost" onClick={() => setConfirmOpen(false)} disabled={trash.busy}>
               Cancel
@@ -191,9 +188,7 @@ export function TrashSkillAction({ skill, readOnly, onSuccess }: TrashSkillActio
           </div>
         </div>
       )}
-      {!confirmOpen && (trash.error || trash.success) && (
-        <div style={trash.error ? errorStyle : okStyle}>{trash.error ?? `✓ ${trash.success}`}</div>
-      )}
+      {!confirmOpen && <MutationBanner state={trash} spacing="top" />}
     </div>
   );
 }
@@ -287,11 +282,11 @@ function TrashEntryDetail({
             </div>
           </div>
         )}
-        {(restore.error || restore.success || purge.error || purge.success) && (
-          <div style={restore.error || purge.error ? errorStyle : okStyle}>
-            {restore.error ?? purge.error ?? `✓ ${restore.success ?? purge.success}`}
-          </div>
-        )}
+        <MutationBanner
+          error={restore.error ?? purge.error}
+          success={restore.success ?? purge.success}
+          spacing="top"
+        />
       </div>
     </div>
   );
@@ -326,24 +321,6 @@ function statusBarStyle(tone: "err" | "muted"): CSSProperties {
     background: tone === "err" ? "rgba(216,90,90,0.08)" : "var(--bg-1)",
   };
 }
-
-const errorStyle: CSSProperties = {
-  marginTop: 10,
-  padding: "6px 10px",
-  color: "var(--err)",
-  background: "rgba(216,90,90,0.08)",
-  border: "1px solid rgba(216,90,90,0.3)",
-  borderRadius: 6,
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-};
-
-const okStyle: CSSProperties = {
-  ...errorStyle,
-  color: "var(--ok)",
-  background: "rgba(111,183,138,0.08)",
-  border: "1px solid rgba(111,183,138,0.3)",
-};
 
 const modeSwitchStyle: CSSProperties = {
   display: "inline-flex",

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -4,6 +4,7 @@ import type { RegistryProjection } from "../../generated/RegistryProjection";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
 import { PlusIcon, SearchIcon, SkillIcon } from "../../components/icons/nav_icons";
 import { EmptyState } from "../../components/panel/EmptyState";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { api, type SkillDiagnosePayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
 import { SkillDiagnosePanel } from "./SkillDiagnosePanel";
@@ -149,20 +150,7 @@ export function SkillsPage({
           )}
         </div>
       </div>
-      {(capture.error || capture.success) && (
-        <div
-          style={{
-            padding: "6px 28px",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            borderBottom: "1px solid var(--line)",
-            color: capture.error ? "var(--err)" : "var(--ok)",
-            background: capture.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
-          }}
-        >
-          {capture.error ?? `✓ ${capture.success}`}
-        </div>
-      )}
+      <MutationBanner state={capture} variant="bar" />
       <div className="page-body" style={{ padding: 0 }}>
         {mode === "skills" && addOpen && (
           <div style={{ padding: "0 28px 12px" }}>
@@ -331,7 +319,7 @@ function SkillAddForm({ onCancel, onSuccess }: { onCancel: () => void; onSuccess
         <label className="hint">name</label>
         <input value={name} onChange={(event) => setName(event.target.value)} placeholder="my-skill" style={formInputStyle} />
       </div>
-      {(add.error || add.success) && <div style={add.error ? errorStyle : okStyle}>{add.error ?? `✓ ${add.success}`}</div>}
+      <MutationBanner state={add} spacing="top" />
       <div style={{ display: "flex", gap: 8, marginTop: 12, justifyContent: "flex-end" }}>
         <button type="button" className="btn ghost" onClick={onCancel} disabled={add.busy}>
           Cancel
@@ -605,7 +593,7 @@ function ProjectSkillForm({
           {project.busy ? "projecting…" : "Project"}
         </button>
       </div>
-      {(project.error || project.success) && <div style={project.error ? errorStyle : okStyle}>{project.error ?? `✓ ${project.success}`}</div>}
+      <MutationBanner state={project} spacing="top" />
     </div>
   );
 }
@@ -661,24 +649,6 @@ const formInputStyle: React.CSSProperties = {
 const fullWidthButtonStyle: React.CSSProperties = {
   width: "100%",
   justifyContent: "center",
-};
-
-const errorStyle: React.CSSProperties = {
-  marginTop: 10,
-  padding: "6px 10px",
-  color: "var(--err)",
-  background: "rgba(216,90,90,0.08)",
-  border: "1px solid rgba(216,90,90,0.3)",
-  borderRadius: 6,
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-};
-
-const okStyle: React.CSSProperties = {
-  ...errorStyle,
-  color: "var(--ok)",
-  background: "rgba(111,183,138,0.08)",
-  border: "1px solid rgba(111,183,138,0.3)",
 };
 
 const skillDescriptionStyle: React.CSSProperties = {

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -2,6 +2,7 @@ import type { RemotePayload } from "../../types";
 import type { FormEvent } from "react";
 import { useEffect, useState } from "react";
 import { GitIcon, PlayIcon, RefreshIcon, SyncIcon } from "../../components/icons/nav_icons";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { api, type OpsHistoryDiagnosePayload } from "../../lib/api/client";
 import { useMutation } from "../../lib/useMutation";
 import { COUNT_TERMS, formatQueuedWrites } from "../../lib/count_labels";
@@ -78,12 +79,8 @@ export function SyncPage({ remote, queuedWriteCount, registryRoot, refreshKey, r
     setRemote.run(configured ? "remote update" : "remote set", () => api.remoteSet({ url }), onMutation);
   };
 
-  const banner =
-    setRemote.error ?? push.error ?? pull.error ?? replay.error ??
-    historyRepair.error ??
-    setRemote.success ?? push.success ?? pull.success ?? replay.success ?? historyRepair.success ?? null;
-  const bannerType =
-    setRemote.error || push.error || pull.error || replay.error || historyRepair.error ? "err" : banner ? "ok" : null;
+  const bannerError = setRemote.error ?? push.error ?? pull.error ?? replay.error ?? historyRepair.error;
+  const bannerSuccess = setRemote.success ?? push.success ?? pull.success ?? replay.success ?? historyRepair.success;
 
   const runHistoryRepair = (strategy: "local" | "remote") => {
     historyRepair.run(`history repair ${strategy}`, () => api.opsHistoryRepair({ strategy }), () => {
@@ -102,20 +99,12 @@ export function SyncPage({ remote, queuedWriteCount, registryRoot, refreshKey, r
           </div>
         </div>
       </div>
-      {banner && (
-        <div
-          style={{
-            padding: "6px 28px",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            borderBottom: "1px solid var(--line)",
-            color: bannerType === "err" ? "var(--err)" : "var(--ok)",
-            background: bannerType === "err" ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
-          }}
-        >
-          {banner}
-        </div>
-      )}
+      <MutationBanner
+        error={bannerError}
+        success={bannerSuccess}
+        variant="bar"
+        prefixSuccess={false}
+      />
       <div className="page-body">
         <div className="kpi-row">
           <Kpi label="Sync state" value={formatSyncState(state)} tone={stateTone} valueKind="status" />

--- a/panel/src/pages/panel/TargetsPage.tsx
+++ b/panel/src/pages/panel/TargetsPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import type { Ownership, Skill, Target } from "../../lib/types";
 import { AgentAvatar } from "../../components/panel/AgentAvatar";
+import { MutationBanner } from "../../components/panel/MutationBanner";
 import { PlusIcon } from "../../components/icons/nav_icons";
 import { TargetAddForm } from "../../components/panel/forms/TargetAddForm";
-import { api, ApiError, type TargetShowPayload } from "../../lib/api/client";
+import { api, type TargetShowPayload } from "../../lib/api/client";
+import { useApiQuery } from "../../lib/useApiQuery";
 import { useMutation } from "../../lib/useMutation";
 
 const OWNERSHIP_TOOLTIP: Record<Ownership, string> = {
@@ -104,11 +106,7 @@ export function TargetsPage({
               >
                 <PlusIcon /> {importObserved.busy ? "Importing..." : "Import observed skills"}
               </button>
-              {(importObserved.error || importObserved.success) && (
-                <div className="mutation-note" data-tone={importObserved.error ? "err" : "ok"}>
-                  {importObserved.error ?? `✓ ${importObserved.success}`}
-                </div>
-              )}
+              <MutationBanner state={importObserved} />
             </div>
           </div>
         )}
@@ -259,12 +257,6 @@ function ObservedSkillList({ skills }: { skills: Skill[] }) {
   );
 }
 
-type DetailState =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | { kind: "ready"; payload: NonNullable<TargetShowPayload["data"]> }
-  | { kind: "error"; message: string };
-
 function TargetDetail({
   target,
   readOnly,
@@ -278,34 +270,18 @@ function TargetDetail({
   mutationVersion: number;
   onRemoved: (id: string) => void;
 }) {
-  const [state, setState] = useState<DetailState>({ kind: "idle" });
+  const state = useApiQuery<NonNullable<TargetShowPayload["data"]>>(
+    async (signal) => {
+      const res = await api.targetShow(target.id, signal);
+      if (!res.ok || !res.data) {
+        throw new Error(res.error?.message ?? "target fetch returned ok=false");
+      }
+      return res.data;
+    },
+    [target.id, mutationVersion],
+    { enabled: !readOnly },
+  );
   const remove = useMutation();
-
-  useEffect(() => {
-    if (readOnly) {
-      setState({ kind: "idle" });
-      return;
-    }
-
-    const controller = new AbortController();
-    setState({ kind: "loading" });
-    api
-      .targetShow(target.id, controller.signal)
-      .then((res) => {
-        if (controller.signal.aborted) return;
-        if (!res.ok || !res.data) {
-          setState({ kind: "error", message: res.error?.message ?? "target fetch returned ok=false" });
-          return;
-        }
-        setState({ kind: "ready", payload: res.data });
-      })
-      .catch((err) => {
-        if (controller.signal.aborted) return;
-        const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : String(err);
-        setState({ kind: "error", message });
-      });
-    return () => controller.abort();
-  }, [readOnly, target.id, mutationVersion]);
 
   const bindings = state.kind === "ready" ? state.payload.bindings ?? [] : [];
   const projections = state.kind === "ready" ? state.payload.projections ?? [] : [];
@@ -343,23 +319,7 @@ function TargetDetail({
           <span className="hint">Target is referenced by {bindings.length} binding{bindings.length === 1 ? "" : "s"}.</span>
         )}
       </div>
-      {(remove.error || remove.success) && (
-        <div
-          style={{
-            marginBottom: 12,
-            padding: "6px 10px",
-            borderRadius: 6,
-            border: "1px solid",
-            borderColor: remove.error ? "rgba(216,90,90,0.3)" : "rgba(111,183,138,0.25)",
-            background: remove.error ? "rgba(216,90,90,0.08)" : "rgba(111,183,138,0.08)",
-            color: remove.error ? "var(--err)" : "var(--ok)",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-          }}
-        >
-          {remove.error ?? `✓ ${remove.success}`}
-        </div>
-      )}
+      <MutationBanner state={remove} spacing="bottom" />
       <div className="target-detail-grid">
         <div>
           <div className="section-title">Bindings → this target</div>

--- a/panel/src/styles/panel/primitives.css
+++ b/panel/src/styles/panel/primitives.css
@@ -61,17 +61,44 @@
 .mutation-note {
   padding: 6px 10px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(111, 183, 138, 0.25);
-  background: rgba(111, 183, 138, 0.08);
+  border: 1px solid var(--ok-border);
+  background: var(--ok-bg);
   color: var(--ok);
   font-family: var(--font-mono);
   font-size: 11px;
 }
 
 .mutation-note[data-tone="err"] {
-  border-color: rgba(216, 90, 90, 0.3);
-  background: rgba(216, 90, 90, 0.08);
+  border-color: var(--err-border);
+  background: var(--err-bg);
   color: var(--err);
+}
+
+.mutation-note[data-tone="warn"] {
+  border-color: var(--warn-border);
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+
+.mutation-note[data-tone="muted"] {
+  border-color: var(--line);
+  background: var(--bg-2);
+  color: var(--ink-2);
+}
+
+.mutation-note[data-variant="bar"] {
+  padding: 6px 28px;
+  border-width: 0 0 1px;
+  border-radius: 0;
+  border-bottom-color: var(--line);
+}
+
+.mutation-note[data-spacing="top"] {
+  margin-top: 10px;
+}
+
+.mutation-note[data-spacing="bottom"] {
+  margin-bottom: 12px;
 }
 
 .field-input,

--- a/panel/src/styles/tokens.css
+++ b/panel/src/styles/tokens.css
@@ -30,6 +30,12 @@
   --warn: #e6b450;
   --err: #d85a5a;
   --pending: #c2a05e;
+  --ok-bg: rgba(111, 183, 138, 0.08);
+  --ok-border: rgba(111, 183, 138, 0.25);
+  --warn-bg: rgba(230, 180, 80, 0.08);
+  --warn-border: rgba(230, 180, 80, 0.32);
+  --err-bg: rgba(216, 90, 90, 0.08);
+  --err-border: rgba(216, 90, 90, 0.3);
 
   --managed: #d97736;
   --observed: #6fb78a;
@@ -82,6 +88,12 @@
   --warn: #a9791c;
   --err: #c0392b;
   --pending: #9a7b32;
+  --ok-bg: rgba(47, 141, 94, 0.08);
+  --ok-border: rgba(47, 141, 94, 0.25);
+  --warn-bg: rgba(169, 121, 28, 0.08);
+  --warn-border: rgba(169, 121, 28, 0.3);
+  --err-bg: rgba(192, 57, 43, 0.08);
+  --err-border: rgba(192, 57, 43, 0.28);
 
   --managed: #c05f23;
   --observed: #2f8d5e;
@@ -125,6 +137,12 @@
   --warn: #9a6700;
   --err: #cf222e;
   --pending: #bf8700;
+  --ok-bg: rgba(26, 127, 55, 0.08);
+  --ok-border: rgba(26, 127, 55, 0.24);
+  --warn-bg: rgba(154, 103, 0, 0.08);
+  --warn-border: rgba(154, 103, 0, 0.28);
+  --err-bg: rgba(207, 34, 46, 0.08);
+  --err-border: rgba(207, 34, 46, 0.26);
 
   --managed: #0969da;
   --observed: #1a7f37;

--- a/panel/src/types.ts
+++ b/panel/src/types.ts
@@ -84,36 +84,3 @@ export type RegistryPayload = {
     message?: string;
   };
 };
-
-export type RegistryModel = {
-  available: boolean;
-  counts: NonNullable<NonNullable<RegistryPayload["data"]>["counts"]>;
-  bindings: RegistryBinding[];
-  targets: RegistryTarget[];
-  rules: RegistryRule[];
-  projections: RegistryProjection[];
-  checkpoint?: RegistryCheckpoint;
-  error?: string;
-};
-
-export type PanelData = {
-  health: HealthPayload;
-  info: InfoPayload;
-  skills: string[];
-  remote: RemotePayload;
-  pending: PendingPayload;
-  registry: RegistryModel;
-  remoteWarnings: string[];
-  live: boolean;
-  lastUpdated: string;
-};
-
-export type SkillView = {
-  name: string;
-  projections: RegistryProjection[];
-  rules: RegistryRule[];
-  bindings: RegistryBinding[];
-  targets: RegistryTarget[];
-  methods: string[];
-  driftedCount: number;
-};


### PR DESCRIPTION
## Summary
- Add shared `MutationBanner` plus theme-aware status background/border tokens.
- Replace repeated mutation result banners across high-value panel pages.
- Add `useApiQuery` and migrate repeated read-fetch state in history, binding details, and target details.
- Remove unused `RegistryModel`, `PanelData`, and `SkillView` exports confirmed by `rg`.

## Validation
- `cd panel && bun run typecheck`
- `cd panel && bun run test -- --run`
- `cd panel && bun run build`

Fixes #290