### PR TITLE
docs: sync CLI contract with clap surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ Supported `--agent` values are `claude`, `codex`, `cursor`, `windsurf`, `cline`,
 
 ```bash
 loom init
+loom backup export [--output <path>] [--format tar] [--include-target-cache]
+loom backup inspect <artifact>
+loom backup restore <artifact> [--force-empty-root]
 loom monitor [--target <target-id>] [--once] [--interval-seconds <seconds>]
+loom doctor
 
 loom workspace status
 loom workspace doctor
@@ -237,7 +241,7 @@ loom workspace init [--scan-existing]
 loom workspace binding add --agent <agent> --profile <id> --matcher-kind <path-prefix|exact-path|name> --matcher-value <value> --target <target-id> [--policy-profile <id>]
 loom workspace binding list
 loom workspace binding show <binding-id>
-loom workspace binding remove <binding-id>
+loom workspace binding remove <binding-id> [--orphan-projections]
 loom workspace remote set <git-url>
 loom workspace remote status
 
@@ -256,8 +260,14 @@ loom skill snapshot <skill>
 loom skill release <skill> <version>
 loom skill rollback <skill> [--to <ref> | --steps <n>] [--preview]
 loom skill diff <skill> <from> <to>
+loom skill history <skill> [--limit <n>] [--from <rev>] [--to <rev>] [--include-diff-stat] [--include-ops]
+loom skill trash add <skill>
+loom skill trash list
+loom skill trash restore <skill> [--trash-id <id>]
+loom skill trash purge <trash-id>
 loom skill verify <skill>
 loom skill diagnose <skill>
+loom skill watch [<skill>] [--debounce-ms <ms>] [--max-batch <n>] [--dry-run] [--once]
 loom skill import-observed [--target <target-id>]
 loom skill monitor-observed [--target <target-id>] [--once] [--interval-seconds <seconds>]
 loom skill orphan list

--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -1,6 +1,6 @@
 # Loom registry model CLI Contract
 
-Updated: 2026-05-18
+Updated: 2026-06-11
 Status: Implemented
 
 ## 1. Purpose
@@ -32,12 +32,17 @@ This document turns [LOOM_STATE_MODEL.md](LOOM_STATE_MODEL.md) into a concrete m
 
 Top-level command groups:
 
-1. `workspace`
-2. `target`
-3. `skill`
-4. `sync`
-5. `ops`
-6. `panel`
+1. `init`
+2. `backup`
+3. `monitor`
+4. `workspace`
+5. `target`
+6. `skill`
+7. `sync`
+8. `ops`
+9. `agent`
+10. `panel`
+11. `doctor`
 
 Removed from runtime surface:
 
@@ -174,15 +179,21 @@ Base error codes:
 5. `SKILL_NOT_FOUND`
 6. `BINDING_NOT_FOUND`
 7. `TARGET_NOT_FOUND`
-8. `LOCK_BUSY`
-9. `REMOTE_UNREACHABLE`
-10. `REMOTE_DIVERGED`
-11. `PUSH_REJECTED`
-12. `REPLAY_CONFLICT`
-13. `QUEUE_BLOCKED`
-14. `GIT_ERROR`
-15. `IO_ERROR`
-16. `INTERNAL_ERROR`
+8. `TARGET_NOT_MANAGED`
+9. `TARGET_AGENT_MISMATCH`
+10. `PROJECTION_CONFLICT`
+11. `PROJECTION_METHOD_UNSUPPORTED`
+12. `CAPTURE_CONFLICT`
+13. `AUDIT_ERROR`
+14. `LOCK_BUSY`
+15. `REMOTE_UNREACHABLE`
+16. `REMOTE_DIVERGED`
+17. `PUSH_REJECTED`
+18. `REPLAY_CONFLICT`
+19. `QUEUE_BLOCKED`
+20. `GIT_ERROR`
+21. `IO_ERROR`
+22. `INTERNAL_ERROR`
 
 Semantics:
 
@@ -195,7 +206,7 @@ Semantics:
 ### 9.1 `workspace status`
 
 ```bash
-loom --json --root <root> workspace status [--binding <binding-id>|--all-bindings]
+loom --json --root <root> workspace status
 ```
 
 Read-only.
@@ -233,7 +244,7 @@ Requirements:
 ### 9.2 `workspace doctor`
 
 ```bash
-loom --json --root <root> workspace doctor [--binding <binding-id>|--all-bindings]
+loom --json --root <root> workspace doctor
 ```
 
 Read-only unless a future explicit repair subcommand is introduced.

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -39,6 +39,90 @@ fn top_level_help_describes_command_groups() {
 }
 
 #[test]
+fn cli_contract_docs_track_current_surface() {
+    let contract = include_str!("../docs/LOOM_CLI_CONTRACT.md");
+    let readme = include_str!("../README.md");
+
+    for command in [
+        "`init`",
+        "`backup`",
+        "`monitor`",
+        "`workspace`",
+        "`target`",
+        "`skill`",
+        "`sync`",
+        "`ops`",
+        "`agent`",
+        "`panel`",
+        "`doctor`",
+    ] {
+        assert!(
+            contract.contains(command),
+            "CLI contract missing top-level command {command}"
+        );
+    }
+
+    for stale in [
+        "workspace status [--binding",
+        "workspace doctor [--binding",
+        "--all-bindings",
+    ] {
+        assert!(
+            !contract.contains(stale),
+            "CLI contract still documents stale workspace selector {stale:?}"
+        );
+    }
+
+    for code in [
+        "ARG_INVALID",
+        "DEPENDENCY_CONFLICT",
+        "SCHEMA_MISMATCH",
+        "STATE_CORRUPT",
+        "SKILL_NOT_FOUND",
+        "BINDING_NOT_FOUND",
+        "TARGET_NOT_FOUND",
+        "TARGET_NOT_MANAGED",
+        "TARGET_AGENT_MISMATCH",
+        "PROJECTION_CONFLICT",
+        "PROJECTION_METHOD_UNSUPPORTED",
+        "CAPTURE_CONFLICT",
+        "AUDIT_ERROR",
+        "LOCK_BUSY",
+        "REMOTE_UNREACHABLE",
+        "REMOTE_DIVERGED",
+        "PUSH_REJECTED",
+        "REPLAY_CONFLICT",
+        "QUEUE_BLOCKED",
+        "GIT_ERROR",
+        "IO_ERROR",
+        "INTERNAL_ERROR",
+    ] {
+        assert!(
+            contract.contains(code),
+            "CLI contract missing error code {code}"
+        );
+    }
+
+    for command in [
+        "loom backup export",
+        "loom backup inspect",
+        "loom backup restore",
+        "loom doctor",
+        "loom skill history",
+        "loom skill trash add",
+        "loom skill trash list",
+        "loom skill trash restore",
+        "loom skill trash purge",
+        "loom skill watch",
+    ] {
+        assert!(
+            readme.contains(command),
+            "README CLI reference missing command {command}"
+        );
+    }
+}
+
+#[test]
 fn top_level_init_uses_default_registry_root_and_scans_existing_dirs() {
     let home = TestDir::new("cli-default-home");
     let codex_skill = home.path().join(".codex/skills/demo-skill");


### PR DESCRIPTION
## Summary
- update `LOOM_CLI_CONTRACT.md` so top-level commands, workspace status/doctor forms, and error codes match the current clap/types surface
- fill README's full CLI reference with backup, top-level doctor, skill history, skill watch, and skill trash commands
- add a CLI surface regression test that catches these documented contract entries drifting again

Fixes #287.

## Validation
- `cargo fmt --check`
- `cargo test --locked cli_contract_docs_track_current_surface`
- `cargo check --locked`
- `git diff --check`