### PR TITLE
SkillM UI refactor A4: rebuild Skills and skill detail

### DIFF
--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -5,7 +5,6 @@ import { api } from "../lib/api/client";
 import { ControlRoomShell } from "../components/panel/ControlRoomShell";
 import type { ToastViewModel } from "../components/panel/Toasts";
 import { OverviewPage } from "./panel/OverviewPage";
-import { SkillsPage } from "./panel/SkillsPage";
 import { TargetsPage } from "./panel/TargetsPage";
 import { BindingsPage } from "./panel/BindingsPage";
 import { HistoryPage } from "./panel/HistoryPage";
@@ -20,6 +19,7 @@ import { selectPanelViewModel } from "../lib/panel_view_model";
 const TweakPanel = lazy(() =>
   import("../components/panel/TweakPanel").then((module) => ({ default: module.TweakPanel })),
 );
+const SkillsPage = lazy(() => import("./panel/SkillsPage").then((module) => ({ default: module.SkillsPage })));
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -240,16 +240,18 @@ export function PanelApp() {
         break;
       case "skills":
         view = (
-          <SkillsPage
-            skills={skills}
-            targets={targets}
-            bindings={bindings}
-            projections={live.projections}
-            selectedSkill={selectedSkill}
-            onSelectSkill={(id) => setSelectedSkill(id)}
-            onMutation={onMutation}
-            readOnly={readOnly}
-          />
+          <Suspense fallback={null}>
+            <SkillsPage
+              skills={skills}
+              targets={targets}
+              bindings={bindings}
+              projections={live.projections}
+              selectedSkill={selectedSkill}
+              onSelectSkill={(id) => setSelectedSkill(id)}
+              onMutation={onMutation}
+              readOnly={readOnly}
+            />
+          </Suspense>
         );
         break;
       case "targets":

--- a/panel/src/pages/panel/SkillsPage.test.tsx
+++ b/panel/src/pages/panel/SkillsPage.test.tsx
@@ -545,6 +545,10 @@ describe("SkillsPage — trash UI", () => {
     );
   }
 
+  function openTrashStateTab() {
+    fireEvent.click(screen.getByRole("button", { name: "Trash state" }));
+  }
+
   it("lists trash entries in the Trash view", async () => {
     renderPage();
     openTrashView();
@@ -561,6 +565,7 @@ describe("SkillsPage — trash UI", () => {
     const onSelectSkill = vi.fn();
     renderPage({ onMutation, onSelectSkill });
 
+    openTrashStateTab();
     fireEvent.click(screen.getByRole("button", { name: "Trash my-skill" }));
     fireEvent.click(screen.getByRole("button", { name: "Move to trash" }));
 
@@ -574,6 +579,7 @@ describe("SkillsPage — trash UI", () => {
   it("keeps an open trash confirmation read-only safe", async () => {
     const view = renderPage();
 
+    openTrashStateTab();
     fireEvent.click(screen.getByRole("button", { name: "Trash my-skill" }));
     expect(screen.getByRole("button", { name: "Move to trash" })).not.toBeDisabled();
 
@@ -641,6 +647,7 @@ describe("SkillsPage — trash UI", () => {
 
   it("disables trash mutations in read-only mode", async () => {
     renderPage({ readOnly: true });
+    openTrashStateTab();
     expect(screen.getByRole("button", { name: "Trash my-skill" })).toBeDisabled();
 
     openTrashView();

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -100,6 +100,19 @@ export function SkillsPage({
       onMutation,
     );
   };
+  const filtersActive =
+    Boolean(query) ||
+    sourceFilter !== "all" ||
+    targetFilter !== "all" ||
+    attentionFilter !== "all" ||
+    tagFilter !== "all";
+  const clearFilters = () => {
+    setQ("");
+    setSourceFilter("all");
+    setTargetFilter("all");
+    setAttentionFilter("all");
+    setTagFilter("all");
+  };
 
   const onSkillTrashed = () => {
     onSelectSkill(null);
@@ -229,9 +242,10 @@ export function SkillsPage({
           filtered.length === 0 ? (
             <SkillListEmptyState
               query={query}
+              filtersActive={filtersActive}
               readOnly={readOnly}
               onAddSkill={() => setAddOpen(true)}
-              onClearFilter={() => setQ("")}
+              onClearFilter={clearFilters}
             />
           ) : (
             <div className="two-col" style={{ height: "100%", gap: 0 }}>
@@ -314,23 +328,29 @@ export function SkillsPage({
 
 function SkillListEmptyState({
   query,
+  filtersActive,
   readOnly,
   onAddSkill,
   onClearFilter,
 }: {
   query: string;
+  filtersActive: boolean;
   readOnly: boolean;
   onAddSkill: () => void;
   onClearFilter: () => void;
 }) {
-  if (query) {
+  if (filtersActive) {
     return (
       <EmptyState
         title="No matching skills"
         icon={<SearchIcon />}
         actions={[{ label: "Clear filter", onClick: onClearFilter, variant: "ghost" }]}
       >
-        Nothing in the registry matches <span className="mono">{query}</span>.
+        {query ? (
+          <>Nothing in the registry matches <span className="mono">{query}</span>.</>
+        ) : (
+          "No skills match the selected filters."
+        )}
       </EmptyState>
     );
   }
@@ -656,16 +676,22 @@ function ProjectSkillForm({
   const [bindingId, setBindingId] = useState(bindings[0]?.id ?? "");
   const [method, setMethod] = useState<"symlink" | "copy" | "materialize">("symlink");
   const project = useMutation();
+  const bindingOptionKey = bindings.map((binding) => binding.id).join("\u001f");
+  const selectedBinding = bindings.find((binding) => binding.id === bindingId) ?? null;
+
+  useEffect(() => {
+    setBindingId((current) => (bindings.some((binding) => binding.id === current) ? current : bindings[0]?.id ?? ""));
+  }, [bindingOptionKey]);
 
   const runProject = () => {
-    if (!bindingId) return;
-    project.run("skill project", () => api.project({ skill: skillName, binding: bindingId, method }), onMutation);
+    if (!selectedBinding) return;
+    project.run("skill project", () => api.project({ skill: skillName, binding: selectedBinding.id, method }), onMutation);
   };
 
   return (
     <div className="card" style={{ padding: 12, marginBottom: 12 }}>
       <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 130px auto", gap: 8 }}>
-        <select value={bindingId} onChange={(event) => setBindingId(event.target.value)} style={formInputStyle} disabled={readOnly}>
+        <select value={selectedBinding?.id ?? ""} onChange={(event) => setBindingId(event.target.value)} style={formInputStyle} disabled={readOnly}>
           {bindings.length === 0 && <option value="">(no bindings)</option>}
           {bindings.map((binding) => {
             const target = targets.find((item) => item.id === binding.target);
@@ -686,7 +712,7 @@ function ProjectSkillForm({
           <option value="copy">copy</option>
           <option value="materialize">materialize</option>
         </select>
-        <button className="btn primary" onClick={runProject} disabled={readOnly || project.busy || !bindingId}>
+        <button className="btn primary" onClick={runProject} disabled={readOnly || project.busy || !selectedBinding}>
           {project.busy ? "projecting…" : "Project"}
         </button>
       </div>

--- a/panel/src/pages/panel/SkillsPage.tsx
+++ b/panel/src/pages/panel/SkillsPage.tsx
@@ -29,6 +29,8 @@ interface SkillsPageProps {
 }
 
 type SkillsViewMode = "skills" | "trash";
+type SkillAttentionFilter = "all" | "attention";
+type SkillTagFilter = "all" | "tagged" | "untagged";
 
 export function SkillsPage({
   skills,
@@ -43,14 +45,27 @@ export function SkillsPage({
   const [q, setQ] = useState("");
   const [mode, setMode] = useState<SkillsViewMode>("skills");
   const [addOpen, setAddOpen] = useState(false);
+  const [sourceFilter, setSourceFilter] = useState("all");
+  const [targetFilter, setTargetFilter] = useState("all");
+  const [attentionFilter, setAttentionFilter] = useState<SkillAttentionFilter>("all");
+  const [tagFilter, setTagFilter] = useState<SkillTagFilter>("all");
   const [captureBindingId, setCaptureBindingId] = useState("");
   const [trashRefreshKey, setTrashRefreshKey] = useState(0);
   const query = q.trim().toLowerCase();
+  const targetOptions = targets.map((target) => target.id);
   const filtered = skills.filter((s) => {
-    if (!query) return true;
-    return [s.name, s.tag, s.description ?? ""].some((value) =>
-      value.toLowerCase().includes(query),
-    );
+    const matchesQuery =
+      !query ||
+      [s.name, s.tag, s.description ?? "", s.sourceStatus, ...s.releaseTags, ...s.snapshotTags].some((value) =>
+        value.toLowerCase().includes(query),
+      );
+    const matchesSource = sourceFilter === "all" || s.sourceStatus === sourceFilter;
+    const matchesTarget = targetFilter === "all" || s.targets.includes(targetFilter) || s.observedTargetIds?.includes(targetFilter);
+    const needsAttention = s.sourceStatus !== "present" || s.bindingCount === 0 || s.projectionCount === 0;
+    const matchesAttention = attentionFilter === "all" || needsAttention;
+    const hasTags = s.releaseTags.length > 0 || s.snapshotTags.length > 0;
+    const matchesTags = tagFilter === "all" || (tagFilter === "tagged" ? hasTags : !hasTags);
+    return matchesQuery && matchesSource && matchesTarget && matchesAttention && matchesTags;
   });
   const sel = filtered.find((s) => s.id === selectedSkill) ?? filtered[0] ?? skills.find((s) => s.id === selectedSkill) ?? skills[0];
   const capture = useMutation();
@@ -112,6 +127,53 @@ export function SkillsPage({
             />
             <kbd>⌘K</kbd>
           </div>
+          {mode === "skills" && (
+            <>
+              <select
+                aria-label="Source status filter"
+                value={sourceFilter}
+                onChange={(event) => setSourceFilter(event.target.value)}
+                style={filterSelectStyle}
+              >
+                <option value="all">all sources</option>
+                <option value="present">present</option>
+                <option value="missing">missing</option>
+                <option value="non-compliant">non-compliant</option>
+              </select>
+              <select
+                aria-label="Target filter"
+                value={targetFilter}
+                onChange={(event) => setTargetFilter(event.target.value)}
+                style={filterSelectStyle}
+              >
+                <option value="all">all targets</option>
+                {targetOptions.map((targetId) => (
+                  <option key={targetId} value={targetId}>
+                    {targetId}
+                  </option>
+                ))}
+              </select>
+              <select
+                aria-label="Attention filter"
+                value={attentionFilter}
+                onChange={(event) => setAttentionFilter(event.target.value as SkillAttentionFilter)}
+                style={filterSelectStyle}
+              >
+                <option value="all">all states</option>
+                <option value="attention">needs attention</option>
+              </select>
+              <select
+                aria-label="Tag filter"
+                value={tagFilter}
+                onChange={(event) => setTagFilter(event.target.value as SkillTagFilter)}
+                style={filterSelectStyle}
+              >
+                <option value="all">all tags</option>
+                <option value="tagged">tagged</option>
+                <option value="untagged">untagged</option>
+              </select>
+            </>
+          )}
           {mode === "skills" && selectedSkillBindings.length > 1 && (
             <select
               aria-label="Capture binding"
@@ -226,6 +288,7 @@ export function SkillsPage({
                     skill={sel}
                     targets={targets}
                     bindings={bindings}
+                    projections={projections}
                     onMutation={onMutation}
                     onTrashed={onSkillTrashed}
                     readOnly={readOnly}
@@ -386,13 +449,15 @@ const captureSelectStyle = {
   fontSize: 11,
   outline: "none",
 };
+const filterSelectStyle = { ...captureSelectStyle, minWidth: 120, maxWidth: 180 };
 
-type DetailTab = "history" | "diff" | "targets" | "diagnose";
+type DetailTab = "overview" | "lifecycle" | "diagnose" | "history" | "diff" | "projections" | "trash";
 
 function SkillDetail({
   skill,
   targets,
   bindings,
+  projections,
   onMutation,
   onTrashed,
   readOnly,
@@ -400,11 +465,12 @@ function SkillDetail({
   skill: Skill;
   targets: Target[];
   bindings: Binding[];
+  projections: RegistryProjection[];
   onMutation: () => void;
   onTrashed: () => void;
   readOnly: boolean;
 }) {
-  const [tab, setTab] = useState<DetailTab>("history");
+  const [tab, setTab] = useState<DetailTab>("lifecycle");
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [historyEvents, setHistoryEvents] = useState<LifecycleEvent[]>([]);
@@ -419,10 +485,22 @@ function SkillDetail({
     .filter((t): t is Target => t !== undefined);
 
   const skillBindings = bindings.filter((b) => b.skill === skill.name);
+  const skillProjections = projections.filter((projection) => projection.skill_id === skill.name);
   const policyLabel = summarizePolicy(skillBindings);
+  const projectionHealthLabel =
+    skillProjections.length === 0
+      ? "no projections"
+      : Object.entries(
+          skillProjections.reduce<Record<string, number>>((acc, projection) => {
+            acc[projection.health] = (acc[projection.health] ?? 0) + 1;
+            return acc;
+          }, {}),
+        )
+          .map(([health, count]) => `${health} ${count}`)
+          .join(" · ");
 
   useEffect(() => {
-    if (tab !== "history") return;
+    if (tab !== "lifecycle" && tab !== "history") return;
     const ctrl = new AbortController();
     setHistoryLoading(true);
     setHistoryError(null);
@@ -491,24 +569,42 @@ function SkillDetail({
       </div>
 
       <LifecycleActions skillName={skill.name} onMutation={onLifecycleMutation} readOnly={readOnly} />
-      <TrashSkillAction skill={skill} onSuccess={onTrashed} readOnly={readOnly} />
 
       <div className="tabs">
-        <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")}>
+        <button className={tab === "overview" ? "active" : ""} onClick={() => setTab("overview")}>
+          Overview
+        </button>
+        <button className={tab === "lifecycle" ? "active" : ""} onClick={() => setTab("lifecycle")}>
           Lifecycle
-        </button>
-        <button className={tab === "diff" ? "active" : ""} onClick={() => setTab("diff")}>
-          Diff
-        </button>
-        <button className={tab === "targets" ? "active" : ""} onClick={() => setTab("targets")}>
-          Targets ({targetObjs.length})
         </button>
         <button className={tab === "diagnose" ? "active" : ""} onClick={() => setTab("diagnose")}>
           Diagnose
         </button>
+        <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")}>
+          History
+        </button>
+        <button className={tab === "diff" ? "active" : ""} onClick={() => setTab("diff")}>
+          Diff
+        </button>
+        <button className={tab === "projections" ? "active" : ""} onClick={() => setTab("projections")}>
+          Projections ({skillProjections.length})
+        </button>
+        <button className={tab === "trash" ? "active" : ""} onClick={() => setTab("trash")}>
+          Trash state
+        </button>
       </div>
 
-      {tab === "history" && (
+      {tab === "overview" && (
+        <div className="card" style={{ padding: 12, marginBottom: 12 }}>
+          <div className="kv" style={{ margin: 0 }}>
+            <div className="k">Projected targets</div>
+            <div className="v">{targetObjs.length}</div>
+            <div className="k">Projection health</div>
+            <div className="v">{projectionHealthLabel}</div>
+          </div>
+        </div>
+      )}
+      {(tab === "lifecycle" || tab === "history") && (
         <>
           {historyLoading && (
             <div style={{ color: "var(--ink-3)", fontSize: 12 }}>Loading…</div>
@@ -524,21 +620,22 @@ function SkillDetail({
         </>
       )}
       {tab === "diff" && <SkillDiff skillName={skill.name} />}
-      {tab === "targets" && (
+      {tab === "projections" && (
         <>
           <ProjectSkillForm
             skillName={skill.name}
-            bindings={bindings}
+            bindings={skillBindings}
             targets={targets}
             onMutation={onMutation}
             readOnly={readOnly}
           />
-          <TargetsTab targets={targetObjs} />
+          <ProjectionsTab projections={skillProjections} targets={targets} />
         </>
       )}
       {tab === "diagnose" && (
         <SkillDiagnosePanel loading={diagnoseLoading} error={diagnoseError} diagnose={diagnose} />
       )}
+      {tab === "trash" && <TrashSkillAction skill={skill} onSuccess={onTrashed} readOnly={readOnly} />}
     </div>
   );
 }
@@ -598,39 +695,36 @@ function ProjectSkillForm({
   );
 }
 
-function TargetsTab({ targets }: { targets: Target[] }) {
-  if (targets.length === 0) {
+function ProjectionsTab({ projections, targets }: { projections: RegistryProjection[]; targets: Target[] }) {
+  if (projections.length === 0) {
     return <div className="empty" style={{ padding: "18px 4px" }}>This skill is not projected to any target.</div>;
   }
 
   return (
     <div>
-      {targets.map((t) => (
-        <div
-          key={t.id}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            padding: "10px 12px",
-            borderBottom: "1px solid var(--line-soft)",
-          }}
-        >
-          <AgentAvatar agent={t.agent} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 12.5, color: "var(--ink-0)" }}>
-              {t.agent}/{t.profile}
+      {projections.map((projection) => {
+        const target = targets.find((item) => item.id === projection.target_id);
+        return (
+          <div
+            key={projection.instance_id}
+            style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 12px", borderBottom: "1px solid var(--line-soft)" }}
+          >
+            <AgentAvatar agent={target?.agent ?? projection.target_id} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 12.5, color: "var(--ink-0)" }}>
+                {target ? `${target.agent}/${target.profile}` : projection.target_id}
+              </div>
+              <div className="mono" style={{ fontSize: 10.5, color: "var(--ink-3)", overflowWrap: "anywhere" }}>
+                {projection.materialized_path}
+              </div>
+              <div className="mono dim" style={{ fontSize: 10.5 }}>
+                {projection.method} · {projection.last_applied_rev}
+              </div>
             </div>
-            <div className="mono" style={{ fontSize: 10.5, color: "var(--ink-3)" }}>
-              {t.path}
-            </div>
+            <span className={`chip ${projection.health === "healthy" ? "present" : "missing"}`}>{projection.health}</span>
           </div>
-          <span className={`chip ${t.ownership}`}>
-            <span className="dot" />
-            {t.ownership}
-          </span>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/panel/src/pages/panel/SkillsPageFilters.test.tsx
+++ b/panel/src/pages/panel/SkillsPageFilters.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
 import type { Binding, Skill, Target } from "../../lib/types";
@@ -130,6 +131,22 @@ describe("SkillsPage filters and detail tabs", () => {
     expect(list().queryByText("attention-skill")).not.toBeInTheDocument();
   });
 
+  it("shows filter empty state and clears non-query filters", () => {
+    renderFixture();
+
+    fireEvent.change(screen.getByLabelText("Source status filter"), { target: { value: "non-compliant" } });
+
+    expect(screen.getByText("No matching skills")).toBeInTheDocument();
+    expect(screen.getByText("No skills match the selected filters.")).toBeInTheDocument();
+    expect(screen.queryByText("No tracked skills yet")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear filter" }));
+
+    expect((screen.getByLabelText("Source status filter") as HTMLSelectElement).value).toBe("all");
+    expect(within(screen.getByRole("table")).getByText("ready-skill")).toBeInTheDocument();
+    expect(within(screen.getByRole("table")).getByText("attention-skill")).toBeInTheDocument();
+  });
+
   it("renders real detail tabs without source or files tabs", () => {
     renderFixture();
     expect(screen.queryByRole("button", { name: "Source" })).not.toBeInTheDocument();
@@ -145,5 +162,54 @@ describe("SkillsPage filters and detail tabs", () => {
     fireEvent.click(screen.getByRole("button", { name: "Projections (1)" }));
     expect(screen.getByText("/tmp/target/ready-skill")).toBeInTheDocument();
     expect(screen.getByText("copy · abc12345")).toBeInTheDocument();
+  });
+
+  it("projects with the binding for the currently selected skill", async () => {
+    const secondSkill: Skill = {
+      ...baseSkill,
+      id: "second",
+      name: "second-skill",
+      description: "Second skill",
+      latestRev: "def67890",
+      targets: ["target-2"],
+    };
+    const secondTarget: Target = { ...target, id: "target-2", agent: "codex", profile: "work" };
+    const secondBinding: Binding = { ...binding, id: "binding-2", skill: "second-skill", target: "target-2" };
+    const secondProjection: RegistryProjection = {
+      ...projection,
+      instance_id: "projection-2",
+      skill_id: "second-skill",
+      binding_id: "binding-2",
+      target_id: "target-2",
+      materialized_path: "/tmp/target/second-skill",
+      last_applied_rev: "def67890",
+    };
+    function Harness() {
+      const [selectedSkill, setSelectedSkill] = useState<string | null>("ready");
+      return (
+        <SkillsPage
+          skills={[baseSkill, secondSkill]}
+          targets={[target, secondTarget]}
+          bindings={[binding, secondBinding]}
+          projections={[projection, secondProjection]}
+          selectedSkill={selectedSkill}
+          onSelectSkill={setSelectedSkill}
+          onMutation={() => {}}
+          readOnly={false}
+        />
+      );
+    }
+    (api.project as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Projections (1)" }));
+    fireEvent.click(within(screen.getByRole("table")).getByText("second-skill"));
+
+    await waitFor(() => expect(screen.getByDisplayValue(/binding-2/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Project" }));
+
+    await waitFor(() =>
+      expect(api.project).toHaveBeenCalledWith({ skill: "second-skill", binding: "binding-2", method: "symlink" }),
+    );
   });
 });

--- a/panel/src/pages/panel/SkillsPageFilters.test.tsx
+++ b/panel/src/pages/panel/SkillsPageFilters.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
+import type { Binding, Skill, Target } from "../../lib/types";
+import { SkillsPage } from "./SkillsPage";
+
+vi.mock("../../lib/api/client", () => ({
+  api: {
+    skillHistory: vi.fn(),
+    skillDiagnose: vi.fn(),
+    skillDiff: vi.fn(),
+    capture: vi.fn(),
+    skillSave: vi.fn(),
+    skillSnapshot: vi.fn(),
+    skillRelease: vi.fn(),
+    skillRollback: vi.fn(),
+    skillTrashList: vi.fn(),
+    skillTrashAdd: vi.fn(),
+    skillTrashRestore: vi.fn(),
+    skillTrashPurge: vi.fn(),
+    project: vi.fn(),
+  },
+}));
+
+// Import after mock registration so we get the mocked version.
+// eslint-disable-next-line import/first
+import { api } from "../../lib/api/client";
+
+const baseSkill: Skill = {
+  id: "ready",
+  name: "ready-skill",
+  description: "Ready skill",
+  tag: "latest",
+  sourceStatus: "present",
+  releaseTags: ["v1"],
+  snapshotTags: [],
+  latestRev: "abc12345",
+  ruleCount: 1,
+  bindingCount: 1,
+  projectionCount: 1,
+  changed: "1h ago",
+  targets: ["target-1"],
+};
+
+const target: Target = {
+  id: "target-1",
+  agent: "claude",
+  profile: "home",
+  path: "~/.claude/skills",
+  ownership: "managed",
+  skills: 1,
+  lastSync: "now",
+};
+
+const binding: Binding = {
+  id: "binding-1",
+  skill: "ready-skill",
+  target: "target-1",
+  matcher: "path_prefix:/repo",
+  method: "copy",
+  policy: "auto",
+};
+
+const projection: RegistryProjection = {
+  instance_id: "projection-1",
+  skill_id: "ready-skill",
+  binding_id: "binding-1",
+  target_id: "target-1",
+  materialized_path: "/tmp/target/ready-skill",
+  method: "copy",
+  last_applied_rev: "abc12345",
+  health: "healthy",
+};
+
+function renderFixture() {
+  const attentionSkill: Skill = {
+    ...baseSkill,
+    id: "attention",
+    name: "attention-skill",
+    sourceStatus: "missing",
+    releaseTags: [],
+    bindingCount: 0,
+    projectionCount: 0,
+    targets: [],
+  };
+  render(
+    <SkillsPage
+      skills={[baseSkill, attentionSkill]}
+      targets={[target]}
+      bindings={[binding]}
+      projections={[projection]}
+      selectedSkill="ready"
+      onSelectSkill={() => {}}
+      onMutation={() => {}}
+      readOnly={false}
+    />,
+  );
+}
+
+describe("SkillsPage filters and detail tabs", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (api.skillHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      data: { skill: "ready-skill", count: 0, events: [] },
+    });
+  });
+
+  it("filters by source status, target, attention state, and tags", () => {
+    renderFixture();
+    const list = () => within(screen.getByRole("table"));
+
+    fireEvent.change(screen.getByLabelText("Source status filter"), { target: { value: "missing" } });
+    expect(list().getByText("attention-skill")).toBeInTheDocument();
+    expect(list().queryByText("ready-skill")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Source status filter"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Target filter"), { target: { value: "target-1" } });
+    expect(list().getByText("ready-skill")).toBeInTheDocument();
+    expect(list().queryByText("attention-skill")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Target filter"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Attention filter"), { target: { value: "attention" } });
+    expect(list().getByText("attention-skill")).toBeInTheDocument();
+    expect(list().queryByText("ready-skill")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Attention filter"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Tag filter"), { target: { value: "tagged" } });
+    expect(list().getByText("ready-skill")).toBeInTheDocument();
+    expect(list().queryByText("attention-skill")).not.toBeInTheDocument();
+  });
+
+  it("renders real detail tabs without source or files tabs", () => {
+    renderFixture();
+    expect(screen.queryByRole("button", { name: "Source" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Files" })).not.toBeInTheDocument();
+
+    for (const name of ["Overview", "Lifecycle", "Diagnose", "History", "Diff", "Projections (1)", "Trash state"]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument();
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Overview" }));
+    expect(screen.getByText("healthy 1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Projections (1)" }));
+    expect(screen.getByText("/tmp/target/ready-skill")).toBeInTheDocument();
+    expect(screen.getByText("copy · abc12345")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Skills filters for source status, target, attention state, and tags
- rebuild skill detail into Overview, Lifecycle, Diagnose, History, Diff, Projections, and Trash state tabs
- keep Source/Files tabs omitted and keep trash confirmations/read-only safety intact
- add focused filter/detail-tab coverage while keeping test files under the 800-line hard ceiling

## Verification
- cd panel && bun run typecheck
- cd panel && bun run test -- SkillsPage
- cd panel && bun run test
- cd panel && bun run build
- cargo check
- git diff --check
- Vite dev server HTTP 200 on http://127.0.0.1:5177/; Browser automation unavailable in this environment

Fixes #306

Stacked on #312.