### PR TITLE
SkillM UI refactor A6: rebuild Activity History and Sync

### DIFF
--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
 import { api, type OpsHistoryDiagnosePayload, type OpsPayload, type RegistryOperationRecord } from "../../lib/api/client";
 import { MutationBanner } from "../../components/panel/MutationBanner";
@@ -15,6 +15,23 @@ import { SearchIcon } from "../../components/icons/nav_icons";
 type FilterKey = "all" | "pending" | "ok" | "err";
 type DiagnoseData = NonNullable<OpsHistoryDiagnosePayload["data"]>;
 const HISTORY_PAGE_SIZE = 100;
+type HistoryFilters = {
+  source: string;
+  intent: string;
+  skill: string;
+  target: string;
+  binding: string;
+  id: string;
+};
+
+const EMPTY_HISTORY_FILTERS: HistoryFilters = {
+  source: "",
+  intent: "",
+  skill: "",
+  target: "",
+  binding: "",
+  id: "",
+};
 
 type HistoryQueryPayload = {
   ops: NonNullable<OpsPayload["data"]>;
@@ -43,6 +60,8 @@ export function HistoryPage({
 }: HistoryPageProps) {
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<HistoryFilters>(EMPTY_HISTORY_FILTERS);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
   const [repairVersion, setRepairVersion] = useState(0);
   const state = useApiQuery<HistoryQueryPayload>(
@@ -102,15 +121,31 @@ export function HistoryPage({
     const needle = query.trim().toLowerCase();
     return operations.filter((op) => {
       if (filter !== "all" && bucket(op) !== filter) return false;
+      if (!matchesField(op.source, filters.source)) return false;
+      if (!matchesField(op.intent, filters.intent)) return false;
+      if (!matchesField(op.skill, filters.skill)) return false;
+      if (!matchesField(op.target, filters.target)) return false;
+      if (!matchesField(op.binding, filters.binding)) return false;
+      if (!matchesField(registryOperationDisplayId(op), filters.id)) return false;
       if (!needle) return true;
       return (
         registryOperationDisplayId(op).toLowerCase().includes(needle) ||
         describeRegistryOperation(op).title.toLowerCase().includes(needle) ||
         op.intent.toLowerCase().includes(needle) ||
+        (op.source ?? "").toLowerCase().includes(needle) ||
+        (op.skill ?? "").toLowerCase().includes(needle) ||
+        (op.target ?? "").toLowerCase().includes(needle) ||
+        (op.binding ?? "").toLowerCase().includes(needle) ||
         (op.last_error?.message ?? "").toLowerCase().includes(needle)
       );
     });
-  }, [operations, filter, query]);
+  }, [operations, filter, filters, query]);
+
+  useEffect(() => {
+    if (selectedId && !filtered.some((op) => registryOperationDisplayId(op) === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [filtered, selectedId]);
 
   const counts = useMemo(
     () => summarizeOps(operations.map((op) => ({ status: bucket(op) }))),
@@ -130,6 +165,11 @@ export function HistoryPage({
       : payload
       ? `${payload.loaded_count} loaded audit change${payload.loaded_count === 1 ? "" : "s"}.`
       : null;
+  const selectedOperation = filtered.find((op) => registryOperationDisplayId(op) === selectedId) ?? null;
+  const setField = (key: keyof HistoryFilters, value: string) => {
+    setFilters((current) => ({ ...current, [key]: value }));
+  };
+  const hasStructuredFilters = Object.values(filters).some((value) => value.trim().length > 0);
 
   return (
     <>
@@ -223,6 +263,11 @@ export function HistoryPage({
               </button>
             ))}
           </div>
+          {hasStructuredFilters && (
+            <button className="btn sm" onClick={() => setFilters(EMPTY_HISTORY_FILTERS)}>
+              Clear operation filters
+            </button>
+          )}
           {payload && (
             <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
               {historySummary && (
@@ -238,6 +283,22 @@ export function HistoryPage({
               </button>
             </div>
           )}
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+            gap: 8,
+            marginBottom: 12,
+          }}
+        >
+          <FilterInput label="Source filter" value={filters.source} onChange={(value) => setField("source", value)} />
+          <FilterInput label="Command or intent filter" value={filters.intent} onChange={(value) => setField("intent", value)} />
+          <FilterInput label="Skill filter" value={filters.skill} onChange={(value) => setField("skill", value)} />
+          <FilterInput label="Target filter" value={filters.target} onChange={(value) => setField("target", value)} />
+          <FilterInput label="Binding filter" value={filters.binding} onChange={(value) => setField("binding", value)} />
+          <FilterInput label="Request/audit/op id filter" value={filters.id} onChange={(value) => setField("id", value)} />
         </div>
 
         <div
@@ -284,11 +345,20 @@ export function HistoryPage({
                 </tr>
               )}
               {filtered.map((op) => (
-                <OpHistoryRow key={registryOperationDisplayId(op)} op={op} />
+                <OpHistoryRow
+                  key={registryOperationDisplayId(op)}
+                  op={op}
+                  selected={selectedId === registryOperationDisplayId(op)}
+                  onSelect={() => setSelectedId(registryOperationDisplayId(op))}
+                />
               ))}
             </tbody>
           </table>
         </div>
+
+        {selectedOperation && (
+          <HistoryDetailDrawer op={selectedOperation} onClose={() => setSelectedId(null)} />
+        )}
 
         {checkpoint && (
           <div style={{ marginTop: 12, fontSize: 11, color: "var(--ink-3)" }}>
@@ -321,12 +391,20 @@ export function bucket(op: RegistryOperationRecord): "pending" | "ok" | "err" {
   return bucketRegistryOperation(op);
 }
 
-function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
+function OpHistoryRow({
+  op,
+  selected,
+  onSelect,
+}: {
+  op: RegistryOperationRecord;
+  selected: boolean;
+  onSelect: () => void;
+}) {
   const kind = bucket(op);
   const color = kind === "err" ? "var(--err)" : kind === "pending" ? "var(--pending)" : "var(--ok)";
   const label = describeRegistryOperation(op);
   return (
-    <tr>
+    <tr onClick={onSelect} style={{ cursor: "pointer", outline: selected ? "1px solid var(--accent)" : undefined }}>
       <td className="name" data-label="Action">
         <div>{label.title}</div>
         {op.last_error && (
@@ -357,6 +435,81 @@ function OpHistoryRow({ op }: { op: RegistryOperationRecord }) {
       </td>
     </tr>
   );
+}
+
+function FilterInput({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return (
+    <label style={{ display: "grid", gap: 4, minWidth: 0 }}>
+      <span style={{ color: "var(--ink-3)", fontSize: 10.5, textTransform: "uppercase" }}>{label}</span>
+      <input
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="field-input"
+        style={{ minHeight: 30, fontSize: 11 }}
+      />
+    </label>
+  );
+}
+
+function HistoryDetailDrawer({ op, onClose }: { op: RegistryOperationRecord; onClose: () => void }) {
+  const payload = summarizePayload(op.payload);
+  const effects = summarizePayload(op.effects);
+  return (
+    <div className="card" style={{ marginTop: 14 }}>
+      <div className="card-head">
+        <h3>Audit detail</h3>
+        <button className="btn sm" onClick={onClose}>Close</button>
+      </div>
+      <div className="card-body">
+        <div className="kv" style={{ margin: 0 }}>
+          <div className="k">Operation id</div>
+          <div className="v mono">{op.op_id ?? "—"}</div>
+          <div className="k">Audit id</div>
+          <div className="v mono">{op.audit_id ?? "—"}</div>
+          <div className="k">Request id</div>
+          <div className="v mono">{op.request_id ?? "—"}</div>
+          <div className="k">Source</div>
+          <div className="v mono">{op.source ?? "—"}</div>
+          <div className="k">Reason/error</div>
+          <div className="v">{op.last_error ? `${op.last_error.code}: ${op.last_error.message}` : "—"}</div>
+          <div className="k">Payload</div>
+          <div className="v mono">{payload}</div>
+          <div className="k">Effects</div>
+          <div className="v mono">{effects}</div>
+          <div className="k">Related objects</div>
+          <div className="v mono">{relatedObjects(op).join(" · ") || "—"}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function matchesField(value: string | null | undefined, filter: string): boolean {
+  const needle = filter.trim().toLowerCase();
+  return !needle || (value ?? "").toLowerCase().includes(needle);
+}
+
+function summarizePayload(value: unknown): string {
+  if (value == null) return "—";
+  if (typeof value !== "object") return String(value);
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return "{}";
+  return entries.slice(0, 4).map(([key, item]) => `${key}:${payloadValue(item)}`).join(" · ");
+}
+
+function payloadValue(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.length}]`;
+  if (value && typeof value === "object") return "{...}";
+  return String(value);
+}
+
+function relatedObjects(op: RegistryOperationRecord): string[] {
+  return [
+    op.skill ? `skill ${op.skill}` : null,
+    op.target ? `target ${op.target}` : null,
+    op.binding ? `binding ${op.binding}` : null,
+  ].filter((item): item is string => Boolean(item));
 }
 
 function Kpi({ label, value, tone }: { label: string; value: string | number; tone?: "pending" | "err" }) {

--- a/panel/src/pages/panel/HistoryPage.tsx
+++ b/panel/src/pages/panel/HistoryPage.tsx
@@ -126,7 +126,7 @@ export function HistoryPage({
       if (!matchesField(op.skill, filters.skill)) return false;
       if (!matchesField(op.target, filters.target)) return false;
       if (!matchesField(op.binding, filters.binding)) return false;
-      if (!matchesField(registryOperationDisplayId(op), filters.id)) return false;
+      if (!matchesIdFilter(op, filters.id)) return false;
       if (!needle) return true;
       return (
         registryOperationDisplayId(op).toLowerCase().includes(needle) ||
@@ -490,6 +490,14 @@ function matchesField(value: string | null | undefined, filter: string): boolean
   return !needle || (value ?? "").toLowerCase().includes(needle);
 }
 
+function matchesIdFilter(op: RegistryOperationRecord, filter: string): boolean {
+  const needle = filter.trim().toLowerCase();
+  if (!needle) return true;
+  return [op.op_id, op.audit_id, op.request_id, registryOperationDisplayId(op)]
+    .filter((value): value is string => Boolean(value))
+    .some((value) => value.toLowerCase().includes(needle));
+}
+
 function summarizePayload(value: unknown): string {
   if (value == null) return "—";
   if (typeof value !== "object") return String(value);
@@ -501,7 +509,8 @@ function summarizePayload(value: unknown): string {
 function payloadValue(value: unknown): string {
   if (Array.isArray(value)) return `[${value.length}]`;
   if (value && typeof value === "object") return "{...}";
-  return String(value);
+  const text = String(value);
+  return text.length > 80 ? `${text.slice(0, 77)}...` : text;
 }
 
 function relatedObjects(op: RegistryOperationRecord): string[] {

--- a/panel/src/pages/panel/OpsHistorySyncPage.test.tsx
+++ b/panel/src/pages/panel/OpsHistorySyncPage.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api, type RegistryOperationRecord } from "../../lib/api/client";
+import type { Op } from "../../lib/types";
+import { HistoryPage } from "./HistoryPage";
+import { OpsPage } from "./OpsPage";
+import { SyncPage } from "./SyncPage";
+
+function activity(status: Op["status"], id: string): Op {
+  return {
+    id,
+    status,
+    kind: status === "pending" ? "sync.replay" : "skill.project",
+    skill: id,
+    target: "target-1",
+    method: "copy",
+    time: "now",
+    reason: status === "err" ? "failed to write" : undefined,
+  };
+}
+
+function operation(overrides: Partial<RegistryOperationRecord> = {}): RegistryOperationRecord {
+  return {
+    op_id: "op-1",
+    audit_id: "audit-1",
+    request_id: "req-1",
+    source: "panel",
+    intent: "skill.project",
+    status: "succeeded",
+    ack: false,
+    skill: "skill.writer",
+    target: "target-1",
+    binding: "binding-1",
+    method: "copy",
+    payload: { skill: "skill.writer", target: "target-1" },
+    effects: { projection: "projection-1" },
+    created_at: "2026-04-09T10:05:00Z",
+    updated_at: "2026-04-09T10:05:00Z",
+    ...overrides,
+  };
+}
+
+function diagnosePayload(conflictCount = 0) {
+  return {
+    ok: true,
+    data: {
+      local_branch: true,
+      remote_tracking: true,
+      ahead: 0,
+      behind: 0,
+      local_segments: 1,
+      local_archives: 0,
+      remote_segments: 1,
+      remote_archives: 0,
+      local_snapshot: true,
+      remote_snapshot: true,
+      compact_after_segments: 8,
+      retain_recent_segments: 4,
+      retain_archives: 4,
+      conflicts: Array.from({ length: conflictCount }, (_, index) => ({
+        scope: "segment",
+        path: `segments/${index}.jsonl`,
+        local_blob: "local",
+        remote_blob: "remote",
+        local_rename_path: `segments/${index}.local.jsonl`,
+        remote_rename_path: `segments/${index}.remote.jsonl`,
+      })),
+    },
+  };
+}
+
+describe("Ops, History, and Sync pages", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("orders Activity rows with replayable and failed work first", () => {
+    const { container } = render(
+      <OpsPage
+        ops={[activity("ok", "done-skill"), activity("pending", "queued-skill"), activity("err", "failed-skill")]}
+        onMutation={() => {}}
+        readOnly={false}
+      />,
+    );
+
+    const rows = Array.from(container.querySelectorAll(".op-row")).map((row) => row.textContent ?? "");
+    expect(rows[0]).toContain("queued-skill");
+    expect(rows[1]).toContain("failed-skill");
+    expect(rows[2]).toContain("done-skill");
+  });
+
+  it("filters Audit History by real fields and opens raw detail", async () => {
+    vi.spyOn(api, "ops").mockResolvedValue({
+      ok: true,
+      data: {
+        count: 1,
+        loaded_count: 1,
+        offset: 0,
+        limit: 100,
+        has_more: false,
+        operations: [operation()],
+      },
+    });
+    vi.spyOn(api, "opsHistoryDiagnose").mockResolvedValue(diagnosePayload());
+
+    render(<HistoryPage live={true} mode="live" mutationVersion={0} />);
+
+    expect(await screen.findByText(/skill.writer skill projection done/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Skill filter"), { target: { value: "writer" } });
+    expect(screen.getByText(/skill.writer skill projection done/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Request/audit/op id filter"), { target: { value: "missing-id" } });
+    expect(screen.getByText("No activity matches the current filter.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Clear operation filters"));
+    fireEvent.click(screen.getByText(/skill.writer skill projection done/i));
+
+    expect(await screen.findByText("Audit detail")).toBeInTheDocument();
+    expect(screen.getByText("op-1")).toBeInTheDocument();
+    expect(screen.getByText("audit-1")).toBeInTheDocument();
+    expect(screen.getByText("req-1")).toBeInTheDocument();
+    expect(screen.getByText(/skill:skill.writer/)).toBeInTheDocument();
+    expect(screen.getAllByText(/binding binding-1/).length).toBeGreaterThan(0);
+  });
+
+  it("exposes a manual Sync history diagnosis action", async () => {
+    const diagnose = vi.spyOn(api, "opsHistoryDiagnose").mockResolvedValue(diagnosePayload());
+
+    render(
+      <SyncPage
+        remote={{ configured: true, url: "git@example.com:loom.git", ahead: 0, behind: 0, sync_state: "clean" }}
+        queuedWriteCount={0}
+        registryRoot="/tmp/loom"
+        readOnly={false}
+        onMutation={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(diagnose).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "Diagnose history" }));
+    await waitFor(() => expect(diagnose).toHaveBeenCalledTimes(2));
+  });
+});

--- a/panel/src/pages/panel/OpsHistorySyncPage.test.tsx
+++ b/panel/src/pages/panel/OpsHistorySyncPage.test.tsx
@@ -108,6 +108,9 @@ describe("Ops, History, and Sync pages", () => {
     expect(await screen.findByText(/skill.writer skill projection done/i)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Skill filter"), { target: { value: "writer" } });
     expect(screen.getByText(/skill.writer skill projection done/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Request/audit/op id filter"), { target: { value: "req-1" } });
+    expect(screen.getByText(/skill.writer skill projection done/i)).toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText("Request/audit/op id filter"), { target: { value: "missing-id" } });
     expect(screen.getByText("No activity matches the current filter.")).toBeInTheDocument();
 
@@ -120,6 +123,27 @@ describe("Ops, History, and Sync pages", () => {
     expect(screen.getByText("req-1")).toBeInTheDocument();
     expect(screen.getByText(/skill:skill.writer/)).toBeInTheDocument();
     expect(screen.getAllByText(/binding binding-1/).length).toBeGreaterThan(0);
+  });
+
+  it("truncates large primitive payload fields in Audit History detail", async () => {
+    vi.spyOn(api, "ops").mockResolvedValue({
+      ok: true,
+      data: {
+        count: 1,
+        loaded_count: 1,
+        offset: 0,
+        limit: 100,
+        has_more: false,
+        operations: [operation({ payload: { note: "x".repeat(120) } })],
+      },
+    });
+    vi.spyOn(api, "opsHistoryDiagnose").mockResolvedValue(diagnosePayload());
+
+    render(<HistoryPage live={true} mode="live" mutationVersion={0} />);
+    fireEvent.click(await screen.findByText(/skill.writer skill projection done/i));
+
+    expect(screen.getByText(/^note:x{77}\.\.\.$/)).toBeInTheDocument();
+    expect(screen.queryByText(`note:${"x".repeat(120)}`)).not.toBeInTheDocument();
   });
 
   it("exposes a manual Sync history diagnosis action", async () => {

--- a/panel/src/pages/panel/OpsPage.tsx
+++ b/panel/src/pages/panel/OpsPage.tsx
@@ -17,9 +17,11 @@ interface OpsPageProps {
 
 export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
   const [filter, setFilter] = useState<FilterKey>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const retry = useMutation();
   const purge = useMutation();
-  const filtered = filter === "all" ? ops : ops.filter((o) => o.status === filter);
+  const filtered = prioritizeActionNeeded(filter === "all" ? ops : ops.filter((o) => o.status === filter));
+  const selected = filtered.find((op) => op.id === selectedId) ?? null;
   const counts = summarizeOps(ops);
   const finalized = counts.ok + counts.err;
   const successRate = finalized > 0 ? (counts.ok / finalized) * 100 : null;
@@ -145,11 +147,62 @@ export function OpsPage({ ops, onMutation, readOnly }: OpsPageProps) {
               {ops.length === 0 ? "No activity yet." : "No activity matches the current filter."}
             </div>
           ) : (
-            filtered.map((o) => <OpRow key={o.id} op={o} />)
+            filtered.map((o) => (
+              <div
+                key={o.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => setSelectedId(o.id)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") setSelectedId(o.id);
+                }}
+                style={{ cursor: "pointer" }}
+              >
+                <OpRow op={o} />
+              </div>
+            ))
           )}
         </div>
+        {selected && <ActivityDetail op={selected} onClose={() => setSelectedId(null)} />}
       </div>
     </>
+  );
+}
+
+function prioritizeActionNeeded(ops: Op[]): Op[] {
+  return [...ops].sort((a, b) => statusPriority(a.status) - statusPriority(b.status));
+}
+
+function statusPriority(status: OpStatus): number {
+  if (status === "pending") return 0;
+  if (status === "err") return 1;
+  return 2;
+}
+
+function ActivityDetail({ op, onClose }: { op: Op; onClose: () => void }) {
+  return (
+    <div className="card" style={{ marginTop: 16 }}>
+      <div className="card-head">
+        <h3>Activity detail</h3>
+        <button className="btn sm" onClick={onClose}>Close</button>
+      </div>
+      <div className="card-body">
+        <div className="kv" style={{ margin: 0 }}>
+          <div className="k">Raw id</div>
+          <div className="v mono">{op.id}</div>
+          <div className="k">Command</div>
+          <div className="v mono">{op.kind}</div>
+          <div className="k">Skill</div>
+          <div className="v mono">{op.skill}</div>
+          <div className="k">Target</div>
+          <div className="v mono">{op.target}</div>
+          <div className="k">Method</div>
+          <div className="v mono">{op.method}</div>
+          <div className="k">Reason</div>
+          <div className="v">{op.reason ?? "—"}</div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/panel/src/pages/panel/SyncPage.tsx
+++ b/panel/src/pages/panel/SyncPage.tsx
@@ -182,6 +182,14 @@ export function SyncPage({ remote, queuedWriteCount, registryRoot, refreshKey, r
         <div className="card" style={{ marginBottom: 16 }}>
           <div className="card-head">
             <h3>History repair</h3>
+            <button
+              className="btn sm"
+              disabled={readOnly || diagnoseLoading}
+              onClick={() => setRepairVersion((value) => value + 1)}
+              title={readOnly ? "registry offline" : "re-run history branch diagnosis"}
+            >
+              Diagnose history
+            </button>
             <span className={`chip ${diagnoseLoading ? "" : diagnoseError || conflictCount > 0 ? "warn" : "ok"}`}>
               {diagnoseLoading
                 ? "checking"


### PR DESCRIPTION
## Summary

- Keeps V1 wording while making Activity prioritize replayable and failed/action-needed rows.
- Adds Activity detail disclosure with raw id, command, skill, target, method, and reason fields.
- Expands Audit History with structured filters for status, source, command/intent, skill, target, binding, and request/audit/op id.
- Adds an audit detail panel with raw ids, reason/error, payload/effects summaries, and related object links.
- Adds an explicit Sync history diagnosis action while preserving existing set remote/pull/push/replay/history repair API semantics.

Depends on #314. Fixes #308.

## Verification

- `cd panel && bun run typecheck`
- `cd panel && bun run test -- OpsPage HistoryPage SyncPage operation_labels count_labels PanelOperationLoop OpsHistorySyncPage`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `cargo check`
- `./scripts/perf-smoke.sh`