### PR TITLE
SkillM UI refactor A5: rebuild Control Plane

### DIFF
--- a/panel/src/lib/api/adapters.test.ts
+++ b/panel/src/lib/api/adapters.test.ts
@@ -117,4 +117,32 @@ describe("api adapters enum handling", () => {
     expect(binding.ruleCount).toBe(2);
     expect(binding.skillCount).toBe(2);
   });
+
+  it("keeps a single-rule skill literally named multi projectable", () => {
+    const binding = adaptBinding(
+      {
+        binding_id: "binding-1",
+        agent: "claude",
+        profile_id: "default",
+        workspace_matcher: { kind: "path_prefix", value: "/repo" },
+        default_target_id: "target-1",
+        policy_profile: "auto",
+        active: true,
+      },
+      [
+        {
+          binding_id: "binding-1",
+          skill_id: "multi",
+          target_id: "target-1",
+          method: "copy",
+          watch_policy: "auto",
+        },
+      ],
+    );
+
+    expect(binding.skill).toBe("multi");
+    expect(binding.method).toBe("copy");
+    expect(binding.ruleCount).toBe(1);
+    expect(binding.skillCount).toBe(1);
+  });
 });

--- a/panel/src/lib/api/adapters.test.ts
+++ b/panel/src/lib/api/adapters.test.ts
@@ -82,4 +82,39 @@ describe("api adapters enum handling", () => {
     ).toBe("unknown");
     expect(adaptRegistryOperation(operation({ method: "teleport" })).method).toBe("unknown");
   });
+
+  it("labels multi-rule bindings without fabricating a single projectable skill", () => {
+    const binding = adaptBinding(
+      {
+        binding_id: "binding-1",
+        agent: "claude",
+        profile_id: "default",
+        workspace_matcher: { kind: "path_prefix", value: "/repo" },
+        default_target_id: "target-1",
+        policy_profile: "auto",
+        active: true,
+      },
+      [
+        {
+          binding_id: "binding-1",
+          skill_id: "skill-a",
+          target_id: "target-1",
+          method: "copy",
+          watch_policy: "auto",
+        },
+        {
+          binding_id: "binding-1",
+          skill_id: "skill-b",
+          target_id: "target-1",
+          method: "symlink",
+          watch_policy: "auto",
+        },
+      ],
+    );
+
+    expect(binding.skill).toBe("multi");
+    expect(binding.method).toBe("unknown");
+    expect(binding.ruleCount).toBe(2);
+    expect(binding.skillCount).toBe(2);
+  });
 });

--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -173,14 +173,19 @@ function inferTag(name: string): string {
 }
 
 export function adaptBinding(b: RegistryBinding, rules: RegistryRule[]): Binding {
-  const rule = rules.find((r) => r.binding_id === b.binding_id);
+  const bindingRules = rules.filter((r) => r.binding_id === b.binding_id);
+  const skillCount = new Set(bindingRules.map((rule) => rule.skill_id)).size;
+  const multi = bindingRules.length > 1 || skillCount > 1;
+  const rule = multi ? undefined : bindingRules[0];
   return {
     id: b.binding_id,
-    skill: rule?.skill_id ?? "—",
+    skill: bindingRules.length === 0 ? "—" : multi ? "multi" : bindingRules[0].skill_id,
     target: b.default_target_id,
     matcher: `${b.workspace_matcher.kind}:${b.workspace_matcher.value}`,
     method: rule ? toMethod(rule.method) : "unknown",
     policy: b.policy_profile === "manual" ? "manual" : "auto",
+    ruleCount: bindingRules.length,
+    skillCount,
   };
 }
 

--- a/panel/src/lib/binding_labels.ts
+++ b/panel/src/lib/binding_labels.ts
@@ -1,0 +1,5 @@
+import type { Binding } from "./types";
+
+export function isMultiBinding(binding: Binding): boolean {
+  return binding.skill === "multi" || (binding.ruleCount ?? 0) > 1 || (binding.skillCount ?? 0) > 1;
+}

--- a/panel/src/lib/binding_labels.ts
+++ b/panel/src/lib/binding_labels.ts
@@ -1,5 +1,5 @@
 import type { Binding } from "./types";
 
 export function isMultiBinding(binding: Binding): boolean {
-  return binding.skill === "multi" || (binding.ruleCount ?? 0) > 1 || (binding.skillCount ?? 0) > 1;
+  return (binding.ruleCount ?? 0) > 1 || (binding.skillCount ?? 0) > 1;
 }

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -84,6 +84,8 @@ export interface Binding {
   matcher: string;
   method: ProjectionMethod;
   policy: "auto" | "manual";
+  ruleCount?: number;
+  skillCount?: number;
 }
 
 export type PanelPageKey =

--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -5,21 +5,21 @@ import { api } from "../lib/api/client";
 import { ControlRoomShell } from "../components/panel/ControlRoomShell";
 import type { ToastViewModel } from "../components/panel/Toasts";
 import { OverviewPage } from "./panel/OverviewPage";
-import { TargetsPage } from "./panel/TargetsPage";
-import { BindingsPage } from "./panel/BindingsPage";
 import { HistoryPage } from "./panel/HistoryPage";
 import { OpsPage } from "./panel/OpsPage";
 import { SettingsPage } from "./panel/SettingsPage";
 import { SyncPage } from "./panel/SyncPage";
 import { DoctorPage } from "./panel/DoctorPage";
 import { FirstRunPage } from "./panel/FirstRunPage";
-import { ProjectionsPage } from "./panel/ProjectionsPage";
 import { selectPanelViewModel } from "../lib/panel_view_model";
 
 const TweakPanel = lazy(() =>
   import("../components/panel/TweakPanel").then((module) => ({ default: module.TweakPanel })),
 );
 const SkillsPage = lazy(() => import("./panel/SkillsPage").then((module) => ({ default: module.SkillsPage })));
+const ControlPlanePage = lazy(() =>
+  import("./panel/ControlPlanePage").then((module) => ({ default: module.ControlPlanePage })),
+);
 
 const DEFAULT_TWEAKS: TweakState = {
   vizMode: "loom",
@@ -204,6 +204,24 @@ export function PanelApp() {
     setSelectedTarget(id);
     setSelectedSkill(null);
   };
+  const controlPlane = (initialTab: "targets" | "bindings" | "projections") => (
+    <Suspense fallback={null}>
+      <ControlPlanePage
+        initialTab={initialTab}
+        skills={skills}
+        targets={targets}
+        bindings={bindings}
+        projections={live.projections}
+        selectedTarget={selectedTarget}
+        onSelectTarget={toggleTarget}
+        onRemoveTarget={onRemoveTarget}
+        onMutation={onMutation}
+        onNavigate={setPage}
+        readOnly={readOnly}
+        mutationVersion={mutationVersion}
+      />
+    </Suspense>
+  );
 
   let view: React.ReactNode;
   if (live.mode === "first-run") {
@@ -255,41 +273,13 @@ export function PanelApp() {
         );
         break;
       case "targets":
-        view = (
-          <TargetsPage
-            targets={targets}
-            skills={skills}
-            selectedTarget={selectedTarget}
-            onSelectTarget={toggleTarget}
-            onRemoveTarget={onRemoveTarget}
-            onMutation={onMutation}
-            readOnly={readOnly}
-            mutationVersion={mutationVersion}
-          />
-        );
+        view = controlPlane("targets");
         break;
       case "bindings":
-        view = (
-          <BindingsPage
-            bindings={bindings}
-            targets={targets}
-            projections={live.projections}
-            onMutation={onMutation}
-            readOnly={readOnly}
-            mutationVersion={mutationVersion}
-          />
-        );
+        view = controlPlane("bindings");
         break;
       case "projections":
-        view = (
-          <ProjectionsPage
-            projections={live.projections}
-            targets={targets}
-            bindings={bindings}
-            readOnly={readOnly}
-            onMutation={onMutation}
-          />
-        );
+        view = controlPlane("projections");
         break;
       case "ops":
         view = <OpsPage ops={ops} onMutation={onMutation} readOnly={readOnly} />;

--- a/panel/src/pages/panel/BindingsPage.tsx
+++ b/panel/src/pages/panel/BindingsPage.tsx
@@ -6,6 +6,7 @@ import { BindingIcon, PlusIcon } from "../../components/icons/nav_icons";
 import { EmptyState } from "../../components/panel/EmptyState";
 import { BindingAddForm } from "../../components/panel/forms/BindingAddForm";
 import { api, type BindingShowPayload } from "../../lib/api/client";
+import { isMultiBinding } from "../../lib/binding_labels";
 import { useApiQuery } from "../../lib/useApiQuery";
 import { useMutation } from "../../lib/useMutation";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
@@ -200,7 +201,7 @@ export function BindingsPage({
                           {b.id}
                         </td>
                         <td className="name" data-label="Skill">
-                          {b.skill}
+                          {isMultiBinding(b) ? <span className="badge warn">multi</span> : b.skill}
                         </td>
                         <td data-label="Target">
                           {t && (
@@ -285,7 +286,7 @@ function BindingDetail({
   const t = targets.find((x) => x.id === binding.target);
   const rules = state.kind === "ready" ? state.payload.rules ?? [] : [];
   const projections = state.kind === "ready" ? state.payload.projections ?? [] : [];
-  const canProject = !readOnly && binding.skill !== "—" && Boolean(t) && binding.method !== "unknown";
+  const canProject = !readOnly && binding.skill !== "—" && !isMultiBinding(binding) && Boolean(t) && binding.method !== "unknown";
   const actionBusy = project.busy || remove.busy;
 
   const runProject = () => {
@@ -333,6 +334,8 @@ function BindingDetail({
               ? "registry offline"
               : binding.skill === "—"
               ? "binding has no skill rule"
+              : isMultiBinding(binding)
+              ? "binding has multiple rules; project from a specific skill"
               : !t
               ? "binding target is missing"
               : "project this binding to its target"

--- a/panel/src/pages/panel/ControlPlanePage.test.tsx
+++ b/panel/src/pages/panel/ControlPlanePage.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
+import type { Binding, Skill, Target } from "../../lib/types";
+import { ControlPlanePage } from "./ControlPlanePage";
+
+const target: Target = {
+  id: "target-1",
+  agent: "claude",
+  profile: "home",
+  path: "~/.claude/skills",
+  ownership: "managed",
+  skills: 1,
+  projectedSkills: 1,
+  lastSync: "now",
+};
+
+const skill: Skill = {
+  id: "s-skill.writer",
+  name: "skill.writer",
+  tag: "v1",
+  sourceStatus: "present",
+  releaseTags: ["v1"],
+  snapshotTags: [],
+  latestRev: "abc12345",
+  ruleCount: 2,
+  bindingCount: 1,
+  projectionCount: 2,
+  changed: "now",
+  targets: ["target-1"],
+};
+
+const multiBinding: Binding = {
+  id: "binding-1",
+  skill: "multi",
+  target: "target-1",
+  matcher: "path_prefix:/repo",
+  method: "unknown",
+  policy: "auto",
+  ruleCount: 2,
+  skillCount: 2,
+};
+
+const projections: RegistryProjection[] = [
+  {
+    instance_id: "projection-1",
+    skill_id: "skill.writer",
+    binding_id: "binding-1",
+    target_id: "target-1",
+    materialized_path: "/tmp/projection-1",
+    method: "copy",
+    last_applied_rev: "abc12345",
+    health: "healthy",
+  },
+  {
+    instance_id: "projection-2",
+    skill_id: "skill.reader",
+    binding_id: "binding-1",
+    target_id: "target-1",
+    materialized_path: "/tmp/projection-2",
+    method: "symlink",
+    last_applied_rev: "def67890",
+    health: "drifted",
+  },
+];
+
+function renderControlPlane(initialTab: "targets" | "bindings" | "projections" = "targets") {
+  const onNavigate = vi.fn();
+  render(
+    <ControlPlanePage
+      initialTab={initialTab}
+      skills={[skill]}
+      targets={[target]}
+      bindings={[multiBinding]}
+      projections={projections}
+      selectedTarget={null}
+      onSelectTarget={() => {}}
+      onRemoveTarget={() => {}}
+      onMutation={() => {}}
+      onNavigate={onNavigate}
+      readOnly={false}
+      mutationVersion={0}
+    />,
+  );
+  return { onNavigate };
+}
+
+describe("ControlPlanePage", () => {
+  it("keeps direct target, binding, and projection entry points as tabs", () => {
+    renderControlPlane("bindings");
+
+    expect(screen.getByRole("heading", { name: "Control Plane" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Bindings" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText(/Rules mapping skills to targets/)).toBeInTheDocument();
+  });
+
+  it("renders a graph from real projection method and health values", () => {
+    renderControlPlane("targets");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Graph" }));
+
+    expect(screen.getByText("copy 1 · symlink 1")).toBeInTheDocument();
+    expect(screen.getAllByText("healthy 1 · drifted 1").length).toBeGreaterThan(0);
+    expect(screen.getByText("writes projections · 1 binding · 2 projections")).toBeInTheDocument();
+
+    const routes = screen.getByRole("table");
+    expect(within(routes).getAllByText("multi")).toHaveLength(2);
+    expect(within(routes).getByText("binding-1")).toBeInTheDocument();
+  });
+
+  it("navigates to the matching page key when a direct tab is selected", () => {
+    const { onNavigate } = renderControlPlane("targets");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Projections" }));
+
+    expect(onNavigate).toHaveBeenCalledWith("projections");
+  });
+});

--- a/panel/src/pages/panel/ControlPlanePage.tsx
+++ b/panel/src/pages/panel/ControlPlanePage.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useState } from "react";
+import type { RegistryProjection } from "../../generated/RegistryProjection";
+import type { Binding, PanelPageKey, Skill, Target } from "../../lib/types";
+import { AgentAvatar } from "../../components/panel/AgentAvatar";
+import { isMultiBinding } from "../../lib/binding_labels";
+import { BindingsPage } from "./BindingsPage";
+import { ProjectionsPage } from "./ProjectionsPage";
+import { TargetsPage } from "./TargetsPage";
+
+export type ControlPlaneTab = "graph" | "targets" | "bindings" | "projections";
+
+interface ControlPlanePageProps {
+  initialTab: Exclude<ControlPlaneTab, "graph">;
+  skills: Skill[];
+  targets: Target[];
+  bindings: Binding[];
+  projections: RegistryProjection[];
+  selectedTarget: string | null;
+  onSelectTarget: (id: string) => void;
+  onRemoveTarget: (id: string) => void;
+  onMutation: () => void;
+  onNavigate: (page: PanelPageKey) => void;
+  readOnly: boolean;
+  mutationVersion: number;
+}
+
+const TABS: Array<{ id: ControlPlaneTab; label: string; page?: PanelPageKey }> = [
+  { id: "graph", label: "Graph" },
+  { id: "targets", label: "Targets", page: "targets" },
+  { id: "bindings", label: "Bindings", page: "bindings" },
+  { id: "projections", label: "Projections", page: "projections" },
+];
+
+export function ControlPlanePage({
+  initialTab,
+  skills,
+  targets,
+  bindings,
+  projections,
+  selectedTarget,
+  onSelectTarget,
+  onRemoveTarget,
+  onMutation,
+  onNavigate,
+  readOnly,
+  mutationVersion,
+}: ControlPlanePageProps) {
+  const [tab, setTab] = useState<ControlPlaneTab>(initialTab);
+
+  useEffect(() => setTab(initialTab), [initialTab]);
+
+  const selectTab = (next: ControlPlaneTab) => {
+    setTab(next);
+    const page = TABS.find((item) => item.id === next)?.page;
+    if (page) onNavigate(page);
+  };
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="title-block">
+          <h1>Control Plane</h1>
+          <div className="subtitle">Target ownership, binding routes, and realized projections.</div>
+        </div>
+        <div className="header-actions" role="tablist" aria-label="Control plane tabs">
+          {TABS.map((item) => (
+            <button
+              key={item.id}
+              role="tab"
+              aria-selected={tab === item.id}
+              className={`btn ${tab === item.id ? "primary" : "ghost"}`}
+              onClick={() => selectTab(item.id)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {tab === "graph" && (
+        <ControlPlaneGraph targets={targets} bindings={bindings} projections={projections} />
+      )}
+      {tab === "targets" && (
+        <TargetsPage
+          targets={targets}
+          skills={skills}
+          selectedTarget={selectedTarget}
+          onSelectTarget={onSelectTarget}
+          onRemoveTarget={onRemoveTarget}
+          onMutation={onMutation}
+          readOnly={readOnly}
+          mutationVersion={mutationVersion}
+        />
+      )}
+      {tab === "bindings" && (
+        <BindingsPage
+          bindings={bindings}
+          targets={targets}
+          projections={projections}
+          onMutation={onMutation}
+          readOnly={readOnly}
+          mutationVersion={mutationVersion}
+        />
+      )}
+      {tab === "projections" && (
+        <ProjectionsPage
+          projections={projections}
+          targets={targets}
+          bindings={bindings}
+          readOnly={readOnly}
+          onMutation={onMutation}
+        />
+      )}
+    </>
+  );
+}
+
+function ControlPlaneGraph({
+  targets,
+  bindings,
+  projections,
+}: {
+  targets: Target[];
+  bindings: Binding[];
+  projections: RegistryProjection[];
+}) {
+  const health = useMemo(() => countBy(projections, (projection) => projection.observed_drift ? "drifted" : projection.health || "unknown"), [projections]);
+  const methods = useMemo(() => countBy(projections, (projection) => projection.method || "unknown"), [projections]);
+
+  return (
+    <div className="page-body">
+      <div className="kpi-row" style={{ marginBottom: 16 }}>
+        <Kpi label="Targets" value={targets.length} meta={ownershipSummary(targets)} />
+        <Kpi label="Bindings" value={bindings.length} meta={`${bindings.filter(isMultiBinding).length} multi`} />
+        <Kpi label="Projection methods" value={projections.length} meta={summary(methods)} />
+        <Kpi label="Projection health" value={projections.length} meta={summary(health)} />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(240px, 0.9fr) minmax(320px, 1.2fr)", gap: 16 }}>
+        <section className="card">
+          <div className="card-head">
+            <h3>Targets</h3>
+            <span className="badge">{targets.length}</span>
+          </div>
+          <div className="card-body" style={{ display: "grid", gap: 10 }}>
+            {targets.length === 0 && <div className="empty">No targets registered.</div>}
+            {targets.map((target) => (
+              <TargetCard key={target.id} target={target} bindings={bindings} projections={projections} />
+            ))}
+          </div>
+        </section>
+
+        <section className="card">
+          <div className="card-head">
+            <h3>Routes</h3>
+            <span className="badge">{bindings.length} bindings</span>
+          </div>
+          <div className="card-body" style={{ padding: 0 }}>
+            {bindings.length === 0 ? (
+              <div className="empty" style={{ padding: 18 }}>No binding routes configured.</div>
+            ) : (
+              <table className="tbl mobile-cards">
+                <thead>
+                  <tr>
+                    <th>Binding</th>
+                    <th>Skill</th>
+                    <th>Target</th>
+                    <th>Method</th>
+                    <th>Health</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bindings.map((binding) => (
+                    <BindingGraphRow
+                      key={binding.id}
+                      binding={binding}
+                      target={targets.find((target) => target.id === binding.target)}
+                      projections={projections.filter((projection) => projection.binding_id === binding.id)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function TargetCard({ target, bindings, projections }: { target: Target; bindings: Binding[]; projections: RegistryProjection[] }) {
+  const inboundBindings = bindings.filter((binding) => binding.target === target.id).length;
+  const targetProjections = projections.filter((projection) => projection.target_id === target.id);
+  return (
+    <div style={{ border: "1px solid var(--line)", borderRadius: 6, padding: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <AgentAvatar agent={target.agent} size={28} radius={7} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ color: "var(--ink-0)", fontSize: 13 }}>{target.agent}/{target.profile}</div>
+          <div className="mono" style={{ color: "var(--ink-2)", fontSize: 11, overflowWrap: "anywhere" }}>{target.path}</div>
+        </div>
+        <span className={`chip ${target.ownership}`}>{target.ownership}</span>
+      </div>
+      <div className="mono dim" style={{ marginTop: 9, fontSize: 11 }}>
+        {capabilities(target)} · {inboundBindings} binding{inboundBindings === 1 ? "" : "s"} · {targetProjections.length} projection{targetProjections.length === 1 ? "" : "s"}
+      </div>
+    </div>
+  );
+}
+
+function BindingGraphRow({ binding, target, projections }: { binding: Binding; target?: Target; projections: RegistryProjection[] }) {
+  const health = summary(countBy(projections, (projection) => projection.observed_drift ? "drifted" : projection.health || "unknown"));
+  const method = isMultiBinding(binding) ? "multi" : binding.method;
+  return (
+    <tr>
+      <td className="mono dim" data-label="Binding">{binding.id}</td>
+      <td data-label="Skill">{isMultiBinding(binding) ? <span className="badge warn">multi</span> : binding.skill}</td>
+      <td data-label="Target">{target ? `${target.agent}/${target.profile}` : binding.target}</td>
+      <td data-label="Method"><span className={`chip method ${method}`}>{method}</span></td>
+      <td className="mono dim" data-label="Health">{health || "no projections"}</td>
+    </tr>
+  );
+}
+
+function Kpi({ label, value, meta }: { label: string; value: number; meta: string }) {
+  return (
+    <div className="kpi">
+      <div className="label">{label}</div>
+      <div className="value">{value}</div>
+      <div className="meta">{meta}</div>
+    </div>
+  );
+}
+
+function capabilities(target: Target): string {
+  if (target.ownership === "managed") return "writes projections";
+  if (target.ownership === "observed") return "reads observed inventory";
+  if (target.ownership === "external") return "context only";
+  return "capabilities unknown";
+}
+
+function ownershipSummary(targets: Target[]): string {
+  return summary(countBy(targets, (target) => target.ownership || "unknown")) || "none";
+}
+
+function summary(counts: Record<string, number>): string {
+  return Object.entries(counts).map(([key, value]) => `${key} ${value}`).join(" · ");
+}
+
+function countBy<T>(items: T[], keyOf: (item: T) => string): Record<string, number> {
+  return items.reduce<Record<string, number>>((acc, item) => {
+    const key = keyOf(item);
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
## Summary

- Adds a tabbed Control Plane surface for Graph, Targets, Bindings, and Projections while preserving the existing direct page keys.
- Reuses the existing Targets, Bindings, and Projections pages for their current API-backed details, mutations, read-only gates, and orphan cleanup confirmations.
- Builds the Graph tab only from live targets, bindings, and RegistryProjection method/health data.
- Labels multi-rule bindings as `multi` from the existing registry rules array instead of fabricating a single skill/method.
- Lazy-loads the Control Plane surface so the panel payload budget stays under the perf gate.

Depends on #313. Fixes #307.

## Verification

- `cd panel && bun run typecheck`
- `cd panel && bun run test -- ControlPlanePage TargetsPage BindingsPage ProjectionsPage panel_state`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `cargo check`
- `./scripts/perf-smoke.sh`