### PR TITLE
SkillM UI refactor A7: polish Doctor Settings and First Run

### DIFF
--- a/panel/src/pages/PanelApp.tsx
+++ b/panel/src/pages/PanelApp.tsx
@@ -310,7 +310,7 @@ export function PanelApp() {
         );
         break;
       case "doctor":
-        view = <DoctorPage apiReachable={live.apiReachable} mode={live.mode} refreshKey={live.lastUpdated} />;
+        view = <DoctorPage apiReachable={live.apiReachable} mode={live.mode} refreshKey={live.lastUpdated} onNavigate={setPage} />;
         break;
       case "settings":
         view = <SettingsPage live={live.live} mode={live.mode} registryRoot={live.registryRoot} />;

--- a/panel/src/pages/panel/DoctorPage.tsx
+++ b/panel/src/pages/panel/DoctorPage.tsx
@@ -168,12 +168,16 @@ function DoctorRow({ check, onNavigate }: { check: DoctorCheck; onNavigate?: (pa
 }
 
 function nextActionPage(check: DoctorCheck): PanelPageKey {
-  const id = check.id.toLowerCase();
-  if (id.includes("target")) return "targets";
-  if (id.includes("binding")) return "bindings";
-  if (id.includes("projection")) return "projections";
-  if (id.includes("history") || id.includes("pending")) return "history";
-  if (id.includes("git")) return "sync";
+  const idRoot = check.id.split(":")[0].toLowerCase();
+  if (idRoot.startsWith("binding_") || check.section === "bindings" || typeof check.details?.binding_id === "string") {
+    return "bindings";
+  }
+  if (idRoot.startsWith("projection_") || check.section === "projections") return "projections";
+  if (idRoot.startsWith("target_") || check.section === "targets" || typeof check.details?.target_id === "string") {
+    return "targets";
+  }
+  if (idRoot.includes("history") || idRoot.includes("pending")) return "history";
+  if (idRoot.includes("git")) return "sync";
   return "settings";
 }
 

--- a/panel/src/pages/panel/DoctorPage.tsx
+++ b/panel/src/pages/panel/DoctorPage.tsx
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useState } from "react";
 import { RefreshIcon, ShieldIcon } from "../../components/icons/nav_icons";
 import { api, ApiError, type DoctorCheck, type DoctorPayload } from "../../lib/api/client";
 import type { PanelDataMode } from "../../lib/api/usePanelData";
+import type { PanelPageKey } from "../../lib/types";
 
 interface DoctorPageProps {
   apiReachable: boolean;
   mode: PanelDataMode;
   refreshKey: string | null;
+  onNavigate?: (page: PanelPageKey) => void;
 }
 
 type DoctorState =
@@ -15,7 +17,7 @@ type DoctorState =
   | { kind: "ready"; payload: DoctorPayload }
   | { kind: "error"; message: string };
 
-export function DoctorPage({ apiReachable, mode, refreshKey }: DoctorPageProps) {
+export function DoctorPage({ apiReachable, mode, refreshKey, onNavigate }: DoctorPageProps) {
   const [state, setState] = useState<DoctorState>({ kind: "idle" });
   const [manualTick, setManualTick] = useState(0);
 
@@ -44,6 +46,7 @@ export function DoctorPage({ apiReachable, mode, refreshKey }: DoctorPageProps) 
   const checks = state.kind === "ready" ? state.payload.checks_v1 ?? [] : [];
   const failed = checks.filter((check) => !check.ok);
   const grouped = useMemo(() => groupChecks(checks), [checks]);
+  const passed = checks.length - failed.length;
 
   return (
     <>
@@ -84,8 +87,13 @@ export function DoctorPage({ apiReachable, mode, refreshKey }: DoctorPageProps) 
             title="Total registry integrity probes executed by `loom workspace doctor`"
           />
           <Kpi
+            label="Sections"
+            value={grouped.length}
+            title="Doctor sections returned by the backend."
+          />
+          <Kpi
             label="Needs action"
-            value={failed.length}
+            value={`${failed.length} failed / ${passed} passed`}
             tone={failed.length > 0 ? "pending" : undefined}
             title="Failed doctor checks. Independent from pending sync."
           />
@@ -107,7 +115,7 @@ export function DoctorPage({ apiReachable, mode, refreshKey }: DoctorPageProps) 
                   <table className="tbl" style={{ fontSize: 12 }}>
                     <tbody>
                       {sectionChecks.map((check) => (
-                        <DoctorRow key={check.id} check={check} />
+                        <DoctorRow key={check.id} check={check} onNavigate={onNavigate} />
                       ))}
                     </tbody>
                   </table>
@@ -121,7 +129,7 @@ export function DoctorPage({ apiReachable, mode, refreshKey }: DoctorPageProps) 
   );
 }
 
-function DoctorRow({ check }: { check: DoctorCheck }) {
+function DoctorRow({ check, onNavigate }: { check: DoctorCheck; onNavigate?: (page: PanelPageKey) => void }) {
   const label = doctorCheckLabel(check);
   const context = doctorCheckContext(check);
 
@@ -144,12 +152,46 @@ function DoctorRow({ check }: { check: DoctorCheck }) {
       <td>
         <div style={{ color: "var(--ink-1)" }}>{check.message}</div>
         {!check.ok && check.next_action && (
-          <div style={{ color: "var(--ink-3)", marginTop: 3 }}>{check.next_action}</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", marginTop: 5 }}>
+            <span style={{ color: "var(--ink-3)" }}>{check.next_action}</span>
+            {onNavigate && (
+              <button className="btn sm" onClick={() => onNavigate(nextActionPage(check))}>
+                Open {nextActionPageLabel(check)}
+              </button>
+            )}
+          </div>
         )}
         {check.id === "agent_skill_inventory" && <AgentInventoryDetails details={check.details} />}
       </td>
     </tr>
   );
+}
+
+function nextActionPage(check: DoctorCheck): PanelPageKey {
+  const id = check.id.toLowerCase();
+  if (id.includes("target")) return "targets";
+  if (id.includes("binding")) return "bindings";
+  if (id.includes("projection")) return "projections";
+  if (id.includes("history") || id.includes("pending")) return "history";
+  if (id.includes("git")) return "sync";
+  return "settings";
+}
+
+function nextActionPageLabel(check: DoctorCheck): string {
+  const page = nextActionPage(check);
+  const labels: Record<PanelPageKey, string> = {
+    overview: "Overview",
+    skills: "Skills",
+    targets: "Targets",
+    bindings: "Bindings",
+    projections: "Projections",
+    ops: "Activity",
+    history: "Audit History",
+    sync: "Sync",
+    doctor: "Doctor",
+    settings: "Settings",
+  };
+  return labels[page];
 }
 
 type AgentInventoryRow = {

--- a/panel/src/pages/panel/DoctorSettingsScanability.test.tsx
+++ b/panel/src/pages/panel/DoctorSettingsScanability.test.tsx
@@ -80,6 +80,53 @@ test("DoctorPage renders human labels before internal check IDs", async () => {
   }
 });
 
+test("DoctorPage routes binding and projection checks before target fallback", async () => {
+  const originalDoctor = api.workspaceDoctor;
+  const payload: DoctorPayload = {
+    healthy: false,
+    checks_v1: [
+      {
+        section: "bindings",
+        id: "binding_target_exists:binding_claude_missing",
+        ok: false,
+        severity: "error",
+        message: "binding default target is missing",
+        next_action: "remove or update the binding",
+        details: {
+          binding_id: "binding_claude_missing",
+          target_id: "target_claude_missing",
+        },
+      },
+      {
+        section: "projections",
+        id: "projection_path_exists:projection_1",
+        ok: false,
+        severity: "warning",
+        message: "projection path is missing",
+        next_action: "recreate or capture the projection",
+        details: {
+          instance_id: "projection_1",
+          target_id: "target_claude_project_a",
+        },
+      },
+    ],
+  };
+  api.workspaceDoctor = async () => payload;
+
+  try {
+    const navigate = vi.fn();
+    render(<DoctorPage apiReachable={true} mode="live" refreshKey="tick-1" onNavigate={navigate} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open Bindings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Projections" }));
+
+    expect(navigate).toHaveBeenNthCalledWith(1, "bindings");
+    expect(navigate).toHaveBeenNthCalledWith(2, "projections");
+  } finally {
+    api.workspaceDoctor = originalDoctor;
+  }
+});
+
 test("SettingsPage wraps long paths and exposes copy buttons", async () => {
   const originalInfo = api.info;
   api.info = async () => ({

--- a/panel/src/pages/panel/DoctorSettingsScanability.test.tsx
+++ b/panel/src/pages/panel/DoctorSettingsScanability.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, expect, test } from "vitest";
+import { afterAll, beforeEach, expect, test, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { api, type DoctorPayload } from "../../lib/api/client";
 import { DoctorPage } from "./DoctorPage";
@@ -62,7 +62,8 @@ test("DoctorPage renders human labels before internal check IDs", async () => {
   api.workspaceDoctor = async () => payload;
 
   try {
-    const { container } = render(<DoctorPage apiReachable={true} mode="live" refreshKey="tick-1" />);
+    const navigate = vi.fn();
+    const { container } = render(<DoctorPage apiReachable={true} mode="live" refreshKey="tick-1" onNavigate={navigate} />);
 
     await screen.findByText("Git integrity");
     expect(screen.getByText("Target path")).toBeTruthy();
@@ -71,6 +72,9 @@ test("DoctorPage renders human labels before internal check IDs", async () => {
 
     const rendered = container.textContent ?? "";
     expect(rendered.indexOf("Target path")).toBeLessThan(rendered.indexOf("target_path_exists:target_claude_claude_project_a"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Targets" }));
+    expect(navigate).toHaveBeenCalledWith("targets");
   } finally {
     api.workspaceDoctor = originalDoctor;
   }
@@ -96,6 +100,9 @@ test("SettingsPage wraps long paths and exposes copy buttons", async () => {
     const { container } = render(<SettingsPage live={true} mode="live" registryRoot="/tmp/loom-registry-with-a-long-path" />);
 
     await screen.findByText("/tmp/home/.claude/projects/example-with-a-long-name/skills");
+    expect(screen.getByText("Operational metadata")).toBeInTheDocument();
+    expect(screen.getByText("Local preferences")).toBeInTheDocument();
+    expect(screen.getByText("Reduced motion")).toBeInTheDocument();
     expect(container.querySelector(".setting-path-text")).toBeTruthy();
     expect(container.querySelector(".setting-copy-btn")).toBeTruthy();
 

--- a/panel/src/pages/panel/FirstRunPage.tsx
+++ b/panel/src/pages/panel/FirstRunPage.tsx
@@ -58,6 +58,11 @@ export function FirstRunPage({ registryRoot, onReady }: FirstRunPageProps) {
             {result && <span className="chip ok">ready</span>}
           </div>
           <div className="card-body">
+            <div className="kpi-row" style={{ marginBottom: 14 }}>
+              <FirstRunKpi label="Registry root" value={registryRoot ?? "not connected"} />
+              <FirstRunKpi label="Scan mode" value={scanExisting ? "scan existing dirs" : "initialize only"} />
+              <FirstRunKpi label="State" value={running ? "running" : result ? "ready" : "waiting"} />
+            </div>
             <label style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 14 }}>
               <input
                 type="checkbox"
@@ -77,5 +82,14 @@ export function FirstRunPage({ registryRoot, onReady }: FirstRunPageProps) {
         </div>
       </div>
     </>
+  );
+}
+
+function FirstRunKpi({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="kpi">
+      <div className="label">{label}</div>
+      <div className="value status-value">{value}</div>
+    </div>
   );
 }

--- a/panel/src/pages/panel/SettingsPage.tsx
+++ b/panel/src/pages/panel/SettingsPage.tsx
@@ -38,6 +38,10 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
   const [info, setInfo] = useState<InfoState>({ kind: "idle" });
   const [cleared, setCleared] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState<{ value: string; state: "copied" | "failed" } | null>(null);
+  const reducedMotion =
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
 
   useEffect(() => {
     if (!live) {
@@ -117,7 +121,7 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
         {!live && <div className="empty" style={{ marginBottom: 16 }}>{offlineHint}</div>}
         <div className="card" style={{ marginBottom: 16 }}>
           <div className="card-head">
-            <h3>Registry paths</h3>
+            <h3>Operational metadata</h3>
             {info.kind === "loading" && <span className="chip">loading…</span>}
             {info.kind === "error" && <span className="chip" style={{ color: "var(--err)" }}>fetch failed</span>}
           </div>
@@ -153,13 +157,20 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
 
         <div className="card">
           <div className="card-head">
-            <h3>UI preferences</h3>
+            <h3>Local preferences</h3>
             {cleared && <span className="chip ok">cleared · reloading…</span>}
           </div>
           <div className="card-body" style={{ fontSize: 12 }}>
+            <div className="kv" style={{ marginTop: 0, marginBottom: 12 }}>
+              <div className="k">Theme</div>
+              <div className="v mono">{localStorage.getItem("loom.theme") ?? "dark"}</div>
+              <div className="k">Density</div>
+              <div className="v mono">{readDensityPreference()}</div>
+              <div className="k">Reduced motion</div>
+              <div className="v mono">{reducedMotion ? "system reduce" : "system no-preference"}</div>
+            </div>
             <div style={{ marginBottom: 10, color: "var(--ink-2)" }}>
-              Viz mode, accent, density, font and compact toggle live in{" "}
-              <span className="mono">localStorage.loom.tweaks</span>. Click below to reset to defaults and reload.
+              Theme, density, accent, font and compact mode are local browser preferences. Click below to reset them and reload.
             </div>
             <button className="btn" onClick={resetTweaks} disabled={cleared}>
               Reset UI preferences
@@ -169,6 +180,17 @@ export function SettingsPage({ live, mode, registryRoot }: SettingsPageProps) {
       </div>
     </>
   );
+}
+
+function readDensityPreference(): string {
+  const raw = localStorage.getItem("loom.tweaks");
+  if (!raw) return "normal";
+  try {
+    const parsed = JSON.parse(raw) as { density?: unknown };
+    return typeof parsed.density === "string" ? parsed.density : "normal";
+  } catch {
+    return "normal";
+  }
 }
 
 function SettingValue({


### PR DESCRIPTION
## Summary

- Restyles Doctor summary with section/pass-fail counts while preserving structured fetch behavior and offline no-fetch behavior.
- Adds Doctor next-action buttons that route to the relevant page when PanelApp provides navigation.
- Splits Settings into operational metadata and local preferences, including theme/density/reduced-motion state.
- Keeps root guard read-only: no unsupported mutable toggle is added.
- Adds First Run operational status KPIs while preserving the API-backed initialization flow.

Depends on #315. Fixes #309.

## Verification

- `cd panel && bun run typecheck`
- `cd panel && bun run test -- Doctor Settings FirstRun panel_state_live_refresh DoctorSettingsScanability`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `cargo check`
- `./scripts/perf-smoke.sh`