### PR TITLE
refactor: resolve internal layering debt

### DIFF
--- a/src/commands/agent_cmds.rs
+++ b/src/commands/agent_cmds.rs
@@ -5,9 +5,9 @@ mod planning_helpers;
 use serde_json::{Value, json};
 
 use super::helpers::{
-    agent_kind_as_str, map_arg, map_git, map_io, projection_method_as_str,
-    resolve_capture_projection, validate_skill_name,
+    agent_kind_as_str, map_arg, map_git, map_io, projection_method_as_str, validate_skill_name,
 };
+use super::projections::resolve_capture_projection;
 use super::{App, CommandFailure};
 use crate::cli::{AgentPreflightArgs, CaptureArgs, OrphanCleanArgs, ProjectArgs, RollbackArgs};
 use crate::envelope::Meta;

--- a/src/commands/backup_cmds.rs
+++ b/src/commands/backup_cmds.rs
@@ -14,8 +14,9 @@ use walkdir::WalkDir;
 use crate::cli::{
     BackupCommand, BackupExportArgs, BackupFormat, BackupInspectArgs, BackupRestoreArgs,
 };
+use crate::fs_util::remove_path_if_exists;
 use crate::gitops;
-use crate::state::{AppContext, remove_path_if_exists};
+use crate::state::AppContext;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 

--- a/src/commands/event_store.rs
+++ b/src/commands/event_store.rs
@@ -1,12 +1,3 @@
-use std::fs::{self, File, OpenOptions};
-use std::io;
-use std::path::Path;
-
-#[cfg(not(unix))]
-use std::io::Write;
-#[cfg(unix)]
-use std::os::fd::AsRawFd;
-
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -15,6 +6,7 @@ use uuid::Uuid;
 
 use crate::cli::Cli;
 use crate::envelope::Envelope;
+use crate::fs_util::{append_jsonl_raw, ensure_append_log, maybe_fault_inject_any};
 use crate::state::AppContext;
 
 const COMMAND_EVENT_SCHEMA_VERSION: u32 = 1;
@@ -136,98 +128,24 @@ fn append_command_finished_with_fault_tags(
 }
 
 fn append_command_event(ctx: &AppContext, event: &CommandEvent, fault_tags: &[&str]) -> Result<()> {
-    maybe_fault_inject(fault_tags)?;
-    let path = ctx.state_dir.join("events/commands.jsonl");
-    let parent = path
-        .parent()
-        .context("command event path must have a parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create command event dir {}", parent.display()))?;
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .with_context(|| format!("failed to open command event log {}", path.display()))?;
+    maybe_fault_inject_any(fault_tags)?;
     let raw = serde_json::to_string(event).context("failed to encode command event")?;
-    append_jsonl_line(&mut file, &path, &raw)?;
-    file.sync_all()
-        .with_context(|| format!("failed to sync command event {}", path.display()))?;
-    Ok(())
-}
-
-fn append_jsonl_line(file: &mut File, path: &Path, raw: &str) -> Result<()> {
-    let mut line = Vec::with_capacity(raw.len() + 1);
-    line.extend_from_slice(raw.as_bytes());
-    line.push(b'\n');
-    append_single_record_write(file, &line)
-        .with_context(|| format!("failed to append command event {}", path.display()))
-}
-
-#[cfg(unix)]
-fn append_single_record_write(file: &mut File, line: &[u8]) -> io::Result<()> {
-    if line.len() > isize::MAX as usize {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "command event line exceeds write size limit",
-        ));
-    }
-
-    loop {
-        // SAFETY: `line` points to a valid immutable byte buffer for `line.len()`
-        // bytes, and `file.as_raw_fd()` is an open descriptor owned by `file`.
-        let written = unsafe { libc::write(file.as_raw_fd(), line.as_ptr().cast(), line.len()) };
-        if written < 0 {
-            let err = io::Error::last_os_error();
-            if err.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(err);
-        }
-
-        let written = written as usize;
-        if written == line.len() {
-            return Ok(());
-        }
-        return Err(io::Error::new(
-            io::ErrorKind::WriteZero,
-            format!(
-                "short command event append: wrote {} of {} bytes",
-                written,
-                line.len()
-            ),
-        ));
-    }
-}
-
-#[cfg(not(unix))]
-fn append_single_record_write(file: &mut File, line: &[u8]) -> io::Result<()> {
-    file.write_all(line)
+    append_jsonl_raw(&ctx.command_events_file, &raw).with_context(|| {
+        format!(
+            "failed to append command event {}",
+            ctx.command_events_file.display()
+        )
+    })
 }
 
 pub(crate) fn prepare_command_event_store(ctx: &AppContext) -> Result<()> {
-    maybe_fault_inject(&["command_event_prepare"])?;
-    let path = ctx.state_dir.join("events/commands.jsonl");
-    let parent = path
-        .parent()
-        .context("command event path must have a parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create command event dir {}", parent.display()))?;
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .with_context(|| format!("failed to open command event log {}", path.display()))?;
-    file.sync_all()
-        .with_context(|| format!("failed to sync command event {}", path.display()))?;
-    Ok(())
-}
-
-fn maybe_fault_inject(tags: &[&str]) -> Result<()> {
-    let active = std::env::var("LOOM_FAULT_INJECT").ok();
-    if let Some(tag) = active.as_deref().filter(|tag| tags.contains(tag)) {
-        return Err(anyhow::anyhow!("fault injected at {}", tag));
-    }
-    Ok(())
+    maybe_fault_inject_any(&["command_event_prepare"])?;
+    ensure_append_log(&ctx.command_events_file).with_context(|| {
+        format!(
+            "failed to prepare command event log {}",
+            ctx.command_events_file.display()
+        )
+    })
 }
 
 fn redact_sensitive_strings(value: &mut serde_json::Value) {

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -7,8 +7,9 @@ use serde_json::json;
 use uuid::Uuid;
 use walkdir::WalkDir;
 
+use crate::fs_util::remove_path_if_exists;
 use crate::gitops;
-use crate::state::{AppContext, remove_path_if_exists};
+use crate::state::AppContext;
 
 use super::helpers::slugify;
 

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -16,20 +16,6 @@ use crate::types::ErrorCode;
 
 use super::CommandFailure;
 
-// Re-export items from sibling modules so existing `use super::helpers::*` paths keep working.
-pub(crate) use super::file_ops::{
-    backup_path_if_exists, copy_dir_recursive_without_symlinks, read_git_field,
-    restore_path_from_backup, rollback_added_skill,
-};
-pub(crate) use super::projections::{
-    RegistryAuditStateBackup, maybe_autosync_or_queue, project_skill_to_target,
-    record_registry_observation, record_registry_operation, remote_status_payload_with_pending,
-    resolve_capture_projection, restore_registry_audit_state, snapshot_registry_audit_state,
-    sync_push_internal, sync_replay_internal, update_projection_after_capture, upsert_projection,
-    upsert_rule,
-};
-pub use super::projections::{collect_skill_inventory, remote_status_payload};
-
 // ---------------------------------------------------------------------------
 // Git bootstrap
 // ---------------------------------------------------------------------------

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,7 +34,7 @@ use crate::state::{AppContext, home_dir};
 use crate::types::ErrorCode;
 
 pub(crate) use event_store::redact_sensitive_string;
-pub use helpers::collect_skill_inventory;
+pub use projections::collect_skill_inventory;
 
 use event_store::{
     append_command_audit_failure, append_command_finished, append_command_started,

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -23,8 +23,9 @@ use super::event_store::redact_sensitive_string;
 use super::file_ops::{
     copy_dir_recursive, copy_dir_recursive_preserving_symlinks, create_symlink_dir,
 };
-use super::helpers::{map_git, map_io, map_push_rejected, map_queue, map_remote_unreachable};
-use crate::state::remove_path_if_exists;
+use super::helpers::{map_git, map_io, map_queue};
+use super::sync_cmds::sync_push_internal;
+use crate::fs_util::{maybe_fault_inject, remove_path_if_exists};
 
 mod symlink_guard;
 use symlink_guard::ensure_projection_symlinks_contained;
@@ -406,10 +407,7 @@ pub(crate) fn restore_registry_audit_state(
 }
 
 fn maybe_projection_fault(tag: &str) -> Result<()> {
-    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
-        return Err(anyhow::anyhow!("fault injected at {}", tag));
-    }
-    Ok(())
+    Ok(maybe_fault_inject(tag)?)
 }
 
 fn rollback_record_registry_operation(
@@ -543,7 +541,7 @@ fn list_unique_skills_from_dirs(
 }
 
 // ---------------------------------------------------------------------------
-// Remote status / sync internals
+// Remote status / autosync coordination
 // ---------------------------------------------------------------------------
 
 pub fn remote_status_payload(
@@ -673,60 +671,6 @@ pub(crate) fn maybe_autosync_or_queue(
         }
     }
     Ok(())
-}
-
-pub(crate) fn sync_push_internal(
-    ctx: &AppContext,
-) -> std::result::Result<&'static str, CommandFailure> {
-    if !gitops::remote_exists(ctx) {
-        return Err(CommandFailure::new(
-            ErrorCode::ArgInvalid,
-            "remote origin not configured",
-        ));
-    }
-
-    let _state_commit = gitops::commit_paths_if_changed(
-        ctx,
-        &[".gitignore", "state/registry", "state/v3"],
-        "sync: commit registry state",
-    )
-    .map_err(map_git)?;
-    let pending_report = ctx.read_pending_report().map_err(map_io)?;
-    let queued_ids = pending_report
-        .ops
-        .iter()
-        .map(|op| op.stable_id())
-        .collect::<std::collections::BTreeSet<_>>();
-    let remote_main_exists =
-        gitops::fetch_origin_main_if_present(ctx).map_err(map_remote_unreachable)?;
-    let remote_history_exists =
-        gitops::fetch_origin_history_branch_if_present(ctx).map_err(map_remote_unreachable)?;
-    if remote_history_exists {
-        let _ = gitops::sync_history_branch_from_remote(ctx).map_err(map_git)?;
-    }
-    if remote_main_exists {
-        let (_ahead, behind) = gitops::ahead_behind_main(ctx).map_err(map_git)?;
-        if behind > 0 {
-            return Err(CommandFailure::new(
-                ErrorCode::RemoteDiverged,
-                "local branch is behind origin/main",
-            ));
-        }
-    }
-    gitops::push_main_with_tags(ctx).map_err(map_push_rejected)?;
-    ctx.remove_pending_ops(&queued_ids).map_err(map_queue)?;
-    Ok("pushed")
-}
-
-pub(crate) fn sync_replay_internal(
-    ctx: &AppContext,
-) -> std::result::Result<&'static str, CommandFailure> {
-    let pending = ctx.pending_count().map_err(map_io)?;
-    if pending == 0 {
-        return Ok("no_pending_ops");
-    }
-    sync_push_internal(ctx)?;
-    Ok("replayed")
 }
 
 #[cfg(test)]

--- a/src/commands/projections.rs
+++ b/src/commands/projections.rs
@@ -646,6 +646,7 @@ pub(crate) fn maybe_autosync_or_queue(
     if !gitops::remote_exists(ctx) {
         ctx.append_pending(command, details, request_id.to_string())
             .map_err(map_queue)?;
+        gitops::mirror_pending_ops_history(ctx).map_err(map_git)?;
         meta.sync_state = Some(SyncState::PendingPush);
         meta.warnings
             .push("remote origin not configured, operation queued".to_string());
@@ -659,6 +660,7 @@ pub(crate) fn maybe_autosync_or_queue(
         Err(err) => {
             ctx.append_pending(command, details, request_id.to_string())
                 .map_err(map_queue)?;
+            gitops::mirror_pending_ops_history(ctx).map_err(map_git)?;
             meta.sync_state = Some(match err.code {
                 ErrorCode::RemoteDiverged => SyncState::Diverged,
                 ErrorCode::ReplayConflict => SyncState::Conflicted,

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -23,16 +23,21 @@ use crate::state_model::{
 };
 use crate::types::ErrorCode;
 
+use super::file_ops::{
+    backup_path_if_exists, copy_dir_recursive_without_symlinks, restore_path_from_backup,
+    rollback_added_skill,
+};
 use super::fs_probe::probe_symlink;
 use super::helpers::{
-    RegistryAuditStateBackup, backup_path_if_exists, commit_registry_state,
-    copy_dir_recursive_without_symlinks, ensure_skill_exists, map_arg, map_git, map_io, map_lock,
-    map_project_io, map_registry_state, maybe_autosync_or_queue, project_skill_to_target,
-    projection_instance_id, projection_method_as_str, record_registry_observation,
-    record_registry_operation, resolve_capture_projection, restore_path_from_backup,
-    restore_registry_audit_state, rollback_added_skill, snapshot_registry_audit_state,
-    update_projection_after_capture, upsert_projection, upsert_rule, validate_projection_method,
-    validate_skill_name,
+    commit_registry_state, ensure_skill_exists, map_arg, map_git, map_io, map_lock, map_project_io,
+    map_registry_state, projection_instance_id, projection_method_as_str,
+    validate_projection_method, validate_skill_name,
+};
+use super::projections::{
+    RegistryAuditStateBackup, maybe_autosync_or_queue, project_skill_to_target,
+    record_registry_observation, record_registry_operation, resolve_capture_projection,
+    restore_registry_audit_state, snapshot_registry_audit_state, update_projection_after_capture,
+    upsert_projection, upsert_rule,
 };
 use super::{App, CommandFailure};
 

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -15,8 +15,8 @@ use crate::cli::{
     SkillOnlyArgs,
 };
 use crate::envelope::Meta;
+use crate::fs_util::remove_path_if_exists;
 use crate::gitops;
-use crate::state::remove_path_if_exists;
 use crate::state_model::{
     RegistryBindingRule, RegistryBindingsFile, RegistryProjectionInstance,
     RegistryProjectionTarget, RegistryProjectionsFile, RegistryRulesFile, RegistryStatePaths,

--- a/src/commands/sync_cmds.rs
+++ b/src/commands/sync_cmds.rs
@@ -121,6 +121,7 @@ impl App {
                 let _workspace = self.ctx.lock_workspace().map_err(map_lock)?;
                 self.ensure_write_layout()?;
                 let purged = self.ctx.purge_pending().map_err(map_io)?;
+                gitops::mirror_pending_ops_history(&self.ctx).map_err(map_git)?;
                 Ok((json!({"purged": purged}), Meta::default()))
             }
             OpsCommand::History { command } => self.cmd_ops_history(command),
@@ -244,6 +245,7 @@ pub(crate) fn sync_push_internal(
     }
     gitops::push_main_with_tags(ctx).map_err(map_push_rejected)?;
     ctx.remove_pending_ops(&queued_ids).map_err(map_queue)?;
+    gitops::mirror_pending_ops_history(ctx).map_err(map_git)?;
     Ok("pushed")
 }
 

--- a/src/commands/sync_cmds.rs
+++ b/src/commands/sync_cmds.rs
@@ -9,10 +9,8 @@ use crate::gitops;
 use crate::state::{AppContext, synthesize_snapshot_raw_from_segment_bodies};
 use crate::types::ErrorCode;
 
-use super::helpers::{
-    map_git, map_io, map_lock, map_replay_conflict, remote_status_payload, sync_push_internal,
-    sync_replay_internal,
-};
+use super::helpers::{map_git, map_io, map_lock, map_replay_conflict};
+use super::projections::{remote_status_payload, sync_push_internal, sync_replay_internal};
 use super::{App, CommandFailure};
 
 impl App {

--- a/src/commands/sync_cmds.rs
+++ b/src/commands/sync_cmds.rs
@@ -6,11 +6,15 @@ use serde_json::json;
 use crate::cli::{HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand, SyncCommand};
 use crate::envelope::Meta;
 use crate::gitops;
-use crate::state::{AppContext, synthesize_snapshot_raw_from_segment_bodies};
+use crate::state::AppContext;
+use crate::state::journal::synthesize_snapshot_raw_from_segment_bodies;
 use crate::types::ErrorCode;
 
-use super::helpers::{map_git, map_io, map_lock, map_replay_conflict};
-use super::projections::{remote_status_payload, sync_push_internal, sync_replay_internal};
+use super::helpers::{
+    map_git, map_io, map_lock, map_push_rejected, map_queue, map_remote_unreachable,
+    map_replay_conflict,
+};
+use super::projections::remote_status_payload;
 use super::{App, CommandFailure};
 
 impl App {
@@ -198,4 +202,58 @@ fn rebuild_local_pending_ops_snapshot(ctx: &AppContext) -> anyhow::Result<bool> 
         },
     )?;
     Ok(true)
+}
+
+pub(crate) fn sync_push_internal(
+    ctx: &AppContext,
+) -> std::result::Result<&'static str, CommandFailure> {
+    if !gitops::remote_exists(ctx) {
+        return Err(CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            "remote origin not configured",
+        ));
+    }
+
+    let _state_commit = gitops::commit_paths_if_changed(
+        ctx,
+        &[".gitignore", "state/registry", "state/v3"],
+        "sync: commit registry state",
+    )
+    .map_err(map_git)?;
+    let pending_report = ctx.read_pending_report().map_err(map_io)?;
+    let queued_ids = pending_report
+        .ops
+        .iter()
+        .map(|op| op.stable_id())
+        .collect::<std::collections::BTreeSet<_>>();
+    let remote_main_exists =
+        gitops::fetch_origin_main_if_present(ctx).map_err(map_remote_unreachable)?;
+    let remote_history_exists =
+        gitops::fetch_origin_history_branch_if_present(ctx).map_err(map_remote_unreachable)?;
+    if remote_history_exists {
+        gitops::sync_history_branch_from_remote(ctx).map_err(map_git)?;
+    }
+    if remote_main_exists {
+        let (_ahead, behind) = gitops::ahead_behind_main(ctx).map_err(map_git)?;
+        if behind > 0 {
+            return Err(CommandFailure::new(
+                ErrorCode::RemoteDiverged,
+                "local branch is behind origin/main",
+            ));
+        }
+    }
+    gitops::push_main_with_tags(ctx).map_err(map_push_rejected)?;
+    ctx.remove_pending_ops(&queued_ids).map_err(map_queue)?;
+    Ok("pushed")
+}
+
+pub(crate) fn sync_replay_internal(
+    ctx: &AppContext,
+) -> std::result::Result<&'static str, CommandFailure> {
+    let pending = ctx.pending_count().map_err(map_io)?;
+    if pending == 0 {
+        return Ok("no_pending_ops");
+    }
+    sync_push_internal(ctx)?;
+    Ok("replayed")
 }

--- a/src/commands/target_cmds.rs
+++ b/src/commands/target_cmds.rs
@@ -12,9 +12,9 @@ use crate::types::ErrorCode;
 
 use super::helpers::{
     agent_kind_as_str, commit_registry_state, map_io, map_lock, map_registry_state,
-    maybe_autosync_or_queue, record_registry_operation, target_capabilities,
-    target_ownership_as_str, unique_target_id,
+    target_capabilities, target_ownership_as_str, unique_target_id,
 };
+use super::projections::{maybe_autosync_or_queue, record_registry_operation};
 use super::{App, CommandFailure};
 
 impl App {

--- a/src/commands/trash_cmds.rs
+++ b/src/commands/trash_cmds.rs
@@ -14,11 +14,13 @@ use crate::state::remove_path_if_exists;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
+use super::file_ops::{backup_path_if_exists, restore_path_from_backup};
 use super::helpers::{
-    RegistryAuditStateBackup, backup_path_if_exists, map_arg, map_git, map_io, map_lock,
-    map_registry_state, maybe_autosync_or_queue, record_registry_operation,
-    restore_path_from_backup, restore_registry_audit_state, slugify, snapshot_registry_audit_state,
-    validate_skill_name,
+    map_arg, map_git, map_io, map_lock, map_registry_state, slugify, validate_skill_name,
+};
+use super::projections::{
+    RegistryAuditStateBackup, maybe_autosync_or_queue, record_registry_operation,
+    restore_registry_audit_state, snapshot_registry_audit_state,
 };
 use super::{App, CommandFailure};
 

--- a/src/commands/trash_cmds.rs
+++ b/src/commands/trash_cmds.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 
 use crate::cli::{TrashAddArgs, TrashPurgeArgs, TrashRestoreArgs};
 use crate::envelope::Meta;
+use crate::fs_util::remove_path_if_exists;
 use crate::gitops;
-use crate::state::remove_path_if_exists;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -10,10 +10,13 @@ use crate::gitops;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
+use super::file_ops::{backup_path_if_exists, restore_path_from_backup};
 use super::helpers::{
-    backup_path_if_exists, commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock,
-    map_registry_state, maybe_autosync_or_queue, record_registry_observation,
-    record_registry_operation, restore_path_from_backup, validate_skill_name,
+    commit_registry_state, ensure_skill_exists, map_arg, map_git, map_lock, map_registry_state,
+    validate_skill_name,
+};
+use super::projections::{
+    maybe_autosync_or_queue, record_registry_observation, record_registry_operation,
 };
 use super::{App, CommandFailure};
 

--- a/src/commands/version_cmds.rs
+++ b/src/commands/version_cmds.rs
@@ -420,7 +420,7 @@ fn restore_path_best_effort(
         }
     } else {
         if !maybe_push_rollback_fault(&mut errors, remove_step)
-            && let Err(err) = crate::state::remove_path_if_exists(path)
+            && let Err(err) = crate::fs_util::remove_path_if_exists(path)
         {
             push_rollback_error(&mut errors, remove_step, err);
         }
@@ -465,7 +465,7 @@ fn restore_registry_layout_best_effort(
         }
     } else {
         if !maybe_push_rollback_fault(&mut errors, "remove_registry_layout")
-            && let Err(err) = crate::state::remove_path_if_exists(&paths.registry_dir)
+            && let Err(err) = crate::fs_util::remove_path_if_exists(&paths.registry_dir)
         {
             push_rollback_error(&mut errors, "remove_registry_layout", err);
         }
@@ -531,7 +531,7 @@ fn remove_backup_path_best_effort(backup: Option<&serde_json::Value>) {
     else {
         return;
     };
-    let _ = crate::state::remove_path_if_exists(path);
+    let _ = crate::fs_util::remove_path_if_exists(path);
     if let Some(parent) = path.parent() {
         let _ = fs::remove_dir(parent);
         if let Some(grandparent) = parent.parent() {

--- a/src/commands/watch_cmds.rs
+++ b/src/commands/watch_cmds.rs
@@ -8,9 +8,9 @@ use serde_json::{Value, json};
 
 use crate::cli::WatchArgs;
 use crate::envelope::Meta;
+use crate::fs_util::remove_path_if_exists;
 use crate::gitops;
 use crate::state::AppContext;
-use crate::state::remove_path_if_exists;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 

--- a/src/commands/watch_cmds.rs
+++ b/src/commands/watch_cmds.rs
@@ -14,10 +14,10 @@ use crate::state::remove_path_if_exists;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
-use super::helpers::{
-    RegistryAuditStateBackup, map_arg, map_git, map_io, map_lock, map_registry_state,
-    record_registry_operation, restore_registry_audit_state, snapshot_registry_audit_state,
-    validate_skill_name,
+use super::helpers::{map_arg, map_git, map_io, map_lock, map_registry_state, validate_skill_name};
+use super::projections::{
+    RegistryAuditStateBackup, record_registry_operation, restore_registry_audit_state,
+    snapshot_registry_audit_state,
 };
 use super::{App, CommandFailure};
 use walkdir::WalkDir;

--- a/src/commands/workspace_cmds/binding.rs
+++ b/src/commands/workspace_cmds/binding.rs
@@ -10,10 +10,10 @@ use crate::state_model::{RegistryWorkspaceBinding, RegistryWorkspaceMatcher};
 use crate::types::ErrorCode;
 
 use super::super::helpers::{
-    agent_kind_as_str, commit_registry_state, map_lock, map_registry_state,
-    maybe_autosync_or_queue, record_registry_operation, unique_binding_id, validate_non_empty,
-    validate_policy_profile, workspace_matcher_kind_as_str,
+    agent_kind_as_str, commit_registry_state, map_lock, map_registry_state, unique_binding_id,
+    validate_non_empty, validate_policy_profile, workspace_matcher_kind_as_str,
 };
+use super::super::projections::{maybe_autosync_or_queue, record_registry_operation};
 use super::super::{App, CommandFailure};
 
 impl App {

--- a/src/commands/workspace_cmds/init.rs
+++ b/src/commands/workspace_cmds/init.rs
@@ -5,9 +5,8 @@ use crate::envelope::Meta;
 use crate::state::home_dir;
 use crate::types::ErrorCode;
 
-use super::super::helpers::{
-    agent_kind_as_str, commit_registry_state, map_lock, maybe_autosync_or_queue,
-};
+use super::super::helpers::{agent_kind_as_str, commit_registry_state, map_lock};
+use super::super::projections::maybe_autosync_or_queue;
 use super::super::{App, CommandFailure};
 use super::shared::{DEFAULT_SCAN_AGENTS, default_skill_dir};
 

--- a/src/commands/workspace_cmds/orphan.rs
+++ b/src/commands/workspace_cmds/orphan.rs
@@ -9,7 +9,8 @@ use crate::cli::OrphanCleanArgs;
 use crate::envelope::Meta;
 use crate::state_model::RegistryProjectionInstance;
 
-use super::super::helpers::{map_io, map_registry_state, record_registry_operation};
+use super::super::helpers::{map_io, map_registry_state};
+use super::super::projections::record_registry_operation;
 use super::super::{App, CommandFailure};
 
 pub(super) enum LivePathCleanup {

--- a/src/commands/workspace_cmds/remote.rs
+++ b/src/commands/workspace_cmds/remote.rs
@@ -5,7 +5,8 @@ use crate::envelope::Meta;
 use crate::gitops;
 use crate::types::ErrorCode;
 
-use super::super::helpers::{map_git, map_lock, remote_status_payload};
+use super::super::helpers::{map_git, map_lock};
+use super::super::projections::remote_status_payload;
 use super::super::{App, CommandFailure};
 
 impl App {

--- a/src/commands/workspace_cmds/status.rs
+++ b/src/commands/workspace_cmds/status.rs
@@ -5,10 +5,9 @@ use crate::state::resolve_agent_skill_dirs;
 use crate::state_model::RegistryStatePaths;
 use crate::types::ErrorCode;
 
-use super::super::helpers::{
-    collect_skill_inventory, map_io, map_registry_state, read_git_field,
-    remote_status_payload_with_pending,
-};
+use super::super::file_ops::read_git_field;
+use super::super::helpers::{map_io, map_registry_state};
+use super::super::projections::{collect_skill_inventory, remote_status_payload_with_pending};
 use super::super::{App, CommandFailure};
 
 impl App {

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -4,9 +4,12 @@
 //! destination path already exists. Every atomic-overwrite path (write-to-tmp
 //! then replace) must use [`rename_atomic`] instead of `std::fs::rename`.
 
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::Path;
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 
 /// Atomically replace `dst` with `src`.
 ///
@@ -48,6 +51,119 @@ pub fn write_atomic(path: &Path, contents: &str) -> io::Result<()> {
     }
 
     rename_atomic(&tmp_path, path)
+}
+
+/// Append newline-terminated records and sync the file.
+pub fn append_lines(path: &Path, lines: &[String]) -> io::Result<()> {
+    if lines.is_empty() {
+        return Ok(());
+    }
+
+    let mut file = open_append_file(path)?;
+    for line in lines {
+        let mut record = Vec::with_capacity(line.len() + 1);
+        record.extend_from_slice(line.as_bytes());
+        record.push(b'\n');
+        append_single_record_write(&mut file, &record)?;
+    }
+    file.sync_all()
+}
+
+/// Append one pre-serialized JSONL record and sync the file.
+pub fn append_jsonl_raw(path: &Path, raw: &str) -> io::Result<()> {
+    let mut file = open_append_file(path)?;
+    let mut record = Vec::with_capacity(raw.len() + 1);
+    record.extend_from_slice(raw.as_bytes());
+    record.push(b'\n');
+    append_single_record_write(&mut file, &record)?;
+    file.sync_all()
+}
+
+/// Ensure an append-only log file exists and is synced to disk.
+pub fn ensure_append_log(path: &Path) -> io::Result<()> {
+    open_append_file(path)?.sync_all()
+}
+
+pub fn maybe_fault_inject(tag: &str) -> io::Result<()> {
+    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
+        return Err(io::Error::other(format!("fault injected at {}", tag)));
+    }
+    Ok(())
+}
+
+pub fn maybe_fault_inject_any(tags: &[&str]) -> io::Result<()> {
+    let active = std::env::var("LOOM_FAULT_INJECT").ok();
+    if let Some(tag) = active.as_deref().filter(|tag| tags.contains(tag)) {
+        return Err(io::Error::other(format!("fault injected at {}", tag)));
+    }
+    Ok(())
+}
+
+pub fn remove_path_if_exists(path: &Path) -> io::Result<()> {
+    let meta = match fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    if meta.file_type().is_symlink() || meta.is_file() {
+        fs::remove_file(path)
+    } else {
+        fs::remove_dir_all(path)
+    }
+}
+
+fn open_append_file(path: &Path) -> io::Result<File> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "cannot append file without parent directory",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+#[cfg(unix)]
+fn append_single_record_write(file: &mut File, record: &[u8]) -> io::Result<()> {
+    if record.len() > isize::MAX as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "append record exceeds write size limit",
+        ));
+    }
+
+    loop {
+        // SAFETY: `record` points to a valid immutable byte buffer for
+        // `record.len()` bytes, and `file.as_raw_fd()` is an open descriptor
+        // owned by `file`.
+        let written =
+            unsafe { libc::write(file.as_raw_fd(), record.as_ptr().cast(), record.len()) };
+        if written < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+
+        let written = written as usize;
+        if written == record.len() {
+            return Ok(());
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!(
+                "short append record write: wrote {} of {} bytes",
+                written,
+                record.len()
+            ),
+        ));
+    }
+}
+
+#[cfg(not(unix))]
+fn append_single_record_write(file: &mut File, record: &[u8]) -> io::Result<()> {
+    file.write_all(record)
 }
 
 #[cfg(windows)]
@@ -145,5 +261,31 @@ mod tests {
             "temp file should be renamed away"
         );
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_jsonl_raw_creates_parent_and_syncs_line() -> std::io::Result<()> {
+        let dir = temp_dir("append-jsonl");
+        let path = dir.join("nested/events.jsonl");
+
+        append_jsonl_raw(&path, r#"{"event":"one"}"#)?;
+        append_jsonl_raw(&path, r#"{"event":"two"}"#)?;
+
+        assert_eq!(
+            fs::read_to_string(&path)?,
+            "{\"event\":\"one\"}\n{\"event\":\"two\"}\n"
+        );
+        fs::remove_dir_all(&dir)
+    }
+
+    #[test]
+    fn append_lines_writes_each_line_once() -> std::io::Result<()> {
+        let dir = temp_dir("append-lines");
+        let path = dir.join("pending.jsonl");
+
+        append_lines(&path, &["a".to_string(), "b".to_string()])?;
+
+        assert_eq!(fs::read_to_string(&path)?, "a\nb\n");
+        fs::remove_dir_all(&dir)
     }
 }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -4,7 +4,8 @@
 //! destination path already exists. Every atomic-overwrite path (write-to-tmp
 //! then replace) must use [`rename_atomic`] instead of `std::fs::rename`.
 
-use std::io;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
 use std::path::Path;
 
 /// Atomically replace `dst` with `src`.
@@ -19,6 +20,34 @@ pub fn rename_atomic(src: &Path, dst: &Path) -> io::Result<()> {
 
     #[cfg(not(windows))]
     std::fs::rename(src, dst)
+}
+
+/// Write contents through a temp file and atomically replace the destination.
+pub fn write_atomic(path: &Path, contents: &str) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "cannot write atomic file without parent directory",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let tmp_path = parent.join(format!(
+        ".{}.tmp-{}",
+        path.file_name().unwrap_or_default().to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+
+    {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&tmp_path)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+    }
+
+    rename_atomic(&tmp_path, path)
 }
 
 #[cfg(windows)]
@@ -95,6 +124,26 @@ mod tests {
 
         assert!(!src.exists());
         assert_eq!(fs::read(&dst).unwrap(), b"hello");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_atomic_replaces_existing_file() {
+        let dir = temp_dir("write-atomic");
+        let dst = dir.join("state.json");
+
+        fs::write(&dst, b"old").unwrap();
+        write_atomic(&dst, "new\n").expect("write_atomic must replace existing file");
+
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "new\n");
+        assert!(
+            fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains(".tmp-")),
+            "temp file should be renamed away"
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src/gitops/history.rs
+++ b/src/gitops/history.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::Path;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use serde::Serialize;
 use serde_json::json;
@@ -408,5 +409,37 @@ pub fn mirror_history_segment(
     )?;
     let expected_old = base.as_ref().map(|state| state.commit.as_str());
     update_ref(ctx, HISTORY_BRANCH_REF, &commit, expected_old)?;
+    Ok(())
+}
+
+pub fn mirror_pending_ops_history(ctx: &AppContext) -> Result<()> {
+    if !repo_is_initialized(ctx)? {
+        return Ok(());
+    }
+
+    let entries = match fs::read_dir(&ctx.pending_ops_history_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err).context("failed to read pending ops history dir"),
+    };
+
+    let mut segments = Vec::new();
+    for entry in entries {
+        let entry = entry.context("failed to read pending ops history entry")?;
+        if entry
+            .file_type()
+            .with_context(|| format!("failed to inspect {}", entry.path().display()))?
+            .is_file()
+        {
+            segments.push(entry.path());
+        }
+    }
+    segments.sort();
+
+    for segment_path in segments {
+        mirror_history_segment(ctx, &segment_path, &ctx.pending_ops_snapshot_file)
+            .context("failed to mirror pending ops history into git")?;
+    }
+
     Ok(())
 }

--- a/src/gitops/history.rs
+++ b/src/gitops/history.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use serde::Serialize;
 use serde_json::json;
 
 use crate::state::AppContext;
@@ -23,90 +22,7 @@ use super::history_impl::{
     detect_history_conflicts, history_tree_entries, load_history_branch_state,
     synthesize_history_snapshot_blob, update_ref,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HistoryRepairStrategy {
-    Local,
-    Remote,
-}
-
-impl HistoryRepairStrategy {
-    pub(super) fn as_str(self) -> &'static str {
-        match self {
-            Self::Local => "local",
-            Self::Remote => "remote",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Default)]
-pub struct HistoryStatusReport {
-    pub local_branch: bool,
-    pub remote_tracking: bool,
-    pub ahead: u32,
-    pub behind: u32,
-    pub local_segments: usize,
-    pub local_archives: usize,
-    pub remote_segments: usize,
-    pub remote_archives: usize,
-    pub local_snapshot: bool,
-    pub remote_snapshot: bool,
-    pub compact_after_segments: usize,
-    pub retain_recent_segments: usize,
-    pub retain_archives: usize,
-    pub conflicts: Vec<HistoryConflictReport>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct HistoryConflictReport {
-    pub scope: String,
-    pub path: String,
-    pub local_blob: String,
-    pub remote_blob: String,
-    pub local_rename_path: String,
-    pub remote_rename_path: String,
-}
-
-#[derive(Debug, Clone, Serialize, Default)]
-pub struct HistoryRepairReport {
-    pub result: String,
-    pub strategy: String,
-    pub commit: Option<String>,
-    pub repaired_conflicts: usize,
-    pub compacted_segments: usize,
-    pub rolled_archives: usize,
-    pub local_segments: usize,
-    pub local_archives: usize,
-    pub local_snapshot: bool,
-    pub conflicts: Vec<HistoryConflictReport>,
-}
-
-impl HistoryRepairReport {
-    pub(crate) fn noop(strategy: HistoryRepairStrategy) -> Self {
-        Self {
-            result: "noop".to_string(),
-            strategy: strategy.as_str().to_string(),
-            ..Self::default()
-        }
-    }
-
-    pub(crate) fn from_status(
-        result: impl Into<String>,
-        strategy: HistoryRepairStrategy,
-        commit: Option<String>,
-        status: &HistoryStatusReport,
-    ) -> Self {
-        Self {
-            result: result.into(),
-            strategy: strategy.as_str().to_string(),
-            commit,
-            local_segments: status.local_segments,
-            local_archives: status.local_archives,
-            local_snapshot: status.local_snapshot,
-            ..Self::default()
-        }
-    }
-}
+use super::history_types::{HistoryRepairReport, HistoryRepairStrategy, HistoryStatusReport};
 
 pub fn history_status(ctx: &AppContext) -> Result<HistoryStatusReport> {
     if !repo_is_initialized(ctx)? {

--- a/src/gitops/history.rs
+++ b/src/gitops/history.rs
@@ -66,7 +66,7 @@ pub struct HistoryConflictReport {
     pub remote_rename_path: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct HistoryRepairReport {
     pub result: String,
     pub strategy: String,
@@ -78,6 +78,33 @@ pub struct HistoryRepairReport {
     pub local_archives: usize,
     pub local_snapshot: bool,
     pub conflicts: Vec<HistoryConflictReport>,
+}
+
+impl HistoryRepairReport {
+    pub(crate) fn noop(strategy: HistoryRepairStrategy) -> Self {
+        Self {
+            result: "noop".to_string(),
+            strategy: strategy.as_str().to_string(),
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn from_status(
+        result: impl Into<String>,
+        strategy: HistoryRepairStrategy,
+        commit: Option<String>,
+        status: &HistoryStatusReport,
+    ) -> Self {
+        Self {
+            result: result.into(),
+            strategy: strategy.as_str().to_string(),
+            commit,
+            local_segments: status.local_segments,
+            local_archives: status.local_archives,
+            local_snapshot: status.local_snapshot,
+            ..Self::default()
+        }
+    }
 }
 
 pub fn history_status(ctx: &AppContext) -> Result<HistoryStatusReport> {
@@ -205,18 +232,7 @@ pub fn repair_history_branch(
     strategy: HistoryRepairStrategy,
 ) -> Result<HistoryRepairReport> {
     if !repo_is_initialized(ctx)? {
-        return Ok(HistoryRepairReport {
-            result: "noop".to_string(),
-            strategy: strategy.as_str().to_string(),
-            commit: None,
-            repaired_conflicts: 0,
-            compacted_segments: 0,
-            rolled_archives: 0,
-            local_segments: 0,
-            local_archives: 0,
-            local_snapshot: false,
-            conflicts: Vec::new(),
-        });
+        return Ok(HistoryRepairReport::noop(strategy));
     }
 
     let remote_history_exists = if remote_exists(ctx) {
@@ -232,33 +248,16 @@ pub fn repair_history_branch(
     };
 
     match (local, remote) {
-        (None, None) => Ok(HistoryRepairReport {
-            result: "noop".to_string(),
-            strategy: strategy.as_str().to_string(),
-            commit: None,
-            repaired_conflicts: 0,
-            compacted_segments: 0,
-            rolled_archives: 0,
-            local_segments: 0,
-            local_archives: 0,
-            local_snapshot: false,
-            conflicts: Vec::new(),
-        }),
+        (None, None) => Ok(HistoryRepairReport::noop(strategy)),
         (None, Some(remote)) => {
             update_ref(ctx, HISTORY_BRANCH_REF, &remote.commit, None)?;
             let status = history_status(ctx)?;
-            Ok(HistoryRepairReport {
-                result: "created_from_remote".to_string(),
-                strategy: strategy.as_str().to_string(),
-                commit: Some(remote.commit),
-                repaired_conflicts: 0,
-                compacted_segments: 0,
-                rolled_archives: 0,
-                local_segments: status.local_segments,
-                local_archives: status.local_archives,
-                local_snapshot: status.local_snapshot,
-                conflicts: Vec::new(),
-            })
+            Ok(HistoryRepairReport::from_status(
+                "created_from_remote",
+                strategy,
+                Some(remote.commit),
+                &status,
+            ))
         }
         (Some(local), None) => compact_local_history_branch(ctx, &local, strategy),
         (Some(local), Some(remote)) => {
@@ -266,18 +265,12 @@ pub fn repair_history_branch(
             if ahead == 0 && behind > 0 {
                 update_ref(ctx, HISTORY_BRANCH_REF, &remote.commit, Some(&local.commit))?;
                 let status = history_status(ctx)?;
-                return Ok(HistoryRepairReport {
-                    result: "fast_forwarded_from_remote".to_string(),
-                    strategy: strategy.as_str().to_string(),
-                    commit: Some(remote.commit),
-                    repaired_conflicts: 0,
-                    compacted_segments: 0,
-                    rolled_archives: 0,
-                    local_segments: status.local_segments,
-                    local_archives: status.local_archives,
-                    local_snapshot: status.local_snapshot,
-                    conflicts: Vec::new(),
-                });
+                return Ok(HistoryRepairReport::from_status(
+                    "fast_forwarded_from_remote",
+                    strategy,
+                    Some(remote.commit),
+                    &status,
+                ));
             }
             if ahead == 0 && behind == 0 {
                 return compact_local_history_branch(ctx, &local, strategy);
@@ -298,18 +291,13 @@ pub fn repair_history_branch(
             update_ref(ctx, HISTORY_BRANCH_REF, &commit, Some(&local.commit))?;
             let status = history_status(ctx)?;
 
-            Ok(HistoryRepairReport {
-                result: "repaired".to_string(),
-                strategy: strategy.as_str().to_string(),
-                commit: Some(commit),
-                repaired_conflicts: conflicts.len(),
-                compacted_segments: composed.retention.compacted_segments,
-                rolled_archives: composed.retention.rolled_archives,
-                local_segments: status.local_segments,
-                local_archives: status.local_archives,
-                local_snapshot: status.local_snapshot,
-                conflicts,
-            })
+            let mut report =
+                HistoryRepairReport::from_status("repaired", strategy, Some(commit), &status);
+            report.repaired_conflicts = conflicts.len();
+            report.compacted_segments = composed.retention.compacted_segments;
+            report.rolled_archives = composed.retention.rolled_archives;
+            report.conflicts = conflicts;
+            Ok(report)
         }
     }
 }

--- a/src/gitops/history_impl.rs
+++ b/src/gitops/history_impl.rs
@@ -13,9 +13,7 @@ use super::{
     run_git_allow_failure, run_git_in_with_env,
 };
 
-use super::history::{
-    HistoryConflictReport, HistoryRepairReport, HistoryRepairStrategy, history_status,
-};
+use super::history_types::{HistoryConflictReport, HistoryRepairReport, HistoryRepairStrategy};
 
 #[derive(Debug, Clone)]
 pub(super) struct HistoryBranchState {
@@ -446,9 +444,13 @@ pub(super) fn compact_local_history_branch(
     let composed = compose_history_state(ctx, local, None, None)?;
     let new_tree = build_tree_from_entries(ctx, &history_tree_entries(&composed))?;
     if !composed.retention.changed() || new_tree == local.tree {
-        let status = history_status(ctx)?;
-        return Ok(HistoryRepairReport::from_status(
-            "noop", strategy, None, &status,
+        return Ok(HistoryRepairReport::from_counts(
+            "noop",
+            strategy,
+            None,
+            composed.segments.len(),
+            composed.archives.len(),
+            true,
         ));
     }
 
@@ -459,9 +461,15 @@ pub(super) fn compact_local_history_branch(
         "Compact loom-history retention",
     )?;
     update_ref(ctx, HISTORY_BRANCH_REF, &commit, Some(&local.commit))?;
-    let status = history_status(ctx)?;
 
-    let mut report = HistoryRepairReport::from_status("compacted", strategy, Some(commit), &status);
+    let mut report = HistoryRepairReport::from_counts(
+        "compacted",
+        strategy,
+        Some(commit),
+        composed.segments.len(),
+        composed.archives.len(),
+        true,
+    );
     report.compacted_segments = composed.retention.compacted_segments;
     report.rolled_archives = composed.retention.rolled_archives;
     Ok(report)

--- a/src/gitops/history_impl.rs
+++ b/src/gitops/history_impl.rs
@@ -3,9 +3,8 @@ use std::path::Path;
 
 use anyhow::{Result, anyhow};
 
-use crate::state::{
-    AppContext, summarize_history_body, synthesize_snapshot_raw_from_segment_bodies,
-};
+use crate::state::AppContext;
+use crate::state::journal::{summarize_history_body, synthesize_snapshot_raw_from_segment_bodies};
 
 use super::{
     EMPTY_TREE_SHA, HISTORY_ARCHIVES_DIR, HISTORY_BRANCH_REF, HISTORY_COMPACT_AFTER_SEGMENTS,

--- a/src/gitops/history_impl.rs
+++ b/src/gitops/history_impl.rs
@@ -448,18 +448,9 @@ pub(super) fn compact_local_history_branch(
     let new_tree = build_tree_from_entries(ctx, &history_tree_entries(&composed))?;
     if !composed.retention.changed() || new_tree == local.tree {
         let status = history_status(ctx)?;
-        return Ok(HistoryRepairReport {
-            result: "noop".to_string(),
-            strategy: strategy.as_str().to_string(),
-            commit: None,
-            repaired_conflicts: 0,
-            compacted_segments: 0,
-            rolled_archives: 0,
-            local_segments: status.local_segments,
-            local_archives: status.local_archives,
-            local_snapshot: status.local_snapshot,
-            conflicts: Vec::new(),
-        });
+        return Ok(HistoryRepairReport::from_status(
+            "noop", strategy, None, &status,
+        ));
     }
 
     let commit = create_commit_tree(
@@ -471,18 +462,10 @@ pub(super) fn compact_local_history_branch(
     update_ref(ctx, HISTORY_BRANCH_REF, &commit, Some(&local.commit))?;
     let status = history_status(ctx)?;
 
-    Ok(HistoryRepairReport {
-        result: "compacted".to_string(),
-        strategy: strategy.as_str().to_string(),
-        commit: Some(commit),
-        repaired_conflicts: 0,
-        compacted_segments: composed.retention.compacted_segments,
-        rolled_archives: composed.retention.rolled_archives,
-        local_segments: status.local_segments,
-        local_archives: status.local_archives,
-        local_snapshot: status.local_snapshot,
-        conflicts: Vec::new(),
-    })
+    let mut report = HistoryRepairReport::from_status("compacted", strategy, Some(commit), &status);
+    report.compacted_segments = composed.retention.compacted_segments;
+    report.rolled_archives = composed.retention.rolled_archives;
+    Ok(report)
 }
 
 fn join_history_bodies<'a>(bodies: impl IntoIterator<Item = &'a str>) -> String {

--- a/src/gitops/history_types.rs
+++ b/src/gitops/history_types.rs
@@ -1,0 +1,103 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistoryRepairStrategy {
+    Local,
+    Remote,
+}
+
+impl HistoryRepairStrategy {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Remote => "remote",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct HistoryStatusReport {
+    pub local_branch: bool,
+    pub remote_tracking: bool,
+    pub ahead: u32,
+    pub behind: u32,
+    pub local_segments: usize,
+    pub local_archives: usize,
+    pub remote_segments: usize,
+    pub remote_archives: usize,
+    pub local_snapshot: bool,
+    pub remote_snapshot: bool,
+    pub compact_after_segments: usize,
+    pub retain_recent_segments: usize,
+    pub retain_archives: usize,
+    pub conflicts: Vec<HistoryConflictReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HistoryConflictReport {
+    pub scope: String,
+    pub path: String,
+    pub local_blob: String,
+    pub remote_blob: String,
+    pub local_rename_path: String,
+    pub remote_rename_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct HistoryRepairReport {
+    pub result: String,
+    pub strategy: String,
+    pub commit: Option<String>,
+    pub repaired_conflicts: usize,
+    pub compacted_segments: usize,
+    pub rolled_archives: usize,
+    pub local_segments: usize,
+    pub local_archives: usize,
+    pub local_snapshot: bool,
+    pub conflicts: Vec<HistoryConflictReport>,
+}
+
+impl HistoryRepairReport {
+    pub(crate) fn noop(strategy: HistoryRepairStrategy) -> Self {
+        Self {
+            result: "noop".to_string(),
+            strategy: strategy.as_str().to_string(),
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn from_status(
+        result: impl Into<String>,
+        strategy: HistoryRepairStrategy,
+        commit: Option<String>,
+        status: &HistoryStatusReport,
+    ) -> Self {
+        Self::from_counts(
+            result,
+            strategy,
+            commit,
+            status.local_segments,
+            status.local_archives,
+            status.local_snapshot,
+        )
+    }
+
+    pub(crate) fn from_counts(
+        result: impl Into<String>,
+        strategy: HistoryRepairStrategy,
+        commit: Option<String>,
+        local_segments: usize,
+        local_archives: usize,
+        local_snapshot: bool,
+    ) -> Self {
+        Self {
+            result: result.into(),
+            strategy: strategy.as_str().to_string(),
+            commit,
+            local_segments,
+            local_archives,
+            local_snapshot,
+            ..Self::default()
+        }
+    }
+}

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -1,9 +1,11 @@
 mod diff;
 mod history;
 mod history_impl;
+mod history_types;
 
 pub use diff::*;
 pub use history::*;
+pub use history_types::*;
 
 use std::fs::{self, OpenOptions};
 use std::io::Write;

--- a/src/panel/handlers/ops.rs
+++ b/src/panel/handlers/ops.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 
 use crate::cli::{Command, HistoryRepairStrategyArg, OpsCommand, OpsHistoryCommand};
 use crate::envelope::Envelope;
+use crate::gitops;
 use crate::state::OpsAuditOperation;
 use crate::state_model::RegistryOperationRecord;
 use crate::types::ErrorCode;
@@ -28,7 +29,18 @@ pub(in crate::panel) async fn v1_registry_ops(
 ) -> (StatusCode, Json<serde_json::Value>) {
     match load_registry_snapshot(&state.ctx, "registry.ops") {
         Ok(snapshot) => {
-            let audit_report = match state.ctx.read_ops_audit_report() {
+            let (history_bodies, history_warnings) =
+                match gitops::history_journal_bodies(&state.ctx) {
+                    Ok(bodies) => (bodies, Vec::new()),
+                    Err(err) => (
+                        Vec::new(),
+                        vec![format!("failed to read loom-history branch: {}", err)],
+                    ),
+                };
+            let audit_report = match state
+                .ctx
+                .read_ops_audit_report_with_history(history_bodies, history_warnings)
+            {
                 Ok(report) => report,
                 Err(err) => {
                     let request_id = uuid::Uuid::new_v4().to_string();

--- a/src/state/journal.rs
+++ b/src/state/journal.rs
@@ -1,0 +1,192 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::types::PendingOp;
+
+pub(super) const OPS_SNAPSHOT_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub(super) enum OpJournalEvent {
+    Queued {
+        event_id: String,
+        at: DateTime<Utc>,
+        op: PendingOp,
+    },
+    Audited {
+        event_id: String,
+        at: DateTime<Utc>,
+        op: PendingOp,
+    },
+    Removed {
+        event_id: String,
+        at: DateTime<Utc>,
+        op_id: String,
+        reason: String,
+    },
+}
+
+impl OpJournalEvent {
+    pub(super) fn event_id(&self) -> &str {
+        match self {
+            Self::Queued { event_id, .. }
+            | Self::Audited { event_id, .. }
+            | Self::Removed { event_id, .. } => event_id,
+        }
+    }
+
+    pub(super) fn at(&self) -> DateTime<Utc> {
+        match self {
+            Self::Queued { at, .. } | Self::Audited { at, .. } | Self::Removed { at, .. } => *at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct OpsSnapshot {
+    pub(super) version: u32,
+    pub(super) created_at: DateTime<Utc>,
+    pub(super) history_events: usize,
+    pub(super) active_ops: Vec<PendingOp>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HistoryBodySummary {
+    pub first_at: Option<DateTime<Utc>>,
+    pub last_at: Option<DateTime<Utc>>,
+}
+
+pub(crate) fn synthesize_snapshot_raw_from_segment_bodies(
+    segment_bodies: &[String],
+) -> Result<String> {
+    let mut seen_event_ids = std::collections::BTreeSet::new();
+    let mut ordered_events = Vec::new();
+
+    for body in segment_bodies {
+        for line in body.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let event = parse_journal_line(trimmed)?;
+            let event_id = event.event_id().to_string();
+            if !seen_event_ids.insert(event_id.clone()) {
+                continue;
+            }
+            ordered_events.push((event.at(), event_id, event));
+        }
+    }
+
+    ordered_events.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    let mut active_ops = BTreeMap::new();
+    for (_, _, event) in ordered_events {
+        apply_journal_event(&mut active_ops, event);
+    }
+
+    let snapshot = OpsSnapshot {
+        version: OPS_SNAPSHOT_VERSION,
+        created_at: Utc::now(),
+        history_events: seen_event_ids.len(),
+        active_ops: active_ops.into_values().collect(),
+    };
+
+    serde_json::to_string_pretty(&snapshot).context("failed to encode synthesized ops snapshot")
+}
+
+pub(crate) fn summarize_history_body(raw: &str) -> Result<HistoryBodySummary> {
+    let mut first_at = None;
+    let mut last_at = None;
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event = parse_journal_line(trimmed)?;
+        let at = event.at();
+        first_at = Some(first_at.map_or(at, |current: DateTime<Utc>| current.min(at)));
+        last_at = Some(last_at.map_or(at, |current: DateTime<Utc>| current.max(at)));
+    }
+
+    Ok(HistoryBodySummary { first_at, last_at })
+}
+
+pub(super) fn parse_journal_line(line: &str) -> Result<OpJournalEvent> {
+    if let Ok(event) = serde_json::from_str::<OpJournalEvent>(line) {
+        return Ok(event);
+    }
+
+    let mut op = serde_json::from_str::<PendingOp>(line)
+        .context("line is neither a journal event nor a pending op")?;
+    if op.op_id.is_none() {
+        op.op_id = Some(op.stable_id());
+    }
+    Ok(OpJournalEvent::Queued {
+        event_id: format!("legacy-{}", op.stable_id()),
+        at: op.created_at,
+        op,
+    })
+}
+
+pub(super) fn journal_segment_name(raw_journal: &str) -> Result<String> {
+    let mut ids = Vec::new();
+    let mut non_empty = 0usize;
+
+    for (index, line) in raw_journal.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        non_empty += 1;
+        match parse_journal_line(trimmed) {
+            Ok(event) => ids.push(sanitize_segment_token(event.event_id())),
+            Err(_) => ids.push(format!("invalid{}-{}", index + 1, trimmed.len())),
+        }
+    }
+
+    if non_empty == 0 {
+        anyhow::bail!("cannot name empty journal segment");
+    }
+
+    let first = ids.first().cloned().unwrap_or_else(|| "empty".to_string());
+    let last = ids.last().cloned().unwrap_or_else(|| "empty".to_string());
+    Ok(format!(
+        "{:05}-{}-{}.jsonl",
+        non_empty,
+        shorten_segment_token(&first),
+        shorten_segment_token(&last)
+    ))
+}
+
+pub(super) fn apply_journal_event(
+    active_ops: &mut BTreeMap<String, PendingOp>,
+    event: OpJournalEvent,
+) {
+    match event {
+        OpJournalEvent::Queued { mut op, .. } => {
+            if op.op_id.is_none() {
+                op.op_id = Some(op.stable_id());
+            }
+            active_ops.insert(op.stable_id(), op);
+        }
+        OpJournalEvent::Audited { .. } => {}
+        OpJournalEvent::Removed { op_id, .. } => {
+            active_ops.remove(&op_id);
+        }
+    }
+}
+
+fn sanitize_segment_token(token: &str) -> String {
+    token
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}
+
+fn shorten_segment_token(token: &str) -> String {
+    token.chars().take(12).collect()
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,10 +1,8 @@
+pub(crate) mod journal;
 mod lock;
 mod ops;
 
-pub use ops::{
-    OpsAuditOperation, remove_path_if_exists, summarize_history_body,
-    synthesize_snapshot_raw_from_segment_bodies,
-};
+pub use ops::OpsAuditOperation;
 
 use lock::{LockMetadata, acquire_lock_coordinator, lock_file_matches_owner, try_reap_stale_lock};
 
@@ -34,6 +32,7 @@ pub struct AppContext {
     pub pending_ops_file: PathBuf,
     pub pending_ops_history_dir: PathBuf,
     pub pending_ops_snapshot_file: PathBuf,
+    pub command_events_file: PathBuf,
     in_proc: InProcMap,
 }
 
@@ -219,6 +218,7 @@ impl AppContext {
         let pending_ops_file = state_dir.join("pending_ops.jsonl");
         let pending_ops_history_dir = state_dir.join("pending_ops_history");
         let pending_ops_snapshot_file = state_dir.join("pending_ops_snapshot.json");
+        let command_events_file = state_dir.join("events/commands.jsonl");
 
         Ok(Self {
             root,
@@ -228,6 +228,7 @@ impl AppContext {
             pending_ops_file,
             pending_ops_history_dir,
             pending_ops_snapshot_file,
+            command_events_file,
             in_proc: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -458,29 +459,6 @@ fn ensure_file_with_contents(path: &Path, contents: &str) -> Result<()> {
     write_atomic(path, contents).with_context(|| format!("failed to initialize {}", path.display()))
 }
 
-fn append_lines(path: &Path, lines: &[String]) -> Result<()> {
-    if lines.is_empty() {
-        return Ok(());
-    }
-    let parent = path
-        .parent()
-        .context("cannot append file without parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
-    for line in lines {
-        writeln!(file, "{}", line)
-            .with_context(|| format!("failed to append {}", path.display()))?;
-    }
-    file.sync_all()
-        .with_context(|| format!("failed to sync {}", path.display()))?;
-    Ok(())
-}
-
 fn write_history_segment_if_missing(path: &Path, raw: &str) -> Result<()> {
     if raw.is_empty() {
         return Ok(());
@@ -517,13 +495,6 @@ fn write_history_segment_if_missing(path: &Path, raw: &str) -> Result<()> {
     };
     write_atomic(path, &normalized)
         .with_context(|| format!("failed to write {}", path.display()))?;
-    Ok(())
-}
-
-fn maybe_fault_inject(tag: &str) -> Result<()> {
-    if std::env::var("LOOM_FAULT_INJECT").ok().as_deref() == Some(tag) {
-        return Err(anyhow::anyhow!("fault injected at {}", tag));
-    }
     Ok(())
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 
+use crate::fs_util::write_atomic;
 use crate::types::PendingOp;
 
 const OPS_COMPACTION_THRESHOLD: usize = 16;
@@ -580,41 +581,6 @@ fn package_name_from_cargo_toml(path: &Path) -> Option<String> {
             .map(str::to_string);
     }
     None
-}
-
-fn write_atomic(path: &Path, contents: &str) -> Result<()> {
-    let parent = path
-        .parent()
-        .context("cannot write atomic file without parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
-
-    let tmp_path = parent.join(format!(
-        ".{}.tmp-{}",
-        path.file_name().unwrap_or_default().to_string_lossy(),
-        uuid::Uuid::new_v4()
-    ));
-
-    {
-        let mut file = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&tmp_path)
-            .with_context(|| format!("failed to create temp file {}", tmp_path.display()))?;
-        file.write_all(contents.as_bytes())
-            .with_context(|| format!("failed to write temp file {}", tmp_path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("failed to sync temp file {}", tmp_path.display()))?;
-    }
-
-    crate::fs_util::rename_atomic(&tmp_path, path).with_context(|| {
-        format!(
-            "failed to atomically replace {} with {}",
-            path.display(),
-            tmp_path.display()
-        )
-    })?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::fs_util::{append_lines, maybe_fault_inject, write_atomic};
-use crate::gitops;
 use crate::types::PendingOp;
 
 use super::journal::{
@@ -83,10 +82,14 @@ impl AppContext {
         })
     }
 
-    pub fn read_ops_audit_report(&self) -> Result<OpsAuditReport> {
+    pub(crate) fn read_ops_audit_report_with_history(
+        &self,
+        history_bodies: Vec<(String, String)>,
+        history_warnings: Vec<String>,
+    ) -> Result<OpsAuditReport> {
         let mut events = Vec::new();
         let mut seen_event_ids = BTreeSet::new();
-        let mut warnings = Vec::new();
+        let mut warnings = history_warnings;
 
         collect_audit_events_from_file(
             &self.pending_ops_file,
@@ -102,20 +105,15 @@ impl AppContext {
             &mut events,
             &mut warnings,
         )?;
-        match gitops::history_journal_bodies(self) {
-            Ok(bodies) => {
-                for (path, body) in bodies {
-                    collect_audit_events_from_body(
-                        &path,
-                        "loom_history",
-                        &body,
-                        &mut seen_event_ids,
-                        &mut events,
-                        &mut warnings,
-                    );
-                }
-            }
-            Err(err) => warnings.push(format!("failed to read loom-history branch: {}", err)),
+        for (path, body) in history_bodies {
+            collect_audit_events_from_body(
+                &path,
+                "loom_history",
+                &body,
+                &mut seen_event_ids,
+                &mut events,
+                &mut warnings,
+            );
         }
 
         events.sort_by(|left, right| {
@@ -341,15 +339,12 @@ impl AppContext {
         }
 
         let model = self.read_ops_model()?;
-        let segment_path = if !raw_journal.trim().is_empty() {
+        if !raw_journal.trim().is_empty() {
             let segment_path = self
                 .pending_ops_history_dir
                 .join(journal_segment_name(&raw_journal)?);
             write_history_segment_if_missing(&segment_path, &raw_journal)?;
-            Some(segment_path)
-        } else {
-            None
-        };
+        }
         maybe_fault_inject("ops_compact_after_history")?;
 
         let snapshot = OpsSnapshot {
@@ -363,10 +358,6 @@ impl AppContext {
         write_atomic(&self.pending_ops_snapshot_file, &(snapshot_raw + "\n"))
             .context("failed to write pending ops snapshot")?;
         maybe_fault_inject("ops_compact_after_snapshot")?;
-        if let Some(segment_path) = segment_path.as_ref() {
-            gitops::mirror_history_segment(self, segment_path, &self.pending_ops_snapshot_file)
-                .context("failed to mirror pending ops history into git")?;
-        }
         write_atomic(&self.pending_ops_file, "").context("failed to compact pending_ops.jsonl")?;
         Ok(())
     }

--- a/src/state/ops.rs
+++ b/src/state/ops.rs
@@ -5,61 +5,19 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 
+use crate::fs_util::{append_lines, maybe_fault_inject, write_atomic};
 use crate::gitops;
 use crate::types::PendingOp;
 
+use super::journal::{
+    OPS_SNAPSHOT_VERSION, OpJournalEvent, OpsSnapshot, apply_journal_event, journal_segment_name,
+    parse_journal_line,
+};
+use super::write_history_segment_if_missing;
 use super::{AppContext, OPS_COMPACTION_THRESHOLD};
-use super::{append_lines, maybe_fault_inject, write_atomic, write_history_segment_if_missing};
-
-const OPS_SNAPSHOT_VERSION: u32 = 1;
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-enum OpJournalEvent {
-    Queued {
-        event_id: String,
-        at: DateTime<Utc>,
-        op: PendingOp,
-    },
-    Audited {
-        event_id: String,
-        at: DateTime<Utc>,
-        op: PendingOp,
-    },
-    Removed {
-        event_id: String,
-        at: DateTime<Utc>,
-        op_id: String,
-        reason: String,
-    },
-}
-
-impl OpJournalEvent {
-    fn event_id(&self) -> &str {
-        match self {
-            Self::Queued { event_id, .. }
-            | Self::Audited { event_id, .. }
-            | Self::Removed { event_id, .. } => event_id,
-        }
-    }
-
-    fn at(&self) -> DateTime<Utc> {
-        match self {
-            Self::Queued { at, .. } | Self::Audited { at, .. } | Self::Removed { at, .. } => *at,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct OpsSnapshot {
-    version: u32,
-    created_at: DateTime<Utc>,
-    history_events: usize,
-    active_ops: Vec<PendingOp>,
-}
 
 #[derive(Debug, Default)]
 struct LoadedSnapshot {
@@ -92,12 +50,6 @@ pub struct OpsAuditOperation {
 pub struct OpsAuditReport {
     pub operations: Vec<OpsAuditOperation>,
     pub warnings: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct HistoryBodySummary {
-    pub first_at: Option<DateTime<Utc>>,
-    pub last_at: Option<DateTime<Utc>>,
 }
 
 impl AppContext {
@@ -515,149 +467,8 @@ fn collect_audit_events_from_body(
     }
 }
 
-pub fn synthesize_snapshot_raw_from_segment_bodies(segment_bodies: &[String]) -> Result<String> {
-    let mut seen_event_ids = BTreeSet::new();
-    let mut ordered_events = Vec::new();
-
-    for body in segment_bodies {
-        for line in body.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let event = parse_journal_line(trimmed)?;
-            let event_id = event.event_id().to_string();
-            if !seen_event_ids.insert(event_id.clone()) {
-                continue;
-            }
-            ordered_events.push((event.at(), event_id, event));
-        }
-    }
-
-    ordered_events.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
-
-    let mut active_ops = BTreeMap::new();
-    for (_, _, event) in ordered_events {
-        apply_journal_event(&mut active_ops, event);
-    }
-
-    let snapshot = OpsSnapshot {
-        version: OPS_SNAPSHOT_VERSION,
-        created_at: Utc::now(),
-        history_events: seen_event_ids.len(),
-        active_ops: active_ops.into_values().collect(),
-    };
-
-    serde_json::to_string_pretty(&snapshot).context("failed to encode synthesized ops snapshot")
-}
-
-pub fn summarize_history_body(raw: &str) -> Result<HistoryBodySummary> {
-    let mut first_at = None;
-    let mut last_at = None;
-
-    for line in raw.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let event = parse_journal_line(trimmed)?;
-        let at = event.at();
-        first_at = Some(first_at.map_or(at, |current: DateTime<Utc>| current.min(at)));
-        last_at = Some(last_at.map_or(at, |current: DateTime<Utc>| current.max(at)));
-    }
-
-    Ok(HistoryBodySummary { first_at, last_at })
-}
-
-pub fn remove_path_if_exists(path: &Path) -> Result<()> {
-    let meta = match fs::symlink_metadata(path) {
-        Ok(meta) => meta,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e).context("failed to stat path"),
-    };
-    if meta.file_type().is_symlink() || meta.is_file() {
-        fs::remove_file(path).context("failed to remove file/symlink")?;
-    } else {
-        fs::remove_dir_all(path).context("failed to remove directory")?;
-    }
-    Ok(())
-}
-
 fn new_event_id() -> String {
     uuid::Uuid::new_v4().to_string()
-}
-
-fn parse_journal_line(line: &str) -> Result<OpJournalEvent> {
-    if let Ok(event) = serde_json::from_str::<OpJournalEvent>(line) {
-        return Ok(event);
-    }
-
-    let mut op = serde_json::from_str::<PendingOp>(line)
-        .context("line is neither a journal event nor a pending op")?;
-    if op.op_id.is_none() {
-        op.op_id = Some(op.stable_id());
-    }
-    Ok(OpJournalEvent::Queued {
-        event_id: format!("legacy-{}", op.stable_id()),
-        at: op.created_at,
-        op,
-    })
-}
-
-fn journal_segment_name(raw_journal: &str) -> Result<String> {
-    let mut ids = Vec::new();
-    let mut non_empty = 0usize;
-
-    for (index, line) in raw_journal.lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        non_empty += 1;
-        match parse_journal_line(trimmed) {
-            Ok(event) => ids.push(sanitize_segment_token(event.event_id())),
-            Err(_) => ids.push(format!("invalid{}-{}", index + 1, trimmed.len())),
-        }
-    }
-
-    if non_empty == 0 {
-        return Err(anyhow::anyhow!("cannot name empty journal segment"));
-    }
-
-    let first = ids.first().cloned().unwrap_or_else(|| "empty".to_string());
-    let last = ids.last().cloned().unwrap_or_else(|| "empty".to_string());
-    Ok(format!(
-        "{:05}-{}-{}.jsonl",
-        non_empty,
-        shorten_segment_token(&first),
-        shorten_segment_token(&last)
-    ))
-}
-
-fn apply_journal_event(active_ops: &mut BTreeMap<String, PendingOp>, event: OpJournalEvent) {
-    match event {
-        OpJournalEvent::Queued { mut op, .. } => {
-            if op.op_id.is_none() {
-                op.op_id = Some(op.stable_id());
-            }
-            active_ops.insert(op.stable_id(), op);
-        }
-        OpJournalEvent::Audited { .. } => {}
-        OpJournalEvent::Removed { op_id, .. } => {
-            active_ops.remove(&op_id);
-        }
-    }
-}
-
-fn sanitize_segment_token(token: &str) -> String {
-    token
-        .chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-        .collect()
-}
-
-fn shorten_segment_token(token: &str) -> String {
-    token.chars().take(12).collect()
 }
 
 #[cfg(test)]

--- a/src/state_model/json_io.rs
+++ b/src/state_model/json_io.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use crate::fs_util::write_atomic;
+use crate::fs_util::{append_jsonl_raw, write_atomic};
 
 pub(super) fn ensure_json_file<T>(path: &Path, value: &T) -> Result<()>
 where
@@ -103,23 +103,10 @@ pub(super) fn append_json_line<T>(path: &Path, value: &T) -> Result<()>
 where
     T: Serialize,
 {
-    let parent = path
-        .parent()
-        .context("cannot append registry jsonl file without parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
     let raw = serde_json::to_string(value)
         .with_context(|| format!("failed to encode registry jsonl line {}", path.display()))?;
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed to open registry jsonl file {}", path.display()))?;
-    writeln!(file, "{}", raw)
-        .with_context(|| format!("failed to append registry jsonl file {}", path.display()))?;
-    file.sync_all()
-        .with_context(|| format!("failed to sync registry jsonl file {}", path.display()))?;
-    Ok(())
+    Ok(append_jsonl_raw(path, &raw)
+        .with_context(|| format!("failed to append registry jsonl file {}", path.display()))?)
 }
 
 pub(super) fn read_json_file<T>(path: &Path) -> Result<T>

--- a/src/state_model/json_io.rs
+++ b/src/state_model/json_io.rs
@@ -14,6 +14,8 @@ use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+use crate::fs_util::write_atomic;
+
 pub(super) fn ensure_json_file<T>(path: &Path, value: &T) -> Result<()>
 where
     T: Serialize,
@@ -30,7 +32,7 @@ pub(super) fn ensure_text_file(path: &Path, contents: &str) -> Result<()> {
         ensure_existing_file(path)?;
         return Ok(());
     }
-    write_atomic(path, contents)
+    Ok(write_atomic(path, contents)?)
 }
 
 fn ensure_existing_file(path: &Path) -> Result<()> {
@@ -48,7 +50,7 @@ where
     T: Serialize,
 {
     let raw = serialize_json_file(value)?;
-    write_atomic(path, &raw)
+    Ok(write_atomic(path, &raw)?)
 }
 
 pub(super) fn serialize_json_file<T: Serialize>(value: &T) -> Result<String> {
@@ -164,39 +166,4 @@ where
         items.push(item);
     }
     Ok(items)
-}
-
-fn write_atomic(path: &Path, contents: &str) -> Result<()> {
-    let parent = path
-        .parent()
-        .context("cannot write atomic registry file without parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
-
-    let tmp_path = parent.join(format!(
-        ".{}.tmp-{}",
-        path.file_name().unwrap_or_default().to_string_lossy(),
-        uuid::Uuid::new_v4()
-    ));
-
-    {
-        let mut file = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&tmp_path)
-            .with_context(|| format!("failed to create temp file {}", tmp_path.display()))?;
-        file.write_all(contents.as_bytes())
-            .with_context(|| format!("failed to write temp file {}", tmp_path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("failed to sync temp file {}", tmp_path.display()))?;
-    }
-
-    crate::fs_util::rename_atomic(&tmp_path, path).with_context(|| {
-        format!(
-            "failed to atomically replace {} with {}",
-            path.display(),
-            tmp_path.display()
-        )
-    })?;
-    Ok(())
 }

--- a/src/state_model/json_io.rs
+++ b/src/state_model/json_io.rs
@@ -105,8 +105,8 @@ where
 {
     let raw = serde_json::to_string(value)
         .with_context(|| format!("failed to encode registry jsonl line {}", path.display()))?;
-    Ok(append_jsonl_raw(path, &raw)
-        .with_context(|| format!("failed to append registry jsonl file {}", path.display()))?)
+    append_jsonl_raw(path, &raw)
+        .with_context(|| format!("failed to append registry jsonl file {}", path.display()))
 }
 
 pub(super) fn read_json_file<T>(path: &Path) -> Result<T>


### PR DESCRIPTION
## Summary
- Invert pending ops history mirroring so `state` no longer depends on `gitops`; command/panel layers now coordinate loom-history mirror/audit reads.
- Move pending journal codec into `state::journal` and decouple `gitops/history.rs` from `history_impl.rs` by extracting report/status types.
- Centralize atomic write, JSONL append, fault-injection, and remove-path filesystem primitives in `fs_util`; route state, state_model, and command audit writes through it.
- Remove the `commands/helpers.rs` re-export shim for projection/file owners and move sync push/replay internals to `sync_cmds.rs`.
- Confirmed `agent_cmds.rs` is already split and below the 800-line hard limit, so no L6 code split is needed here.

Fixes #289.

## Verification
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `cargo check --locked`
- `cargo fmt --check`
- `git diff --check`