### PR TITLE
SkillM UI refactor A1/A2: shell and view-model foundation

### DIFF
--- a/panel/src/components/panel/ActivityBar.tsx
+++ b/panel/src/components/panel/ActivityBar.tsx
@@ -1,0 +1,92 @@
+import type { ComponentType, SVGProps } from "react";
+import type { PageViewModel } from "../../lib/panel_view_model";
+import type { PanelPageKey } from "../../lib/types";
+import {
+  BindingIcon,
+  GitIcon,
+  HistoryIcon,
+  HomeIcon,
+  OpsIcon,
+  SearchIcon,
+  SettingsIcon,
+  ShieldIcon,
+  SkillIcon,
+  TargetIcon,
+} from "../icons/nav_icons";
+import { LoomMark } from "../icons/LoomMark";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+const ICONS: Record<PanelPageKey, IconComponent> = {
+  overview: HomeIcon,
+  skills: SkillIcon,
+  targets: TargetIcon,
+  bindings: BindingIcon,
+  projections: GitIcon,
+  ops: OpsIcon,
+  history: HistoryIcon,
+  sync: GitIcon,
+  doctor: ShieldIcon,
+  settings: SettingsIcon,
+};
+
+interface ActivityBarProps {
+  page: PanelPageKey;
+  pages: PageViewModel[];
+  onNavigate: (page: PanelPageKey) => void;
+  onOpenPalette: () => void;
+}
+
+export function ActivityBar({ page, pages, onNavigate, onOpenPalette }: ActivityBarProps) {
+  const buildPages = pages.filter((entry) => entry.group === "build");
+  const operatePages = pages.filter((entry) => entry.group === "operate");
+
+  return (
+    <nav className="activity-bar" aria-label="Panel navigation">
+      <div className="activity-brand" title="Loom">
+        <LoomMark size={24} />
+      </div>
+      <button className="activity-command" type="button" onClick={onOpenPalette} title="Open command palette">
+        <SearchIcon />
+        <span className="sr-only">Command palette</span>
+      </button>
+      <ActivityGroup page={page} pages={buildPages} onNavigate={onNavigate} />
+      <div className="activity-spacer" />
+      <ActivityGroup page={page} pages={operatePages} onNavigate={onNavigate} />
+    </nav>
+  );
+}
+
+function ActivityGroup({
+  page,
+  pages,
+  onNavigate,
+}: {
+  page: PanelPageKey;
+  pages: PageViewModel[];
+  onNavigate: (page: PanelPageKey) => void;
+}) {
+  return (
+    <div className="activity-group">
+      {pages.map((entry) => {
+        const Icon = ICONS[entry.key];
+        const active = page === entry.key;
+        return (
+          <button
+            key={entry.key}
+            className={`activity-item ${active ? "active" : ""}`}
+            type="button"
+            onClick={() => onNavigate(entry.key)}
+            title={entry.countTitle ? `${entry.label}: ${entry.countLabel ?? entry.count}` : entry.label}
+            aria-label={entry.label}
+            aria-current={active ? "page" : undefined}
+          >
+            <Icon />
+            <span className="activity-label">{entry.label}</span>
+            {entry.count != null && <span className="activity-count">{entry.countLabel ?? entry.count}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/panel/src/components/panel/ActivityBar.tsx
+++ b/panel/src/components/panel/ActivityBar.tsx
@@ -82,7 +82,6 @@ function ActivityGroup({
             aria-current={active ? "page" : undefined}
           >
             <Icon />
-            <span className="activity-label">{entry.label}</span>
             {entry.count != null && <span className="activity-count">{entry.countLabel ?? entry.count}</span>}
           </button>
         );

--- a/panel/src/components/panel/CommandPalette.tsx
+++ b/panel/src/components/panel/CommandPalette.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import type { PanelViewModel } from "../../lib/panel_view_model";
+import type { PanelPageKey } from "../../lib/types";
+import { SearchIcon } from "../icons/nav_icons";
+
+interface CommandPaletteProps {
+  open: boolean;
+  viewModel: PanelViewModel;
+  onClose: () => void;
+  onNavigate: (page: PanelPageKey) => void;
+  onSelectSkill: (id: string) => void;
+  onSelectTarget: (id: string) => void;
+  onReplayQueued: () => Promise<void> | void;
+}
+
+interface PaletteCommand {
+  id: string;
+  group: string;
+  label: string;
+  detail?: string;
+  disabled?: boolean;
+  disabledReason?: string;
+  run: () => Promise<void> | void;
+}
+
+export function CommandPalette({
+  open,
+  viewModel,
+  onClose,
+  onNavigate,
+  onSelectSkill,
+  onSelectTarget,
+  onReplayQueued,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const commands = useMemo<PaletteCommand[]>(() => {
+    const pageCommands = viewModel.shell.pages.map((page) => ({
+      id: `page:${page.key}`,
+      group: "Pages",
+      label: page.label,
+      detail: page.key,
+      run: () => onNavigate(page.key),
+    }));
+    const skillCommands = viewModel.skills.map((skill) => ({
+      id: `skill:${skill.id}`,
+      group: "Skills",
+      label: skill.name.label,
+      detail: skill.description.state === "available" ? skill.description.label : "Open skill",
+      disabled: skill.name.state === "unavailable",
+      disabledReason: skill.name.title,
+      run: () => onSelectSkill(skill.id),
+    }));
+    const targetCommands = viewModel.targets.map((target) => ({
+      id: `target:${target.id}`,
+      group: "Targets",
+      label: target.id,
+      detail: target.path.state === "available" ? target.path.label : target.agent.label,
+      run: () => onSelectTarget(target.id),
+    }));
+    const replay = viewModel.actions.replayQueued;
+    const mutationCommands =
+      viewModel.shell.counts.queuedWrites.value && viewModel.shell.counts.queuedWrites.value > 0
+        ? [
+            {
+              id: "mutation:replayQueued",
+              group: "Commands",
+              label: replay.label,
+              detail: replay.disabledReason,
+              disabled: !replay.enabled,
+              disabledReason: replay.disabledReason,
+              run: onReplayQueued,
+            },
+          ]
+        : [];
+    return [...pageCommands, ...skillCommands, ...targetCommands, ...mutationCommands];
+  }, [onNavigate, onReplayQueued, onSelectSkill, onSelectTarget, viewModel]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return commands;
+    return commands.filter((command) =>
+      [command.group, command.label, command.detail ?? ""].some((value) => value.toLowerCase().includes(needle)),
+    );
+  }, [commands, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setActiveIndex(0);
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+  }, [open]);
+
+  if (!open) return null;
+
+  const runCommand = async (command: PaletteCommand) => {
+    if (command.disabled) return;
+    await command.run();
+    onClose();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => Math.min(filtered.length - 1, index + 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => Math.max(0, index - 1));
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const command = filtered[activeIndex];
+      if (command) void runCommand(command);
+    }
+  };
+
+  return (
+    <div className="palette-backdrop" role="presentation" onMouseDown={onClose}>
+      <div
+        className="command-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="palette-input-row">
+          <SearchIcon />
+          <input
+            ref={inputRef}
+            role="searchbox"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+            onKeyDown={onKeyDown}
+            placeholder="Search pages, skills, targets"
+          />
+          <kbd>Esc</kbd>
+        </div>
+        <div className="palette-results" role="listbox" aria-label="Command results">
+          {filtered.length === 0 ? (
+            <div className="palette-empty">No commands found.</div>
+          ) : (
+            filtered.map((command, index) => (
+              <button
+                key={command.id}
+                className={`palette-item ${index === activeIndex ? "active" : ""}`}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => void runCommand(command)}
+                disabled={command.disabled}
+                title={command.disabledReason}
+              >
+                <span className="palette-group">{command.group}</span>
+                <span className="palette-label">{command.label}</span>
+                {command.detail && <span className="palette-detail">{command.detail}</span>}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/panel/src/components/panel/CommandPalette.tsx
+++ b/panel/src/components/panel/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
+import type { CSSProperties, KeyboardEvent } from "react";
 import type { PanelViewModel } from "../../lib/panel_view_model";
 import type { PanelPageKey } from "../../lib/types";
 import { SearchIcon } from "../icons/nav_icons";
@@ -126,16 +126,17 @@ export function CommandPalette({
   };
 
   return (
-    <div className="palette-backdrop" role="presentation" onMouseDown={onClose}>
+    <div className="palette-backdrop" role="presentation" onMouseDown={onClose} style={paletteStyles.backdrop}>
       <div
         className="command-palette"
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
         onMouseDown={(event) => event.stopPropagation()}
+        style={paletteStyles.dialog}
       >
-        <div className="palette-input-row">
-          <SearchIcon />
+        <div className="palette-input-row" style={paletteStyles.inputRow}>
+          <SearchIcon style={paletteStyles.icon} />
           <input
             ref={inputRef}
             role="searchbox"
@@ -146,12 +147,13 @@ export function CommandPalette({
             }}
             onKeyDown={onKeyDown}
             placeholder="Search pages, skills, targets"
+            style={paletteStyles.input}
           />
-          <kbd>Esc</kbd>
+          <kbd style={paletteStyles.kbd}>Esc</kbd>
         </div>
-        <div className="palette-results" role="listbox" aria-label="Command results">
+        <div className="palette-results" role="listbox" aria-label="Command results" style={paletteStyles.results}>
           {filtered.length === 0 ? (
-            <div className="palette-empty">No commands found.</div>
+            <div className="palette-empty" style={paletteStyles.empty}>No commands found.</div>
           ) : (
             filtered.map((command, index) => (
               <button
@@ -164,10 +166,15 @@ export function CommandPalette({
                 onClick={() => void runCommand(command)}
                 disabled={command.disabled}
                 title={command.disabledReason}
+                style={{
+                  ...paletteStyles.item,
+                  ...(index === activeIndex ? paletteStyles.itemActive : null),
+                  ...(command.disabled ? paletteStyles.itemDisabled : null),
+                }}
               >
-                <span className="palette-group">{command.group}</span>
-                <span className="palette-label">{command.label}</span>
-                {command.detail && <span className="palette-detail">{command.detail}</span>}
+                <span className="palette-group" style={paletteStyles.group}>{command.group}</span>
+                <span className="palette-label" style={paletteStyles.label}>{command.label}</span>
+                {command.detail && <span className="palette-detail" style={paletteStyles.detail}>{command.detail}</span>}
               </button>
             ))
           )}
@@ -176,3 +183,98 @@ export function CommandPalette({
     </div>
   );
 }
+
+const clippedText: CSSProperties = {
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const paletteStyles = {
+  backdrop: {
+    position: "fixed",
+    inset: 0,
+    zIndex: 90,
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "center",
+    paddingTop: "12vh",
+    background: "rgba(0, 0, 0, 0.42)",
+  },
+  dialog: {
+    width: "min(640px, calc(100vw - 24px))",
+    maxHeight: "min(620px, 76vh)",
+    display: "flex",
+    flexDirection: "column",
+    border: "1px solid var(--line-hi)",
+    borderRadius: "var(--radius)",
+    background: "var(--bg-1)",
+    boxShadow: "var(--shadow)",
+    overflow: "hidden",
+  },
+  inputRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    padding: "12px 14px",
+    borderBottom: "1px solid var(--line)",
+  },
+  icon: { width: 18, height: 18, color: "var(--ink-2)" },
+  input: {
+    flex: 1,
+    minWidth: 0,
+    color: "var(--ink-0)",
+    background: "transparent",
+    border: 0,
+    outline: 0,
+    fontSize: 14,
+  },
+  kbd: {
+    color: "var(--ink-3)",
+    fontFamily: "var(--font-mono)",
+    fontSize: 10,
+    border: "1px solid var(--line-hi)",
+    borderRadius: "var(--radius-sm)",
+    padding: "1px 5px",
+  },
+  results: { overflow: "auto", padding: 6 },
+  item: {
+    width: "100%",
+    minHeight: 46,
+    display: "grid",
+    gridTemplateColumns: "92px minmax(0, 1fr)",
+    gap: "4px 10px",
+    alignItems: "center",
+    padding: "8px 10px",
+    borderRadius: "var(--radius-sm)",
+    color: "var(--ink-1)",
+    textAlign: "left",
+    border: "1px solid transparent",
+    background: "transparent",
+    cursor: "pointer",
+  },
+  itemActive: { color: "var(--ink-0)", background: "var(--bg-2)", borderColor: "var(--line-hi)" },
+  itemDisabled: { opacity: 0.55, cursor: "not-allowed" },
+  group: {
+    gridRow: "1 / span 2",
+    color: "var(--ink-3)",
+    fontFamily: "var(--font-mono)",
+    fontSize: 10,
+    textTransform: "uppercase",
+  },
+  label: { ...clippedText, color: "inherit" },
+  detail: { ...clippedText, color: "var(--ink-3)", fontSize: 12 },
+  empty: {
+    width: "100%",
+    minHeight: 46,
+    display: "grid",
+    gridTemplateColumns: "92px minmax(0, 1fr)",
+    gap: "4px 10px",
+    alignItems: "center",
+    padding: "8px 10px",
+    borderRadius: "var(--radius-sm)",
+    color: "var(--ink-3)",
+    textAlign: "left",
+  },
+} satisfies Record<string, CSSProperties>;

--- a/panel/src/components/panel/ControlRoomShell.tsx
+++ b/panel/src/components/panel/ControlRoomShell.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import type { PanelViewModel } from "../../lib/panel_view_model";
+import type { PanelPageKey } from "../../lib/types";
+import { ActivityBar } from "./ActivityBar";
+import { CommandPalette } from "./CommandPalette";
+import { StatusBar } from "./StatusBar";
+import { Toasts, type ToastViewModel } from "./Toasts";
+
+interface ControlRoomShellProps {
+  page: PanelPageKey;
+  viewModel: PanelViewModel;
+  className?: string;
+  banners?: ReactNode;
+  children: ReactNode;
+  themeLabel: string;
+  tweaksOpen: boolean;
+  toasts: ToastViewModel[];
+  onDismissToast: (id: string) => void;
+  onNavigate: (page: PanelPageKey) => void;
+  onSelectSkill: (id: string) => void;
+  onSelectTarget: (id: string) => void;
+  onReplayQueued: () => Promise<void> | void;
+  onCycleTheme: () => void;
+  onToggleTweaks: () => void;
+}
+
+export function ControlRoomShell({
+  page,
+  viewModel,
+  className,
+  banners,
+  children,
+  themeLabel,
+  tweaksOpen,
+  toasts,
+  onDismissToast,
+  onNavigate,
+  onSelectSkill,
+  onSelectTarget,
+  onReplayQueued,
+  onCycleTheme,
+  onToggleTweaks,
+}: ControlRoomShellProps) {
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setPaletteOpen(true);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const navigate = (nextPage: PanelPageKey) => {
+    onNavigate(nextPage);
+    setPaletteOpen(false);
+  };
+  const selectSkill = (id: string) => {
+    onSelectSkill(id);
+    onNavigate("skills");
+    setPaletteOpen(false);
+  };
+  const selectTarget = (id: string) => {
+    onSelectTarget(id);
+    onNavigate("targets");
+    setPaletteOpen(false);
+  };
+
+  return (
+    <div className={`control-room-shell${className ? ` ${className}` : ""}`}>
+      <ActivityBar page={page} pages={viewModel.shell.pages} onNavigate={navigate} onOpenPalette={() => setPaletteOpen(true)} />
+      <main className="shell-workspace">
+        <div className="shell-page-frame">
+          {banners && <div className="shell-banner-stack">{banners}</div>}
+          {children}
+        </div>
+      </main>
+      <StatusBar
+        viewModel={viewModel}
+        themeLabel={themeLabel}
+        tweaksOpen={tweaksOpen}
+        onCycleTheme={onCycleTheme}
+        onToggleTweaks={onToggleTweaks}
+        onReplayQueued={onReplayQueued}
+      />
+      <CommandPalette
+        open={paletteOpen}
+        viewModel={viewModel}
+        onClose={() => setPaletteOpen(false)}
+        onNavigate={navigate}
+        onSelectSkill={selectSkill}
+        onSelectTarget={selectTarget}
+        onReplayQueued={onReplayQueued}
+      />
+      <Toasts toasts={toasts} onDismiss={onDismissToast} />
+    </div>
+  );
+}

--- a/panel/src/components/panel/ControlRoomShell.tsx
+++ b/panel/src/components/panel/ControlRoomShell.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import type { PanelViewModel } from "../../lib/panel_view_model";
 import type { PanelPageKey } from "../../lib/types";
 import { ActivityBar } from "./ActivityBar";
-import { CommandPalette } from "./CommandPalette";
 import { StatusBar } from "./StatusBar";
-import { Toasts, type ToastViewModel } from "./Toasts";
+import type { ToastViewModel } from "./Toasts";
+
+const CommandPalette = lazy(() =>
+  import("./CommandPalette").then((module) => ({ default: module.CommandPalette })),
+);
+const Toasts = lazy(() => import("./Toasts").then((module) => ({ default: module.Toasts })));
 
 interface ControlRoomShellProps {
   page: PanelPageKey;
@@ -87,16 +91,24 @@ export function ControlRoomShell({
         onToggleTweaks={onToggleTweaks}
         onReplayQueued={onReplayQueued}
       />
-      <CommandPalette
-        open={paletteOpen}
-        viewModel={viewModel}
-        onClose={() => setPaletteOpen(false)}
-        onNavigate={navigate}
-        onSelectSkill={selectSkill}
-        onSelectTarget={selectTarget}
-        onReplayQueued={onReplayQueued}
-      />
-      <Toasts toasts={toasts} onDismiss={onDismissToast} />
+      {paletteOpen && (
+        <Suspense fallback={null}>
+          <CommandPalette
+            open={paletteOpen}
+            viewModel={viewModel}
+            onClose={() => setPaletteOpen(false)}
+            onNavigate={navigate}
+            onSelectSkill={selectSkill}
+            onSelectTarget={selectTarget}
+            onReplayQueued={onReplayQueued}
+          />
+        </Suspense>
+      )}
+      {toasts.length > 0 && (
+        <Suspense fallback={null}>
+          <Toasts toasts={toasts} onDismiss={onDismissToast} />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/panel/src/components/panel/StatusBar.tsx
+++ b/panel/src/components/panel/StatusBar.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import type { PanelViewModel } from "../../lib/panel_view_model";
+import { GitIcon, PlayIcon, SettingsIcon } from "../icons/nav_icons";
+
+interface StatusBarProps {
+  viewModel: PanelViewModel;
+  themeLabel: string;
+  tweaksOpen: boolean;
+  onCycleTheme: () => void;
+  onToggleTweaks: () => void;
+  onReplayQueued: () => Promise<void> | void;
+}
+
+export function StatusBar({
+  viewModel,
+  themeLabel,
+  tweaksOpen,
+  onCycleTheme,
+  onToggleTweaks,
+  onReplayQueued,
+}: StatusBarProps) {
+  const [replaying, setReplaying] = useState(false);
+  const replay = async () => {
+    if (!viewModel.actions.replayQueued.enabled || replaying) return;
+    setReplaying(true);
+    try {
+      await onReplayQueued();
+    } finally {
+      setReplaying(false);
+    }
+  };
+  const replayAction = viewModel.actions.replayQueued;
+  const queued = viewModel.shell.counts.queuedWrites.value ?? 0;
+
+  return (
+    <footer className="status-bar" aria-label="Panel status">
+      <div className="status-left">
+        <span className="status-pill" data-tone={viewModel.shell.status.tone} title={viewModel.shell.status.title}>
+          <span className="status-dot" />
+          {viewModel.shell.status.label}
+        </span>
+        <span className="status-meta" title={viewModel.shell.registryRoot.title}>
+          {viewModel.shell.registryRoot.label}
+        </span>
+        <span className="status-meta" title={viewModel.shell.remoteState.title}>
+          <GitIcon /> {viewModel.shell.remoteState.label}
+        </span>
+      </div>
+      <div className="status-right">
+        <span className="status-meta">{viewModel.shell.counts.skills.display} skills</span>
+        <span className="status-meta">{viewModel.shell.counts.targets.display} targets</span>
+        <button
+          className="status-action"
+          type="button"
+          onClick={replay}
+          disabled={!replayAction.enabled || replaying}
+          title={replayAction.disabledReason ?? `Replay ${queued} queued write${queued === 1 ? "" : "s"}`}
+        >
+          <PlayIcon /> {replaying ? "replaying" : `queued ${queued}`}
+        </button>
+        <button className="status-action" type="button" onClick={onCycleTheme} title={`Theme: ${themeLabel}`}>
+          {themeLabel}
+        </button>
+        <button
+          className="status-action"
+          type="button"
+          onClick={onToggleTweaks}
+          aria-pressed={tweaksOpen}
+          title={tweaksOpen ? "Hide visual tweaks" : "Show visual tweaks"}
+        >
+          <SettingsIcon /> tweaks
+        </button>
+      </div>
+    </footer>
+  );
+}

--- a/panel/src/components/panel/Toasts.tsx
+++ b/panel/src/components/panel/Toasts.tsx
@@ -1,0 +1,29 @@
+export interface ToastViewModel {
+  id: string;
+  tone: "info" | "success" | "warn" | "error";
+  title: string;
+  detail?: string;
+}
+
+interface ToastsProps {
+  toasts: ToastViewModel[];
+  onDismiss: (id: string) => void;
+}
+
+export function Toasts({ toasts, onDismiss }: ToastsProps) {
+  return (
+    <div className="toast-layer" aria-live="polite" aria-relevant="additions removals">
+      {toasts.map((toast) => (
+        <div className="toast" data-tone={toast.tone} key={toast.id} role="status">
+          <div className="toast-copy">
+            <div className="toast-title">{toast.title}</div>
+            {toast.detail && <div className="toast-detail">{toast.detail}</div>}
+          </div>
+          <button className="toast-dismiss" type="button" onClick={() => onDismiss(toast.id)} aria-label="Dismiss toast">
+            x
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/panel/src/components/panel/Toasts.tsx
+++ b/panel/src/components/panel/Toasts.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 export interface ToastViewModel {
   id: string;
   tone: "info" | "success" | "warn" | "error";
@@ -12,14 +14,26 @@ interface ToastsProps {
 
 export function Toasts({ toasts, onDismiss }: ToastsProps) {
   return (
-    <div className="toast-layer" aria-live="polite" aria-relevant="additions removals">
+    <div className="toast-layer" aria-live="polite" aria-relevant="additions removals" style={toastStyles.layer}>
       {toasts.map((toast) => (
-        <div className="toast" data-tone={toast.tone} key={toast.id} role="status">
+        <div
+          className="toast"
+          data-tone={toast.tone}
+          key={toast.id}
+          role="status"
+          style={{ ...toastStyles.toast, borderColor: toastBorderColor[toast.tone] }}
+        >
           <div className="toast-copy">
-            <div className="toast-title">{toast.title}</div>
-            {toast.detail && <div className="toast-detail">{toast.detail}</div>}
+            <div className="toast-title" style={toastStyles.title}>{toast.title}</div>
+            {toast.detail && <div className="toast-detail" style={toastStyles.detail}>{toast.detail}</div>}
           </div>
-          <button className="toast-dismiss" type="button" onClick={() => onDismiss(toast.id)} aria-label="Dismiss toast">
+          <button
+            className="toast-dismiss"
+            type="button"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss toast"
+            style={toastStyles.dismiss}
+          >
             x
           </button>
         </div>
@@ -27,3 +41,36 @@ export function Toasts({ toasts, onDismiss }: ToastsProps) {
     </div>
   );
 }
+
+const toastBorderColor: Record<ToastViewModel["tone"], string> = {
+  info: "var(--line-hi)",
+  success: "color-mix(in srgb, var(--ok) 45%, var(--line-hi))",
+  warn: "color-mix(in srgb, var(--warn) 50%, var(--line-hi))",
+  error: "color-mix(in srgb, var(--err) 50%, var(--line-hi))",
+};
+
+const toastStyles = {
+  layer: {
+    position: "fixed",
+    right: 16,
+    bottom: 44,
+    zIndex: 100,
+    display: "grid",
+    gap: 8,
+    width: "min(360px, calc(100vw - 32px))",
+  },
+  toast: {
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    padding: "10px 12px",
+    border: "1px solid var(--line-hi)",
+    borderRadius: "var(--radius)",
+    background: "var(--bg-1)",
+    boxShadow: "var(--shadow)",
+  },
+  title: { color: "var(--ink-0)", fontWeight: 600 },
+  detail: { marginTop: 2, color: "var(--ink-2)", fontSize: 12, overflowWrap: "anywhere" },
+  dismiss: { color: "var(--ink-3)", cursor: "pointer" },
+} satisfies Record<string, CSSProperties>;

--- a/panel/src/lib/panel_view_model.test.ts
+++ b/panel/src/lib/panel_view_model.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { RegistryProjection } from "../generated/RegistryProjection";
+import type { PanelLiveData } from "./api/usePanelData";
+import {
+  selectOperationViewModel,
+  selectPanelViewModel,
+  selectProjectionLinks,
+  selectProjectionViewModel,
+  selectTargetViewModel,
+} from "./panel_view_model";
+import type { Op, Target } from "./types";
+
+function liveData(overrides: Partial<PanelLiveData> = {}): PanelLiveData {
+  return {
+    live: true,
+    apiReachable: true,
+    loading: false,
+    error: null,
+    mode: "live",
+    setupRequired: false,
+    lastUpdated: "2026-06-11T12:00:00Z",
+    registryRoot: "/tmp/loom",
+    remote: { sync_state: "CLEAN" },
+    warnings: [],
+    health: { ok: true },
+    counts: { skills: 1, targets: 1, bindings: 0, projections: 0, operations: 0 },
+    skills: [],
+    targets: [],
+    bindings: [],
+    ops: [],
+    projections: [],
+    queuedWriteCount: 0,
+    refetch: () => {},
+    ...overrides,
+  };
+}
+
+describe("panel view-model selectors", () => {
+  it("renders unknown enum values as unknown instead of coercing them", () => {
+    const projection = {
+      instance_id: "projection-1",
+      skill_id: "typed-api-client",
+      target_id: "target-1",
+      materialized_path: "/tmp/target/skill",
+      method: "teleport",
+      last_applied_rev: "abcdef123",
+      health: "healthy",
+    } as RegistryProjection;
+    const target = {
+      id: "target-1",
+      agent: "future-agent",
+      profile: "home",
+      path: "/tmp/target",
+      ownership: "delegated",
+      skills: 0,
+      observedSkills: 0,
+      projectedSkills: 0,
+      lastSync: "now",
+    } as unknown as Target;
+    const op = {
+      id: "op-1",
+      status: "blocked",
+      kind: "project",
+      skill: "typed-api-client",
+      target: "target-1",
+      method: "teleport",
+      time: "now",
+    } as unknown as Op;
+
+    expect(selectProjectionViewModel(projection).method).toMatchObject({
+      state: "available",
+      label: "unknown",
+      raw: "teleport",
+    });
+    expect(selectProjectionLinks([projection])[0].method).toBe("unknown");
+    expect(selectTargetViewModel(target).ownership).toMatchObject({
+      state: "available",
+      label: "unknown",
+      raw: "delegated",
+    });
+    expect(selectOperationViewModel(op).status).toMatchObject({
+      state: "available",
+      label: "unknown",
+      raw: "blocked",
+    });
+  });
+
+  it("marks missing backend fields as explicitly unavailable", () => {
+    const projection = {
+      instance_id: "projection-1",
+      skill_id: "typed-api-client",
+      target_id: "target-1",
+      materialized_path: "/tmp/target/skill",
+      method: "symlink",
+      last_applied_rev: "abcdef123",
+      health: "healthy",
+    } as RegistryProjection;
+    const vm = selectProjectionViewModel(projection);
+
+    expect(vm.binding).toMatchObject({ state: "unavailable", label: "unavailable" });
+    expect(vm.updatedAt).toMatchObject({ state: "unavailable", label: "unavailable" });
+  });
+
+  it("covers shell counts and does not invent missing backend counts", () => {
+    const vm = selectPanelViewModel(liveData({ counts: {}, queuedWriteCount: 2 }), {
+      page: "overview",
+      readOnly: false,
+    });
+
+    expect(vm.shell.counts.skills).toMatchObject({ value: 0, display: "0", state: "available" });
+    expect(vm.shell.counts.queuedWrites).toMatchObject({ value: 2, display: "2", state: "available" });
+    expect(vm.shell.counts.backend.skills).toMatchObject({
+      value: null,
+      display: "unavailable",
+      state: "unavailable",
+    });
+  });
+
+  it("disables every mutation action while the panel is read-only", () => {
+    const vm = selectPanelViewModel(
+      liveData({
+        mode: "offline-empty",
+        live: false,
+        queuedWriteCount: 2,
+      }),
+      { page: "overview", readOnly: true },
+    );
+
+    expect(Object.values(vm.actions)).toHaveLength(10);
+    for (const action of Object.values(vm.actions)) {
+      expect(action.mutation).toBe(true);
+      expect(action.enabled).toBe(false);
+      expect(action.disabledReason).toBe("registry offline");
+    }
+  });
+
+  it("uses the live data mode as the read-only action reason", () => {
+    const vm = selectPanelViewModel(
+      liveData({
+        mode: "first-run",
+        setupRequired: true,
+        live: true,
+      }),
+      { page: "overview", readOnly: true },
+    );
+
+    expect(vm.shell.readOnlyReason).toBe("registry setup required");
+    expect(vm.actions.addSkill.disabledReason).toBe("registry setup required");
+  });
+});

--- a/panel/src/lib/panel_view_model.test.ts
+++ b/panel/src/lib/panel_view_model.test.ts
@@ -101,6 +101,23 @@ describe("panel view-model selectors", () => {
     expect(vm.updatedAt).toMatchObject({ state: "unavailable", label: "unavailable" });
   });
 
+  it("does not fabricate graph methods when projection method is missing", () => {
+    const projection = {
+      instance_id: "projection-1",
+      skill_id: "typed-api-client",
+      target_id: "target-1",
+      materialized_path: "/tmp/target/skill",
+      last_applied_rev: "abcdef123",
+      health: "healthy",
+    } as RegistryProjection;
+
+    expect(selectProjectionViewModel(projection).method).toMatchObject({
+      state: "unavailable",
+      label: "unavailable",
+    });
+    expect(selectProjectionLinks([projection])[0].method).toBe("unknown");
+  });
+
   it("covers shell counts and does not invent missing backend counts", () => {
     const vm = selectPanelViewModel(liveData({ counts: {}, queuedWriteCount: 2 }), {
       page: "overview",

--- a/panel/src/lib/panel_view_model.ts
+++ b/panel/src/lib/panel_view_model.ts
@@ -1,0 +1,507 @@
+import type { PanelDataMode, PanelLiveData } from "./api/usePanelData";
+import { formatActionNeededBadge, formatQueuedWrites, summarizeOps } from "./count_labels";
+import type { Binding, Op, PanelPageKey, ProjectionLink, ProjectionMethod, Skill, Target } from "./types";
+import type { RegistryProjection } from "../generated/RegistryProjection";
+
+export type FieldState = "available" | "unavailable";
+export type StatusTone = "ok" | "warn" | "err" | "pending" | "muted";
+
+export interface FieldViewModel {
+  state: FieldState;
+  label: string;
+  raw?: string | number | boolean;
+  title?: string;
+}
+
+export interface CountViewModel {
+  key: string;
+  label: string;
+  value: number | null;
+  display: string;
+  state: FieldState;
+  title?: string;
+}
+
+export interface PageViewModel {
+  key: PanelPageKey;
+  label: string;
+  group: "build" | "operate";
+  count?: number | null;
+  countLabel?: string;
+  countTitle?: string;
+}
+
+export interface SkillViewModel {
+  id: string;
+  name: FieldViewModel;
+  description: FieldViewModel;
+  sourceStatus: FieldViewModel;
+  latestRev: FieldViewModel;
+  changed: FieldViewModel;
+  bindings: CountViewModel;
+  projections: CountViewModel;
+  targets: CountViewModel;
+}
+
+export interface TargetViewModel {
+  id: string;
+  agent: FieldViewModel;
+  profile: FieldViewModel;
+  path: FieldViewModel;
+  ownership: FieldViewModel;
+  observedSkills: CountViewModel;
+  projectedSkills: CountViewModel;
+}
+
+export interface BindingViewModel {
+  id: string;
+  skill: FieldViewModel;
+  target: FieldViewModel;
+  matcher: FieldViewModel;
+  method: FieldViewModel;
+  policy: FieldViewModel;
+}
+
+export interface ProjectionViewModel {
+  id: FieldViewModel;
+  skill: FieldViewModel;
+  target: FieldViewModel;
+  binding: FieldViewModel;
+  method: FieldViewModel;
+  health: FieldViewModel;
+  materializedPath: FieldViewModel;
+  lastAppliedRev: FieldViewModel;
+  updatedAt: FieldViewModel;
+  drifted: boolean;
+}
+
+export interface OperationViewModel {
+  id: FieldViewModel;
+  status: FieldViewModel;
+  kind: FieldViewModel;
+  skill: FieldViewModel;
+  target: FieldViewModel;
+  method: FieldViewModel;
+  time: FieldViewModel;
+  reason: FieldViewModel;
+}
+
+export interface ActionViewModel {
+  key:
+    | "addSkill"
+    | "addTarget"
+    | "addBinding"
+    | "projectSkill"
+    | "captureSkill"
+    | "cleanOrphans"
+    | "replayQueued"
+    | "repairHistory"
+    | "syncPull"
+    | "syncPush";
+  label: string;
+  mutation: true;
+  enabled: boolean;
+  disabledReason?: string;
+}
+
+export interface ShellStatusViewModel {
+  label: string;
+  title: string;
+  tone: StatusTone;
+}
+
+export interface ShellViewModel {
+  status: ShellStatusViewModel;
+  pages: PageViewModel[];
+  counts: {
+    skills: CountViewModel;
+    targets: CountViewModel;
+    bindings: CountViewModel;
+    projections: CountViewModel;
+    operations: CountViewModel;
+    actionNeeded: CountViewModel;
+    queuedWrites: CountViewModel;
+    backend: {
+      skills: CountViewModel;
+      targets: CountViewModel;
+      bindings: CountViewModel;
+      projections: CountViewModel;
+      operations: CountViewModel;
+    };
+  };
+  registryRoot: FieldViewModel;
+  remoteState: FieldViewModel;
+  readOnly: boolean;
+  readOnlyReason?: string;
+}
+
+export interface PanelViewModel {
+  shell: ShellViewModel;
+  skills: SkillViewModel[];
+  targets: TargetViewModel[];
+  bindings: BindingViewModel[];
+  projections: ProjectionViewModel[];
+  operations: OperationViewModel[];
+  actions: Record<ActionViewModel["key"], ActionViewModel>;
+  graphLinks: ProjectionLink[];
+}
+
+interface PanelViewModelOptions {
+  page: PanelPageKey;
+  readOnly: boolean;
+  historyReadOnly?: boolean;
+}
+
+const UNAVAILABLE = "unavailable";
+const UNKNOWN = "unknown";
+const MISSING_SENTINEL = "\u2014";
+const KNOWN_METHODS = new Set(["symlink", "copy", "materialize"]);
+const KNOWN_OWNERSHIP = new Set(["managed", "observed", "external"]);
+const KNOWN_SOURCE_STATUS = new Set(["present", "missing", "non-compliant"]);
+const KNOWN_OPERATION_STATUS = new Set(["ok", "pending", "err"]);
+const KNOWN_POLICIES = new Set(["auto", "manual"]);
+const READ_ONLY_REASON = "registry offline";
+
+const PAGE_LABELS: Record<PanelPageKey, string> = {
+  overview: "Overview",
+  skills: "Skills",
+  targets: "Targets",
+  bindings: "Bindings",
+  projections: "Projections",
+  ops: "Activity",
+  history: "Audit log",
+  sync: "Git sync",
+  doctor: "Doctor",
+  settings: "Settings",
+};
+
+const PAGE_GROUPS: Record<PanelPageKey, PageViewModel["group"]> = {
+  overview: "build",
+  skills: "build",
+  targets: "build",
+  bindings: "build",
+  projections: "build",
+  ops: "build",
+  history: "operate",
+  sync: "operate",
+  doctor: "operate",
+  settings: "operate",
+};
+
+const PAGE_ORDER: PanelPageKey[] = [
+  "overview",
+  "skills",
+  "targets",
+  "bindings",
+  "projections",
+  "ops",
+  "history",
+  "sync",
+  "doctor",
+  "settings",
+];
+
+function unavailable(reason: string): FieldViewModel {
+  return { state: "unavailable", label: UNAVAILABLE, title: reason };
+}
+
+function textField(value: unknown, reason: string): FieldViewModel {
+  if (value === null || value === undefined || value === "" || value === MISSING_SENTINEL) return unavailable(reason);
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return { state: "available", label: String(value), raw: value };
+  }
+  return { state: "available", label: String(value), raw: String(value) };
+}
+
+function enumField(value: unknown, known: Set<string>, reason: string): FieldViewModel {
+  const field = textField(value, reason);
+  if (field.state === "unavailable") return field;
+  const raw = String(field.raw ?? field.label);
+  if (known.has(raw)) return field;
+  return {
+    state: "available",
+    label: UNKNOWN,
+    raw,
+    title: `Backend returned an unrecognized value: ${raw}`,
+  };
+}
+
+function methodField(value: unknown, reason = "backend did not include a projection method"): FieldViewModel {
+  return enumField(value, KNOWN_METHODS, reason);
+}
+
+function countField(key: string, label: string, value: unknown, reason: string): CountViewModel {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return { key, label, value: null, display: UNAVAILABLE, state: "unavailable", title: reason };
+  }
+  return { key, label, value, display: String(value), state: "available" };
+}
+
+function arrayCount(key: string, label: string, value: number): CountViewModel {
+  return { key, label, value, display: String(value), state: "available" };
+}
+
+function statusForLiveData(live: PanelLiveData): ShellStatusViewModel {
+  if (live.mode === "offline-stale") {
+    return {
+      label: "live API offline / stale snapshot",
+      title: "Last-known registry snapshot. The live API is unreachable.",
+      tone: "err",
+    };
+  }
+  if (live.error) return { label: "registry error", title: live.error, tone: "err" };
+  if (live.loading) return { label: "connecting", title: "Connecting to the registry API", tone: "pending" };
+  if (!live.live) return { label: "registry offline", title: "Registry API is offline", tone: "err" };
+  if (live.mode === "first-run") {
+    return {
+      label: "registry setup required",
+      title: "Registry state has not been initialized yet.",
+      tone: "warn",
+    };
+  }
+
+  const state = (live.remote?.sync_state ?? "").toUpperCase();
+  if (state === "DIVERGED" || state === "CONFLICTED") {
+    return { label: `remote ${state.toLowerCase()}`, title: "Remote and local history differ.", tone: "err" };
+  }
+  if (state === "PENDING_PUSH" || state === "LOCAL_ONLY" || live.queuedWriteCount > 0) {
+    return {
+      label: live.queuedWriteCount > 0 ? formatQueuedWrites(live.queuedWriteCount) : state.toLowerCase().replace("_", " "),
+      title: `${formatQueuedWrites(live.queuedWriteCount)} waiting in the pending queue.`,
+      tone: "warn",
+    };
+  }
+  return { label: "registry clean", title: "Registry is in sync with the Git remote.", tone: "ok" };
+}
+
+function modeReadOnlyReason(mode: PanelDataMode): string {
+  if (mode === "offline-stale") return "live API offline";
+  if (mode === "offline-empty") return "registry offline";
+  if (mode === "first-run") return "registry setup required";
+  return READ_ONLY_REASON;
+}
+
+function mutationAction(
+  key: ActionViewModel["key"],
+  label: string,
+  readOnly: boolean,
+  enabledWhen = true,
+  disabledReason = "action unavailable",
+  readOnlyReason = READ_ONLY_REASON,
+): ActionViewModel {
+  if (readOnly) return { key, label, mutation: true, enabled: false, disabledReason: readOnlyReason };
+  if (!enabledWhen) return { key, label, mutation: true, enabled: false, disabledReason };
+  return { key, label, mutation: true, enabled: true };
+}
+
+export function selectProjectionLinks(projections: readonly RegistryProjection[]): ProjectionLink[] {
+  return projections.map((projection) => {
+    const method = methodField(projection.method);
+    return {
+      skillId: `s-${projection.skill_id}`,
+      targetId: projection.target_id,
+      method: method.label === UNKNOWN ? "unknown" : (method.label as ProjectionMethod),
+    };
+  });
+}
+
+export function selectPanelViewModel(live: PanelLiveData, options: PanelViewModelOptions): PanelViewModel {
+  const opCounts = summarizeOps(live.ops);
+  const backendCounts = live.counts;
+  const actionNeededCount = opCounts.actionNeeded;
+  const readOnlyReason = options.readOnly ? modeReadOnlyReason(live.mode) : undefined;
+  const actionReadOnlyReason = readOnlyReason ?? READ_ONLY_REASON;
+
+  const shellCounts = {
+    skills: arrayCount("skills", "Skills", live.skills.length),
+    targets: arrayCount("targets", "Targets", live.targets.length),
+    bindings: arrayCount("bindings", "Bindings", live.bindings.length),
+    projections: arrayCount("projections", "Projections", live.projections.length),
+    operations: arrayCount("operations", "Operations", live.ops.length),
+    actionNeeded: arrayCount("actionNeeded", "Action needed", actionNeededCount),
+    queuedWrites: arrayCount("queuedWrites", "Queued writes", live.queuedWriteCount),
+    backend: {
+      skills: countField("backendSkills", "Backend skills", backendCounts.skills, "backend counts.skills is unavailable"),
+      targets: countField("backendTargets", "Backend targets", backendCounts.targets, "backend counts.targets is unavailable"),
+      bindings: countField("backendBindings", "Backend bindings", backendCounts.bindings, "backend counts.bindings is unavailable"),
+      projections: countField(
+        "backendProjections",
+        "Backend projections",
+        backendCounts.projections,
+        "backend counts.projections is unavailable",
+      ),
+      operations: countField(
+        "backendOperations",
+        "Backend operations",
+        backendCounts.operations,
+        "backend counts.operations is unavailable",
+      ),
+    },
+  };
+
+  const pages = PAGE_ORDER.map((key): PageViewModel => {
+    const countByPage: Partial<Record<PanelPageKey, CountViewModel>> = {
+      skills: shellCounts.skills,
+      targets: shellCounts.targets,
+      bindings: shellCounts.bindings,
+      projections: shellCounts.projections,
+      ops: shellCounts.actionNeeded,
+    };
+    const count = countByPage[key];
+    return {
+      key,
+      label: PAGE_LABELS[key],
+      group: PAGE_GROUPS[key],
+      count: count?.value,
+      countLabel: key === "ops" && actionNeededCount > 0 ? formatActionNeededBadge(actionNeededCount) : count?.display,
+      countTitle: key === "ops" ? "Replayable or failed activity rows" : count?.label,
+    };
+  });
+
+  const actions: Record<ActionViewModel["key"], ActionViewModel> = {
+    addSkill: mutationAction("addSkill", "Add skill", options.readOnly, true, "action unavailable", actionReadOnlyReason),
+    addTarget: mutationAction("addTarget", "Add target", options.readOnly, true, "action unavailable", actionReadOnlyReason),
+    addBinding: mutationAction(
+      "addBinding",
+      "Add binding",
+      options.readOnly,
+      live.targets.length > 0,
+      "add a target first",
+      actionReadOnlyReason,
+    ),
+    projectSkill: mutationAction(
+      "projectSkill",
+      "Project skill",
+      options.readOnly,
+      live.bindings.length > 0,
+      "add a binding first",
+      actionReadOnlyReason,
+    ),
+    captureSkill: mutationAction(
+      "captureSkill",
+      "Capture skill",
+      options.readOnly,
+      live.bindings.length > 0,
+      "add a binding first",
+      actionReadOnlyReason,
+    ),
+    cleanOrphans: mutationAction(
+      "cleanOrphans",
+      "Clean orphan projections",
+      options.readOnly,
+      live.projections.some((projection) => !projection.binding_id),
+      "no orphan projections",
+      actionReadOnlyReason,
+    ),
+    replayQueued: mutationAction(
+      "replayQueued",
+      "Replay queued writes",
+      options.readOnly,
+      live.queuedWriteCount > 0,
+      "queue empty",
+      actionReadOnlyReason,
+    ),
+    repairHistory: mutationAction(
+      "repairHistory",
+      "Repair history",
+      options.historyReadOnly ?? options.readOnly,
+      true,
+      "history is read-only",
+      options.historyReadOnly && !options.readOnly ? "pending operations must be replayed or purged first" : actionReadOnlyReason,
+    ),
+    syncPull: mutationAction("syncPull", "Pull remote", options.readOnly, true, "action unavailable", actionReadOnlyReason),
+    syncPush: mutationAction(
+      "syncPush",
+      "Push remote",
+      options.readOnly,
+      live.queuedWriteCount === 0,
+      "replay queued writes first",
+      actionReadOnlyReason,
+    ),
+  };
+
+  return {
+    shell: {
+      status: statusForLiveData(live),
+      pages,
+      counts: shellCounts,
+      registryRoot: textField(live.registryRoot, "workspace root is unavailable"),
+      remoteState: textField(live.remote?.sync_state, "remote sync state is unavailable"),
+      readOnly: options.readOnly,
+      readOnlyReason,
+    },
+    skills: live.skills.map(selectSkillViewModel),
+    targets: live.targets.map(selectTargetViewModel),
+    bindings: live.bindings.map(selectBindingViewModel),
+    projections: live.projections.map(selectProjectionViewModel),
+    operations: live.ops.map(selectOperationViewModel),
+    actions,
+    graphLinks: selectProjectionLinks(live.projections),
+  };
+}
+
+export function selectSkillViewModel(skill: Skill): SkillViewModel {
+  const targetCount = Array.isArray(skill.targets) ? skill.targets.length : undefined;
+  return {
+    id: skill.id,
+    name: textField(skill.name, "skill name is unavailable"),
+    description: textField(skill.description, "skill description is unavailable"),
+    sourceStatus: enumField(skill.sourceStatus, KNOWN_SOURCE_STATUS, "skill source status is unavailable"),
+    latestRev: textField(skill.latestRev, "latest revision is unavailable"),
+    changed: textField(skill.changed, "latest update time is unavailable"),
+    bindings: countField("bindings", "Bindings", skill.bindingCount, "binding count is unavailable"),
+    projections: countField("projections", "Projections", skill.projectionCount, "projection count is unavailable"),
+    targets: countField("targets", "Targets", targetCount, "target list is unavailable"),
+  };
+}
+
+export function selectTargetViewModel(target: Target): TargetViewModel {
+  return {
+    id: target.id,
+    agent: textField(target.agent, "target agent is unavailable"),
+    profile: textField(target.profile, "target profile is unavailable"),
+    path: textField(target.path, "target path is unavailable"),
+    ownership: enumField(target.ownership, KNOWN_OWNERSHIP, "target ownership is unavailable"),
+    observedSkills: countField("observedSkills", "Observed skills", target.observedSkills, "observed skill count is unavailable"),
+    projectedSkills: countField("projectedSkills", "Projected skills", target.projectedSkills, "projected skill count is unavailable"),
+  };
+}
+
+export function selectBindingViewModel(binding: Binding): BindingViewModel {
+  return {
+    id: binding.id,
+    skill: textField(binding.skill, "binding skill is unavailable"),
+    target: textField(binding.target, "binding target is unavailable"),
+    matcher: textField(binding.matcher, "workspace matcher is unavailable"),
+    method: methodField(binding.method),
+    policy: enumField(binding.policy, KNOWN_POLICIES, "binding policy is unavailable"),
+  };
+}
+
+export function selectProjectionViewModel(projection: RegistryProjection): ProjectionViewModel {
+  return {
+    id: textField(projection.instance_id, "projection instance id is unavailable"),
+    skill: textField(projection.skill_id, "projection skill is unavailable"),
+    target: textField(projection.target_id, "projection target is unavailable"),
+    binding: textField(projection.binding_id, "projection binding is unavailable"),
+    method: methodField(projection.method),
+    health: textField(projection.health, "projection health is unavailable"),
+    materializedPath: textField(projection.materialized_path, "projection path is unavailable"),
+    lastAppliedRev: textField(projection.last_applied_rev, "last applied revision is unavailable"),
+    updatedAt: textField(projection.updated_at, "projection update time is unavailable"),
+    drifted: Boolean(projection.observed_drift),
+  };
+}
+
+export function selectOperationViewModel(operation: Op): OperationViewModel {
+  return {
+    id: textField(operation.id, "operation id is unavailable"),
+    status: enumField(operation.status, KNOWN_OPERATION_STATUS, "operation status is unavailable"),
+    kind: textField(operation.kind, "operation kind is unavailable"),
+    skill: textField(operation.skill, "operation skill is unavailable"),
+    target: textField(operation.target, "operation target is unavailable"),
+    method: methodField(operation.method, "operation method is unavailable"),
+    time: textField(operation.time, "operation timestamp is unavailable"),
+    reason: textField(operation.reason, "operation reason is unavailable"),
+  };
+}

--- a/panel/src/lib/panel_view_model.ts
+++ b/panel/src/lib/panel_view_model.ts
@@ -297,10 +297,14 @@ function mutationAction(
 export function selectProjectionLinks(projections: readonly RegistryProjection[]): ProjectionLink[] {
   return projections.map((projection) => {
     const method = methodField(projection.method);
+    const methodValue =
+      method.state === "available" && (method.label === "symlink" || method.label === "copy" || method.label === "materialize")
+        ? method.label
+        : "unknown";
     return {
       skillId: `s-${projection.skill_id}`,
       targetId: projection.target_id,
-      method: method.label === UNKNOWN ? "unknown" : (method.label as ProjectionMethod),
+      method: methodValue,
     };
   });
 }

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { PanelApp } from "./PanelApp";
 
 const fetchMock = vi.fn<typeof fetch>();
@@ -177,6 +177,17 @@ function installFetchMock(failingPath: string | null = null, failingResponse?: R
             meta: { warnings: [] },
           }),
         );
+      case "/api/v1/sync/replay":
+        return Promise.resolve(
+          jsonResponse({
+            ok: true,
+            cmd: "sync.replay",
+            request_id: "req-replay",
+            data: { replayed: options.pendingCount ?? 0 },
+            error: null,
+            meta: { warnings: [] },
+          }),
+        );
       default:
         return Promise.reject(new Error(`unexpected fetch ${url}`));
     }
@@ -284,6 +295,7 @@ describe("PanelApp status failure UI", () => {
     });
 
     render(<PanelApp />);
+    fireEvent.click(await screen.findByRole("button", { name: /Audit log/i }));
 
     const repairLocal = (await screen.findByRole("button", {
       name: /Repair from local/i,
@@ -352,6 +364,50 @@ describe("PanelApp status failure UI", () => {
       expect(screen.getByText(/Initialize Registry/i)).toBeTruthy();
     });
     expect(screen.getByText(/Scan existing agent skill directories/i)).toBeTruthy();
+  });
+
+  it("opens the command palette with Ctrl+K and navigates to pages and skills", async () => {
+    installSuccessfulFetchMock();
+
+    render(<PanelApp />);
+
+    await screen.findByRole("heading", { name: "Overview" });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+
+    let dialog = await screen.findByRole("dialog", { name: /Command palette/i });
+    const skillsPageOption = within(dialog).getAllByRole("option").find((option) => {
+      const text = option.textContent ?? "";
+      return text.includes("Pages") && text.includes("Skillsskills");
+    });
+    expect(skillsPageOption).toBeTruthy();
+    fireEvent.click(skillsPageOption as HTMLButtonElement);
+
+    await screen.findByRole("heading", { name: "Skills" });
+    expect(localStorage.getItem("loom.page")).toBe("skills");
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    dialog = await screen.findByRole("dialog", { name: /Command palette/i });
+    fireEvent.change(within(dialog).getByRole("searchbox"), { target: { value: "typed-api" } });
+    fireEvent.click(within(dialog).getByText("typed-api-client").closest("button") as HTMLButtonElement);
+
+    await screen.findByRole("heading", { name: "Skills" });
+    expect(localStorage.getItem("loom.page")).toBe("skills");
+  });
+
+  it("replays queued writes from the status bar through the existing sync API", async () => {
+    installFetchMock(null, undefined, { pendingCount: 2 });
+
+    render(<PanelApp />);
+
+    const replay = (await screen.findByRole("button", { name: /queued 2/i })) as HTMLButtonElement;
+    expect(replay.disabled).toBe(false);
+
+    fireEvent.click(replay);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/sync/replay", expect.anything());
+    });
+    expect(await screen.findByText(/Queued writes replayed/i)).toBeTruthy();
   });
 });
 

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
-import type { PanelPageKey, ProjectionLink, ProjectionMethod, TweakState, VizMode } from "../lib/types";
+import { useEffect, useRef, useState } from "react";
+import type { PanelPageKey, TweakState, VizMode } from "../lib/types";
 import { usePanelData } from "../lib/api/usePanelData";
-import { Sidebar } from "../components/panel/Sidebar";
-import { Topbar } from "../components/panel/Topbar";
+import { api } from "../lib/api/client";
+import { ControlRoomShell } from "../components/panel/ControlRoomShell";
 import { TweakPanel } from "../components/panel/TweakPanel";
+import type { ToastViewModel } from "../components/panel/Toasts";
 import { OverviewPage } from "./panel/OverviewPage";
 import { SkillsPage } from "./panel/SkillsPage";
 import { TargetsPage } from "./panel/TargetsPage";
@@ -15,7 +16,7 @@ import { SyncPage } from "./panel/SyncPage";
 import { DoctorPage } from "./panel/DoctorPage";
 import { FirstRunPage } from "./panel/FirstRunPage";
 import { ProjectionsPage } from "./panel/ProjectionsPage";
-import { summarizeOps } from "../lib/count_labels";
+import { selectPanelViewModel } from "../lib/panel_view_model";
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -82,6 +83,8 @@ export function PanelApp() {
   const [tweakVisible, setTweakVisible] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
   const [selectedTarget, setSelectedTarget] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<ToastViewModel[]>([]);
+  const toastIdRef = useRef(0);
 
   const live = usePanelData();
 
@@ -135,18 +138,6 @@ export function PanelApp() {
   const bindings = live.bindings;
   const ops = live.ops;
 
-  // Projection links for the graph:
-  //   - use RegistryProjection.method verbatim (authoritative).
-  const projectionLinks: ProjectionLink[] = useMemo(() => {
-    return live.projections.map((p) => {
-      const method: ProjectionMethod =
-        p.method === "symlink" || p.method === "copy" || p.method === "materialize"
-          ? p.method
-          : "unknown";
-      return { skillId: `s-${p.skill_id}`, targetId: p.target_id, method };
-    });
-  }, [live.projections]);
-
   const densityClass = tweaks.density === "dense" ? " dense" : tweaks.density === "cozy" ? " cozy" : "";
 
   const [mutationVersion, setMutationVersion] = useState(0);
@@ -157,9 +148,43 @@ export function PanelApp() {
   const historyReadOnly = readOnly || live.queuedWriteCount > 0;
   const historyReadOnlyReason =
     live.queuedWriteCount > 0 ? "pending operations must be replayed or purged first" : undefined;
+  const viewModel = selectPanelViewModel(live, { page, readOnly, historyReadOnly });
   const onMutation = () => {
     setMutationVersion((cur) => cur + 1);
     live.refetch();
+  };
+  const pushToast = (toast: Omit<ToastViewModel, "id">) => {
+    const id = `toast-${++toastIdRef.current}`;
+    setToasts((current) => [...current.slice(-2), { ...toast, id }]);
+  };
+  const dismissToast = (id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  };
+  const replayQueued = async () => {
+    const action = viewModel.actions.replayQueued;
+    if (!action.enabled) {
+      pushToast({
+        tone: "warn",
+        title: action.label,
+        detail: action.disabledReason ?? "action unavailable",
+      });
+      return;
+    }
+    try {
+      await api.syncReplay();
+      pushToast({
+        tone: "success",
+        title: "Queued writes replayed",
+        detail: "Live registry data is refreshing.",
+      });
+      onMutation();
+    } catch (error) {
+      pushToast({
+        tone: "error",
+        title: "Replay failed",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
   };
   const onRemoveTarget = (id: string) => {
     setSelectedTarget((cur) => (cur === id ? null : cur));
@@ -168,7 +193,14 @@ export function PanelApp() {
   const onNewBinding = () => setPage("bindings");
   const onOpenSync = () => setPage("sync");
   const onViewActivity = () => setPage("ops");
-  const opCounts = useMemo(() => summarizeOps(ops), [ops]);
+  const selectSkillFromShell = (id: string) => {
+    setSelectedSkill(id);
+    setSelectedTarget(null);
+  };
+  const selectTargetFromShell = (id: string) => {
+    setSelectedTarget(id);
+    setSelectedSkill(null);
+  };
 
   let view: React.ReactNode;
   if (live.mode === "first-run") {
@@ -181,7 +213,7 @@ export function PanelApp() {
             skills={skills}
             targets={targets}
             ops={ops}
-            projections={projectionLinks}
+            projections={viewModel.graphLinks}
             vizMode={tweaks.vizMode}
             setVizMode={setVizMode}
             selectedSkill={selectedSkill}
@@ -287,46 +319,35 @@ export function PanelApp() {
     }
   }
 
+  const banners = (
+    <>
+      <PanelWarningsBanner warnings={live.warnings} />
+      {live.mode !== "live" && <LiveDataBanner error={live.error} loading={live.loading} mode={live.mode} />}
+    </>
+  );
+
   return (
-    <div className={`app ${tweaks.compact ? "compact" : ""}${densityClass}`}>
-      <Topbar
-        page={page}
-        live={live.live}
-        loading={live.loading}
-        error={live.error}
-        mode={live.mode}
-        registryRoot={live.registryRoot}
-        remoteState={live.remote?.sync_state}
-        queuedWriteCount={live.queuedWriteCount}
-        onReplay={onMutation}
-        onToggleTweaks={() => setTweakVisible((value) => !value)}
-        readOnly={readOnly}
-        tweaksOpen={tweakVisible}
-        themeLabel={THEME_LABEL[theme]}
-        onCycleTheme={cycleTheme}
-      />
-      <Sidebar
-        page={page}
-        setPage={setPage}
-        compact={tweaks.compact}
-        counts={{
-          skills: skills.length,
-          targets: targets.length,
-          bindings: bindings.length,
-          projections: live.projections.length,
-          opsAttention: opCounts.actionNeeded,
-        }}
-        registryRoot={live.registryRoot}
-      />
-      <div className="main">
-        <PanelWarningsBanner warnings={live.warnings} />
-        {live.mode !== "live" && <LiveDataBanner error={live.error} loading={live.loading} mode={live.mode} />}
-        {view}
-      </div>
+    <ControlRoomShell
+      className={`${tweaks.compact ? "compact" : ""}${densityClass}`}
+      page={page}
+      viewModel={viewModel}
+      banners={banners}
+      themeLabel={THEME_LABEL[theme]}
+      tweaksOpen={tweakVisible}
+      toasts={toasts}
+      onDismissToast={dismissToast}
+      onNavigate={setPage}
+      onSelectSkill={selectSkillFromShell}
+      onSelectTarget={selectTargetFromShell}
+      onReplayQueued={replayQueued}
+      onCycleTheme={cycleTheme}
+      onToggleTweaks={() => setTweakVisible((value) => !value)}
+    >
+      {view}
       {tweakVisible && (
         <TweakPanel state={tweaks} onChange={patchTweaks} onDismiss={() => setTweakVisible(false)} />
       )}
-    </div>
+    </ControlRoomShell>
   );
 }
 

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import type { PanelPageKey, TweakState, VizMode } from "../lib/types";
 import { usePanelData } from "../lib/api/usePanelData";
 import { api } from "../lib/api/client";
 import { ControlRoomShell } from "../components/panel/ControlRoomShell";
-import { TweakPanel } from "../components/panel/TweakPanel";
 import type { ToastViewModel } from "../components/panel/Toasts";
 import { OverviewPage } from "./panel/OverviewPage";
 import { SkillsPage } from "./panel/SkillsPage";
@@ -17,6 +16,10 @@ import { DoctorPage } from "./panel/DoctorPage";
 import { FirstRunPage } from "./panel/FirstRunPage";
 import { ProjectionsPage } from "./panel/ProjectionsPage";
 import { selectPanelViewModel } from "../lib/panel_view_model";
+
+const TweakPanel = lazy(() =>
+  import("../components/panel/TweakPanel").then((module) => ({ default: module.TweakPanel })),
+);
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -345,7 +348,9 @@ export function PanelApp() {
     >
       {view}
       {tweakVisible && (
-        <TweakPanel state={tweaks} onChange={patchTweaks} onDismiss={() => setTweakVisible(false)} />
+        <Suspense fallback={null}>
+          <TweakPanel state={tweaks} onChange={patchTweaks} onDismiss={() => setTweakVisible(false)} />
+        </Suspense>
       )}
     </ControlRoomShell>
   );

--- a/panel/src/styles/panel/shell.css
+++ b/panel/src/styles/panel/shell.css
@@ -12,275 +12,411 @@ body,
   overflow: hidden;
 }
 
-.app {
+.control-room-shell {
   display: grid;
-  grid-template-columns: 232px 1fr;
-  grid-template-rows: 46px 1fr;
+  grid-template-columns: 64px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) 32px;
   height: 100vh;
+  min-width: 0;
   background: var(--bg-0);
 }
-.app.compact {
-  grid-template-columns: 56px 1fr;
-}
 
-.topbar {
-  grid-column: 1 / -1;
+.activity-bar {
+  grid-row: 1 / -1;
   display: flex;
-  align-items: center;
-  padding: 0 18px;
-  border-bottom: 1px solid var(--line);
-  background: var(--bg-1);
-  gap: 16px;
-}
-
-.topbar .brand {
-  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 10px;
-  font-family: var(--font-display);
-  font-size: 17px;
-  letter-spacing: -0.01em;
-  font-weight: 500;
-  width: 202px;
-  padding-right: 20px;
+  padding: 12px 8px;
+  background: var(--bg-1);
   border-right: 1px solid var(--line);
-  height: 100%;
+  min-height: 0;
 }
 
-.topbar .brand .mark {
-  width: 26px;
-  height: 26px;
+.activity-brand,
+.activity-command,
+.activity-item {
+  width: 42px;
+  min-height: 42px;
+  border-radius: var(--radius);
   display: grid;
   place-items: center;
 }
 
-.topbar .crumbs {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12.5px;
-  color: var(--ink-1);
-}
-.topbar .crumbs .sep {
-  color: var(--ink-3);
-}
-.topbar .crumbs .cur {
+.activity-brand {
   color: var(--ink-0);
+  margin-bottom: 2px;
 }
 
-.topbar .crumbs .registry {
-  font-family: var(--font-mono);
-  font-size: 12px;
+.activity-command,
+.activity-item {
   color: var(--ink-2);
-  padding: 3px 8px;
-  border: 1px solid var(--line-hi);
-  border-radius: var(--radius-sm);
-  background: var(--bg-2);
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
 }
 
-.topbar .spacer {
+.activity-command:hover,
+.activity-item:hover {
+  color: var(--ink-0);
+  background: var(--bg-2);
+  border-color: var(--line-hi);
+}
+
+.activity-item.active {
+  color: var(--accent);
+  background: var(--bg-3);
+  border-color: var(--line-hi);
+}
+
+.activity-item svg,
+.activity-command svg {
+  width: 18px;
+  height: 18px;
+}
+
+.activity-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+
+.activity-spacer {
   flex: 1;
 }
 
-.topbar .top-actions {
+.activity-label {
+  position: absolute;
+  left: 50px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 20;
+  max-width: 160px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-3);
+  border: 1px solid var(--line-hi);
+  color: var(--ink-0);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity 120ms ease;
+}
+
+.activity-item:hover .activity-label,
+.activity-command:hover .activity-label {
+  opacity: 1;
+}
+
+.activity-count {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: var(--bg-hi);
+  color: var(--ink-1);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.shell-workspace {
+  min-width: 0;
+  min-height: 0;
+}
+
+.shell-page-frame {
+  position: relative;
+  height: 100%;
+  overflow: auto;
+  background: radial-gradient(900px 480px at 50% 0%, color-mix(in srgb, var(--accent) 5%, transparent), transparent 60%), var(--bg-0);
+}
+
+.shell-banner-stack {
+  position: sticky;
+  top: 0;
+  z-index: 15;
+}
+
+.status-bar {
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+  padding: 0 12px;
+  border-top: 1px solid var(--line);
+  background: var(--bg-1);
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.status-left,
+.status-right {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
   min-width: 0;
 }
 
-.topbar .top-chip,
-.topbar .top-btn {
-  min-height: 28px;
-  padding: 5px 10px;
-  border-radius: 999px;
-  font-size: 11.5px;
+.status-left {
+  flex: 1;
+}
+
+.status-meta,
+.status-pill,
+.status-action {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
+  gap: 5px;
+  min-width: 0;
   white-space: nowrap;
-  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, opacity 120ms ease;
 }
 
-.topbar .top-chip {
-  background: var(--bg-2);
+.status-meta {
+  max-width: 340px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ink-3);
+}
+
+.status-pill[data-tone="ok"] .status-dot {
+  background: var(--ok);
+}
+.status-pill[data-tone="warn"] .status-dot {
+  background: var(--warn);
+}
+.status-pill[data-tone="err"] .status-dot {
+  background: var(--err);
+}
+.status-pill[data-tone="pending"] .status-dot {
+  background: var(--pending);
+}
+
+.status-action {
+  min-height: 24px;
+  padding: 2px 8px;
   border: 1px solid var(--line-hi);
+  border-radius: var(--radius-sm);
   color: var(--ink-1);
-  cursor: help;
-  user-select: none;
-}
-
-.topbar .top-chip:first-child {
-  color: var(--ink-0);
-}
-
-.topbar .top-chip:nth-child(2) {
-  color: var(--ink-2);
-}
-
-.topbar .top-chip svg,
-.topbar .top-btn svg {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-}
-
-.topbar .top-chip svg {
-  color: var(--ink-2);
-}
-
-.topbar .top-btn {
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--ink-1);
-  cursor: pointer;
-  font-weight: 500;
-}
-
-.topbar .top-btn:hover {
   background: var(--bg-2);
-  border-color: var(--line-hi);
-  color: var(--ink-0);
+  cursor: pointer;
 }
 
-.topbar .top-btn:disabled {
+.status-action:hover {
+  color: var(--ink-0);
+  background: var(--bg-3);
+}
+
+.status-action:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.topbar .top-btn:disabled:hover {
-  background: transparent;
-  border-color: transparent;
-  color: var(--ink-1);
+.status-action svg,
+.status-meta svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
 }
 
-.topbar .status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--ok);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok) 22%, transparent);
-}
-
-.compact .topbar .brand {
-  width: 56px;
-  padding-right: 0;
+.palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: flex-start;
   justify-content: center;
-}
-.compact .topbar .brand .brand-text {
-  display: none;
+  padding-top: 12vh;
+  background: rgba(0, 0, 0, 0.42);
 }
 
-.sidebar {
-  background: var(--bg-1);
-  border-right: 1px solid var(--line);
-  padding: 14px 10px;
+.command-palette {
+  width: min(640px, calc(100vw - 24px));
+  max-height: min(620px, 76vh);
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  border: 1px solid var(--line-hi);
+  border-radius: var(--radius);
+  background: var(--bg-1);
+  box-shadow: var(--shadow);
+  overflow: hidden;
 }
 
-.sidebar .group {
-  margin-bottom: 18px;
-}
-.sidebar .group-label {
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--ink-3);
-  padding: 0 10px 8px;
-  font-weight: 500;
-}
-.compact .sidebar .group-label {
-  display: none;
-}
-
-.sidebar .nav-item {
+.palette-input-row {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 10px;
-  border-radius: var(--radius);
-  font-size: 13px;
-  color: var(--ink-1);
-  width: 100%;
-  text-align: left;
-  margin-bottom: 1px;
-  position: relative;
-}
-.sidebar .nav-item:hover {
-  background: var(--bg-2);
-  color: var(--ink-0);
-}
-.sidebar .nav-item.active {
-  background: var(--bg-3);
-  color: var(--ink-0);
-}
-.sidebar .nav-item.active::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 8px;
-  bottom: 8px;
-  width: 2px;
-  background: var(--accent);
-  border-radius: 0 2px 2px 0;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
 }
 
-.sidebar .nav-icon {
-  width: 16px;
-  height: 16px;
+.palette-input-row svg {
+  width: 18px;
+  height: 18px;
   color: var(--ink-2);
-  flex-shrink: 0;
-}
-.nav-item.active .nav-icon {
-  color: var(--accent);
 }
 
-.sidebar .nav-count {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-size: 11px;
+.palette-input-row input {
+  flex: 1;
+  min-width: 0;
+  color: var(--ink-0);
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font-size: 14px;
+}
+
+.palette-input-row kbd {
   color: var(--ink-3);
-  padding: 1px 6px;
-  border-radius: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  border: 1px solid var(--line-hi);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
+}
+
+.palette-results {
+  overflow: auto;
+  padding: 6px;
+}
+
+.palette-item,
+.palette-empty {
+  width: 100%;
+  min-height: 46px;
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 4px 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  color: var(--ink-1);
+  text-align: left;
+}
+
+.palette-item {
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+}
+
+.palette-item.active,
+.palette-item:hover {
+  color: var(--ink-0);
   background: var(--bg-2);
+  border-color: var(--line-hi);
+}
+
+.palette-item:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.palette-group {
+  grid-row: 1 / span 2;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.palette-label,
+.palette-detail {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
-.nav-item.active .nav-count {
-  background: var(--bg-hi);
-  color: var(--ink-1);
-}
-.compact .sidebar .nav-count {
-  display: none;
-}
-.compact .sidebar .nav-label {
-  display: none;
-}
-.compact .sidebar .nav-item {
-  justify-content: center;
+
+.palette-label {
+  color: inherit;
 }
 
-.sidebar .foot {
-  margin-top: auto;
-  font-size: 11px;
+.palette-detail {
   color: var(--ink-3);
-  border-top: 1px solid var(--line);
-  padding: 12px 10px 4px;
-  font-family: var(--font-mono);
-}
-.compact .sidebar .foot {
-  display: none;
+  font-size: 12px;
 }
 
-.main {
-  position: relative;
-  overflow: auto;
-  background: radial-gradient(900px 480px at 50% 0%, color-mix(in srgb, var(--accent) 5%, transparent), transparent 60%), var(--bg-0);
+.palette-empty {
+  color: var(--ink-3);
+}
+
+.toast-layer {
+  position: fixed;
+  right: 16px;
+  bottom: 44px;
+  z-index: 100;
+  display: grid;
+  gap: 8px;
+  width: min(360px, calc(100vw - 32px));
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line-hi);
+  border-radius: var(--radius);
+  background: var(--bg-1);
+  box-shadow: var(--shadow);
+}
+
+.toast[data-tone="success"] {
+  border-color: color-mix(in srgb, var(--ok) 45%, var(--line-hi));
+}
+.toast[data-tone="warn"] {
+  border-color: color-mix(in srgb, var(--warn) 50%, var(--line-hi));
+}
+.toast[data-tone="error"] {
+  border-color: color-mix(in srgb, var(--err) 50%, var(--line-hi));
+}
+
+.toast-title {
+  color: var(--ink-0);
+  font-weight: 600;
+}
+
+.toast-detail {
+  margin-top: 2px;
+  color: var(--ink-2);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.toast-dismiss {
+  color: var(--ink-3);
+  cursor: pointer;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .page-header {
@@ -322,114 +458,77 @@ body,
 }
 
 @media (max-width: 720px) {
-  .app,
-  .app.compact {
+  .control-room-shell {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto 32px;
   }
 
-  .topbar {
-    grid-column: 1;
-    min-width: 0;
-    padding: 0 10px;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-
-  .topbar .brand,
-  .compact .topbar .brand {
-    width: auto;
-    min-width: 48px;
-    height: 46px;
-    padding-right: 10px;
-    justify-content: flex-start;
-  }
-
-  .compact .topbar .brand .brand-text {
-    display: inline;
-  }
-
-  .topbar .crumbs {
-    min-width: 0;
-    flex: 1 1 150px;
-  }
-
-  .topbar .crumbs .registry {
-    min-width: 0;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .topbar .spacer {
-    display: none;
-  }
-
-  .topbar .top-actions {
-    flex: 1 0 100%;
-    justify-content: flex-start;
-    overflow-x: auto;
-    padding-bottom: 6px;
-  }
-
-  .sidebar {
+  .activity-bar {
     grid-column: 1;
     grid-row: 2;
     border-right: 0;
     border-bottom: 1px solid var(--line);
     padding: 8px 10px;
     flex-direction: row;
-    gap: 10px;
+    justify-content: flex-start;
+    gap: 8px;
     overflow-x: auto;
     overflow-y: hidden;
-    scrollbar-gutter: stable;
-    box-shadow: inset -28px 0 22px -24px rgba(0, 0, 0, 0.9);
   }
 
-  .sidebar::after {
-    content: "";
-    position: sticky;
-    right: -10px;
-    flex: 0 0 24px;
-    align-self: stretch;
-    margin: -8px -10px -8px 0;
-    background: linear-gradient(90deg, rgba(21, 19, 15, 0), var(--bg-1));
-    pointer-events: none;
+  .activity-group {
+    flex-direction: row;
+    gap: 8px;
   }
 
-  .sidebar .group {
-    display: flex;
-    gap: 6px;
-    margin-bottom: 0;
-    flex: 0 0 auto;
-  }
-
-  .sidebar .group-label,
-  .sidebar .foot {
+  .activity-spacer,
+  .activity-brand {
     display: none;
   }
 
-  .sidebar .nav-item {
-    width: auto;
-    margin-bottom: 0;
-    white-space: nowrap;
+  .activity-command,
+  .activity-item {
+    flex: 0 0 auto;
   }
 
-  .sidebar .nav-item.active::before {
-    left: 8px;
-    right: 8px;
-    top: auto;
-    bottom: 0;
-    width: auto;
-    height: 2px;
-    border-radius: 2px 2px 0 0;
+  .activity-label {
+    display: none;
   }
 
-  .main {
+  .shell-workspace {
+    grid-column: 1;
+    grid-row: 1;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .status-bar {
     grid-column: 1;
     grid-row: 3;
-    min-width: 0;
+    overflow-x: auto;
+  }
+
+  .status-right {
+    flex-shrink: 0;
+  }
+
+  .status-meta {
+    max-width: 220px;
+  }
+
+  .palette-backdrop {
+    padding-top: 7vh;
+  }
+
+  .palette-item,
+  .palette-empty {
+    grid-template-columns: 74px minmax(0, 1fr);
+  }
+
+  .toast-layer {
+    right: 10px;
+    bottom: 46px;
+    width: calc(100vw - 20px);
   }
 
   .page-header {

--- a/panel/src/styles/panel/shell.css
+++ b/panel/src/styles/panel/shell.css
@@ -87,30 +87,6 @@ body,
   flex: 1;
 }
 
-.activity-label {
-  position: absolute;
-  left: 50px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 20;
-  max-width: 160px;
-  padding: 4px 8px;
-  border-radius: var(--radius-sm);
-  background: var(--bg-3);
-  border: 1px solid var(--line-hi);
-  color: var(--ink-0);
-  box-shadow: var(--shadow);
-  opacity: 0;
-  pointer-events: none;
-  white-space: nowrap;
-  transition: opacity 120ms ease;
-}
-
-.activity-item:hover .activity-label,
-.activity-command:hover .activity-label {
-  opacity: 1;
-}
-
 .activity-count {
   position: absolute;
   right: 3px;
@@ -136,7 +112,7 @@ body,
   position: relative;
   height: 100%;
   overflow: auto;
-  background: radial-gradient(900px 480px at 50% 0%, color-mix(in srgb, var(--accent) 5%, transparent), transparent 60%), var(--bg-0);
+  background: var(--bg-0);
 }
 
 .shell-banner-stack {
@@ -236,177 +212,6 @@ body,
   flex-shrink: 0;
 }
 
-.palette-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 90;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding-top: 12vh;
-  background: rgba(0, 0, 0, 0.42);
-}
-
-.command-palette {
-  width: min(640px, calc(100vw - 24px));
-  max-height: min(620px, 76vh);
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--line-hi);
-  border-radius: var(--radius);
-  background: var(--bg-1);
-  box-shadow: var(--shadow);
-  overflow: hidden;
-}
-
-.palette-input-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--line);
-}
-
-.palette-input-row svg {
-  width: 18px;
-  height: 18px;
-  color: var(--ink-2);
-}
-
-.palette-input-row input {
-  flex: 1;
-  min-width: 0;
-  color: var(--ink-0);
-  background: transparent;
-  border: 0;
-  outline: 0;
-  font-size: 14px;
-}
-
-.palette-input-row kbd {
-  color: var(--ink-3);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  border: 1px solid var(--line-hi);
-  border-radius: var(--radius-sm);
-  padding: 1px 5px;
-}
-
-.palette-results {
-  overflow: auto;
-  padding: 6px;
-}
-
-.palette-item,
-.palette-empty {
-  width: 100%;
-  min-height: 46px;
-  display: grid;
-  grid-template-columns: 92px minmax(0, 1fr);
-  gap: 4px 10px;
-  align-items: center;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  color: var(--ink-1);
-  text-align: left;
-}
-
-.palette-item {
-  border: 1px solid transparent;
-  background: transparent;
-  cursor: pointer;
-}
-
-.palette-item.active,
-.palette-item:hover {
-  color: var(--ink-0);
-  background: var(--bg-2);
-  border-color: var(--line-hi);
-}
-
-.palette-item:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.palette-group {
-  grid-row: 1 / span 2;
-  color: var(--ink-3);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  text-transform: uppercase;
-}
-
-.palette-label,
-.palette-detail {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.palette-label {
-  color: inherit;
-}
-
-.palette-detail {
-  color: var(--ink-3);
-  font-size: 12px;
-}
-
-.palette-empty {
-  color: var(--ink-3);
-}
-
-.toast-layer {
-  position: fixed;
-  right: 16px;
-  bottom: 44px;
-  z-index: 100;
-  display: grid;
-  gap: 8px;
-  width: min(360px, calc(100vw - 32px));
-}
-
-.toast {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 10px 12px;
-  border: 1px solid var(--line-hi);
-  border-radius: var(--radius);
-  background: var(--bg-1);
-  box-shadow: var(--shadow);
-}
-
-.toast[data-tone="success"] {
-  border-color: color-mix(in srgb, var(--ok) 45%, var(--line-hi));
-}
-.toast[data-tone="warn"] {
-  border-color: color-mix(in srgb, var(--warn) 50%, var(--line-hi));
-}
-.toast[data-tone="error"] {
-  border-color: color-mix(in srgb, var(--err) 50%, var(--line-hi));
-}
-
-.toast-title {
-  color: var(--ink-0);
-  font-weight: 600;
-}
-
-.toast-detail {
-  margin-top: 2px;
-  color: var(--ink-2);
-  font-size: 12px;
-  overflow-wrap: anywhere;
-}
-
-.toast-dismiss {
-  color: var(--ink-3);
-  cursor: pointer;
-}
-
 .sr-only {
   position: absolute;
   width: 1px;
@@ -491,10 +296,6 @@ body,
     flex: 0 0 auto;
   }
 
-  .activity-label {
-    display: none;
-  }
-
   .shell-workspace {
     grid-column: 1;
     grid-row: 1;
@@ -514,21 +315,6 @@ body,
 
   .status-meta {
     max-width: 220px;
-  }
-
-  .palette-backdrop {
-    padding-top: 7vh;
-  }
-
-  .palette-item,
-  .palette-empty {
-    grid-template-columns: 74px minmax(0, 1fr);
-  }
-
-  .toast-layer {
-    right: 10px;
-    bottom: 46px;
-    width: calc(100vw - 20px);
   }
 
   .page-header {


### PR DESCRIPTION
## Summary
- Replace the runtime panel frame with a SkillM-style control-room shell: activity bar, status bar, command palette, and toast layer.
- Add API-backed panel view-model selectors for shell counts, skills, targets, bindings, projections, operations, and mutation availability.
- Keep existing V1 data contracts, read-only mutation gating, first-run/offline banners, and real projection method handling.

## Verification
- `cd panel && bun run typecheck`
- `cd panel && bun run test -- PanelApp panel_view_model`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `cargo check`
- `cargo test`
- `git diff --check`
- `rg "SM_" panel/src` returned no matches

## Visual check
- Started Vite at `http://127.0.0.1:5173/` and confirmed HTTP 200.
- In-app Browser check was blocked by tool availability: `Browser is not available: iab`.
- No local Playwright/Puppeteer package was available for screenshot fallback.

Fixes #303
Fixes #304
