### PR TITLE
[codex] Replace Panel with SkillM UI

### DIFF
--- a/panel/src/lib/api/adapters.test.ts
+++ b/panel/src/lib/api/adapters.test.ts
@@ -27,6 +27,15 @@ describe("adaptRegistryOperation", () => {
       ).status,
     ).toBe("err");
   });
+
+  it("preserves raw timestamps for real activity aggregation", () => {
+    const adapted = adaptRegistryOperation(
+      operation({ created_at: "2026-05-28T12:00:00Z", updated_at: "2026-05-29T13:00:00Z" }),
+    );
+
+    expect(adapted.createdAt).toBe("2026-05-28T12:00:00Z");
+    expect(adapted.updatedAt).toBe("2026-05-29T13:00:00Z");
+  });
 });
 
 describe("api adapters enum handling", () => {

--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -209,6 +209,8 @@ export function adaptPendingOp(op: PendingOp, index: number): Op {
     target: targetField,
     method: methodField,
     time: op.created_at ? relativeTime(op.created_at) : "queued",
+    createdAt: op.created_at,
+    updatedAt: op.created_at,
   };
 }
 
@@ -221,6 +223,8 @@ export function adaptRegistryOperation(op: RegistryOperationRecord): Op {
     target: op.target ?? op.binding ?? "—",
     method: op.method ? toMethod(op.method) : "—",
     time: op.updated_at ? relativeTime(op.updated_at) : "—",
+    createdAt: op.created_at,
+    updatedAt: op.updated_at,
     reason: op.last_error?.message,
   };
 }
@@ -244,6 +248,7 @@ export function adaptProjectionOp(p: RegistryProjection, index: AdapterIndex): O
     target: t ? `${toAgentSlug(t.agent)}/${profileFromPath(t.path)}` : p.target_id,
     method: toMethod(p.method),
     time: p.updated_at ? relativeTime(p.updated_at) : "—",
+    updatedAt: p.updated_at,
     reason: drifted ? `health=${p.health}${p.observed_drift ? "; drift observed" : ""}` : undefined,
   };
 }

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { RegistryProjection } from "../../generated/RegistryProjection";
-import type { HealthPayload, RemotePayload, RegistryPayload } from "../../types";
+import type { HealthPayload, InfoPayload, RemotePayload, RegistryPayload } from "../../types";
 import type { Binding, Op, Skill, Target } from "../types";
 import {
   adaptBinding,
@@ -14,6 +14,7 @@ import {
 import { ApiError, api } from "./client";
 
 type RegistryCounts = NonNullable<NonNullable<RegistryPayload["data"]>["counts"]>;
+type AgentDir = NonNullable<InfoPayload["agent_dirs"]>[number];
 
 export type PanelDataMode = "live" | "first-run" | "offline-empty" | "offline-stale";
 
@@ -26,6 +27,7 @@ export interface PanelLiveData {
   setupRequired: boolean;
   lastUpdated: string | null;
   registryRoot: string | null;
+  agentDirs: AgentDir[];
   remote: RemotePayload | null;
   warnings: string[];
   health: HealthPayload | null;
@@ -56,6 +58,7 @@ const INITIAL_STATE: LiveState = {
   setupRequired: false,
   lastUpdated: null,
   registryRoot: null,
+  agentDirs: [],
   remote: null,
   warnings: [],
   health: null,
@@ -154,6 +157,7 @@ export function usePanelData(): PanelLiveData {
             error: null,
             lastUpdated: new Date().toISOString(),
             registryRoot: info.data.root ?? null,
+            agentDirs: info.data.agent_dirs ?? [],
             remote: null,
             warnings: baseWarnings,
             health,
@@ -221,6 +225,7 @@ export function usePanelData(): PanelLiveData {
           error: null,
           lastUpdated: new Date().toISOString(),
           registryRoot: info.data.root ?? null,
+          agentDirs: info.data.agent_dirs ?? [],
           remote: remote.data.remote ?? null,
           warnings,
           health,

--- a/panel/src/lib/panel_view_model.test.ts
+++ b/panel/src/lib/panel_view_model.test.ts
@@ -20,6 +20,7 @@ function liveData(overrides: Partial<PanelLiveData> = {}): PanelLiveData {
     setupRequired: false,
     lastUpdated: "2026-06-11T12:00:00Z",
     registryRoot: "/tmp/loom",
+    agentDirs: [],
     remote: { sync_state: "CLEAN" },
     warnings: [],
     health: { ok: true },

--- a/panel/src/lib/types.ts
+++ b/panel/src/lib/types.ts
@@ -74,6 +74,9 @@ export interface Op {
   target: string;
   method: ProjectionMethod | "—";
   time: string;
+  /** Raw backend timestamps. Used for real activity aggregation. */
+  createdAt?: string;
+  updatedAt?: string;
   reason?: string;
 }
 

--- a/panel/src/pages/PanelApp.test.tsx
+++ b/panel/src/pages/PanelApp.test.tsx
@@ -1,25 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { PanelApp } from "./PanelApp";
+import { errorResponse, jsonResponse } from "./test_utils";
 
 const fetchMock = vi.fn<typeof fetch>();
-
-function jsonResponse(body: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    json: vi.fn().mockResolvedValue(body),
-  } as unknown as Response;
-}
-
-function errorResponse(status: number, body: unknown): Response {
-  return {
-    ok: false,
-    status,
-    statusText: "Service Unavailable",
-    json: vi.fn().mockResolvedValue(body),
-  } as unknown as Response;
-}
 
 interface FetchMockOptions {
   skillsWarnings?: string[];

--- a/panel/src/pages/SkillMAuditHistory.tsx
+++ b/panel/src/pages/SkillMAuditHistory.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import { api, type OpsPayload, type RegistryOperationRecord } from "../lib/api/client";
+
+const HISTORY_PAGE_SIZE = 100;
+
+type HistoryData = NonNullable<OpsPayload["data"]>;
+
+interface SkillMAuditHistoryProps {
+  live: boolean;
+  refreshKey: string | null;
+}
+
+interface HistoryState {
+  loading: boolean;
+  error: string | null;
+  data: HistoryData | null;
+}
+
+const INITIAL_HISTORY_STATE: HistoryState = {
+  loading: false,
+  error: null,
+  data: null,
+};
+
+export function SkillMAuditHistory({ live, refreshKey }: SkillMAuditHistoryProps) {
+  const [offset, setOffset] = useState(0);
+  const [state, setState] = useState<HistoryState>(INITIAL_HISTORY_STATE);
+
+  useEffect(() => {
+    if (!live) {
+      setState(INITIAL_HISTORY_STATE);
+      return;
+    }
+
+    const controller = new AbortController();
+    setState((current) => ({ ...current, loading: true, error: null }));
+
+    api.ops({ limit: HISTORY_PAGE_SIZE, offset }, controller.signal)
+      .then((response) => {
+        if (controller.signal.aborted) return;
+        if (!response.ok || !response.data) {
+          setState({
+            loading: false,
+            error: response.error?.message ?? "audit history fetch returned ok=false",
+            data: null,
+          });
+          return;
+        }
+        setState({ loading: false, error: null, data: response.data });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setState({
+          loading: false,
+          error: error instanceof Error ? error.message : String(error),
+          data: null,
+        });
+      });
+
+    return () => controller.abort();
+  }, [live, offset, refreshKey]);
+
+  if (!live) {
+    return <div className="ops-empty">Audit history needs the live panel API.</div>;
+  }
+
+  const data = state.data;
+  const operations = data?.operations ?? [];
+  const summary = data
+    ? data.count > data.loaded_count
+      ? `Showing ${data.loaded_count} of ${data.count} audit changes.`
+      : `${data.loaded_count} loaded audit change${data.loaded_count === 1 ? "" : "s"}.`
+    : null;
+
+  return (
+    <section className="ops-table">
+      <div className="op-row">
+        <span className="op-pill op-done">history</span>
+        <span className="op-detail">
+          {summary ?? (state.loading ? "Loading audit history..." : "Audit history")}
+        </span>
+        <span className="op-note">{state.error ?? "Fetched from /api/v1/ops, not the overview snapshot."}</span>
+        <span />
+        <button
+          className="btn-ghost xs"
+          onClick={() => setOffset((value) => Math.max(0, value - (data?.limit ?? HISTORY_PAGE_SIZE)))}
+          disabled={!data || data.offset === 0}
+        >
+          newer
+        </button>
+        <button
+          className="btn-ghost xs"
+          onClick={() => setOffset((value) => value + (data?.limit ?? HISTORY_PAGE_SIZE))}
+          disabled={!data?.has_more}
+        >
+          older
+        </button>
+      </div>
+      {state.error && <div className="ops-empty">{state.error}</div>}
+      {!state.error && operations.length === 0 && !state.loading && (
+        <div className="ops-empty">No audit history returned by API.</div>
+      )}
+      {operations.map((op) => <AuditHistoryLine key={historyId(op)} op={op} />)}
+    </section>
+  );
+}
+
+function AuditHistoryLine({ op }: { op: RegistryOperationRecord }) {
+  return (
+    <div className={`op-row op-row-${historyClass(op)}`}>
+      <span className={`op-pill op-${historyClass(op)}`}>{historyStatus(op)}</span>
+      <span className="op-time">{op.updated_at || op.created_at}</span>
+      <span className="op-verb">{op.intent}</span>
+      <span className="op-detail">
+        {op.skill ?? historyId(op)}
+        <span className="op-arrow">
+          {" -> "}
+          <code>{op.target ?? op.binding ?? op.source ?? "registry"}</code>
+        </span>
+      </span>
+      <span className="op-note">{op.last_error?.message ?? op.method ?? op.source ?? historyId(op)}</span>
+    </div>
+  );
+}
+
+function historyId(op: RegistryOperationRecord): string {
+  return op.op_id ?? op.audit_id ?? op.request_id ?? `${op.intent}-${op.created_at}`;
+}
+
+function historyStatus(op: RegistryOperationRecord): "ok" | "pending" | "err" {
+  const status = op.status.toLowerCase();
+  if (status === "failed" || status === "err" || status === "error") return "err";
+  if (status === "pending" || status === "queued" || status === "running") return "pending";
+  return "ok";
+}
+
+function historyClass(op: RegistryOperationRecord): "done" | "pending" | "failed" {
+  const status = historyStatus(op);
+  if (status === "err") return "failed";
+  if (status === "pending") return "pending";
+  return "done";
+}

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -1,15 +1,46 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SkillMPanel } from "./SkillMPanel";
 
 const panelData = vi.hoisted(() => ({
   refetch: vi.fn(),
+  current: null as null | {
+    live: boolean;
+    apiReachable: boolean;
+    loading: boolean;
+    error: string | null;
+    mode: "live" | "first-run" | "offline-empty" | "offline-stale";
+    setupRequired: boolean;
+    lastUpdated: string | null;
+    registryRoot: string | null;
+    agentDirs: unknown[];
+    remote: null;
+    warnings: string[];
+    health: { service: string };
+    counts: Record<string, never>;
+    skills: unknown[];
+    targets: unknown[];
+    bindings: unknown[];
+    ops: Array<{
+      id: string;
+      kind: string;
+      skill: string;
+      target: string;
+      status: "ok" | "err" | "pending";
+      time: string;
+      reason?: string;
+      method?: string;
+    }>;
+    projections: unknown[];
+    queuedWriteCount: number;
+  },
   firstRun: {
     live: true,
     apiReachable: true,
     loading: false,
     error: null,
-    mode: "first-run",
+    mode: "first-run" as const,
     setupRequired: true,
     lastUpdated: "2026-06-12T00:00:00.000Z",
     registryRoot: "/tmp/loom-registry",
@@ -25,11 +56,51 @@ const panelData = vi.hoisted(() => ({
     projections: [],
     queuedWriteCount: 0,
   },
+  liveOps: {
+    live: true,
+    apiReachable: true,
+    loading: false,
+    error: null,
+    mode: "live" as const,
+    setupRequired: false,
+    lastUpdated: "2026-06-12T00:00:00.000Z",
+    registryRoot: "/tmp/loom-registry",
+    agentDirs: [],
+    remote: null,
+    warnings: [],
+    health: { service: "loom-panel" },
+    counts: {},
+    skills: [],
+    targets: [],
+    bindings: [],
+    ops: [
+      {
+        id: "op-ok",
+        kind: "skill.save",
+        skill: "docs",
+        target: "codex",
+        status: "ok" as const,
+        time: "2026-06-12 09:00",
+        method: "copy",
+      },
+      {
+        id: "op-pending",
+        kind: "sync.push",
+        skill: "deploy",
+        target: "claude",
+        status: "pending" as const,
+        time: "2026-06-12 09:05",
+        reason: "queued",
+      },
+    ],
+    projections: [],
+    queuedWriteCount: 0,
+  },
 }));
 
 vi.mock("../lib/api/usePanelData", () => ({
   usePanelData: () => ({
-    ...panelData.firstRun,
+    ...(panelData.current ?? panelData.firstRun),
     refetch: panelData.refetch,
   }),
 }));
@@ -37,14 +108,32 @@ vi.mock("../lib/api/usePanelData", () => ({
 afterEach(() => {
   cleanup();
   panelData.refetch.mockReset();
+  panelData.current = null;
+  window.history.replaceState(null, "", "/");
 });
 
 describe("SkillMPanel", () => {
   it("shows the real first-run initialization flow when registry state is missing", async () => {
+    panelData.current = panelData.firstRun;
     render(<SkillMPanel />);
 
     expect(await screen.findByRole("heading", { name: "Initialize Registry" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Initialize" })).toBeTruthy();
     expect(screen.queryByText("Skill 真实统计")).toBeNull();
+  });
+
+  it("switches between queued ops and audit history tabs", async () => {
+    panelData.current = panelData.liveOps;
+    window.history.replaceState(null, "", "/?view=ops");
+
+    render(<SkillMPanel />);
+
+    expect(screen.getByText("sync.push")).toBeTruthy();
+    expect(screen.queryByText("skill.save")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /审计历史/ }));
+
+    expect(screen.getByText("skill.save")).toBeTruthy();
+    expect(new URL(window.location.href).searchParams.get("view")).toBe("history");
   });
 });

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { api } from "../lib/api/client";
 import { SkillMPanel } from "./SkillMPanel";
 
 const panelData = vi.hoisted(() => ({
@@ -107,6 +108,7 @@ vi.mock("../lib/api/usePanelData", () => ({
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   panelData.refetch.mockReset();
   panelData.current = null;
   window.history.replaceState(null, "", "/");
@@ -125,6 +127,33 @@ describe("SkillMPanel", () => {
   it("switches between queued ops and audit history tabs", async () => {
     panelData.current = panelData.liveOps;
     window.history.replaceState(null, "", "/?view=ops");
+    const ops = vi.spyOn(api, "ops").mockResolvedValue({
+      ok: true,
+      data: {
+        count: 40,
+        loaded_count: 1,
+        offset: 0,
+        limit: 100,
+        has_more: false,
+        operations: [
+          {
+            op_id: "hist-1",
+            audit_id: "audit-1",
+            request_id: "req-1",
+            source: "panel",
+            intent: "skill.release",
+            status: "succeeded",
+            ack: false,
+            skill: "release-notes",
+            target: "codex",
+            binding: null,
+            method: "copy",
+            created_at: "2026-06-12T09:00:00Z",
+            updated_at: "2026-06-12T09:01:00Z",
+          },
+        ],
+      },
+    });
 
     render(<SkillMPanel />);
 
@@ -133,7 +162,9 @@ describe("SkillMPanel", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /审计历史/ }));
 
-    expect(screen.getByText("skill.save")).toBeTruthy();
+    expect(await screen.findByText("skill.release")).toBeTruthy();
+    expect(screen.getByText("release-notes")).toBeTruthy();
+    expect(ops.mock.calls[0]?.[0]).toEqual({ limit: 100, offset: 0 });
     expect(new URL(window.location.href).searchParams.get("view")).toBe("history");
   });
 });

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SkillMPanel } from "./SkillMPanel";
+
+const panelData = vi.hoisted(() => ({
+  refetch: vi.fn(),
+  firstRun: {
+    live: true,
+    apiReachable: true,
+    loading: false,
+    error: null,
+    mode: "first-run",
+    setupRequired: true,
+    lastUpdated: "2026-06-12T00:00:00.000Z",
+    registryRoot: "/tmp/loom-registry",
+    agentDirs: [],
+    remote: null,
+    warnings: [],
+    health: { service: "loom-panel" },
+    counts: {},
+    skills: [],
+    targets: [],
+    bindings: [],
+    ops: [],
+    projections: [],
+    queuedWriteCount: 0,
+  },
+}));
+
+vi.mock("../lib/api/usePanelData", () => ({
+  usePanelData: () => ({
+    ...panelData.firstRun,
+    refetch: panelData.refetch,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  panelData.refetch.mockReset();
+});
+
+describe("SkillMPanel", () => {
+  it("shows the real first-run initialization flow when registry state is missing", async () => {
+    render(<SkillMPanel />);
+
+    expect(await screen.findByRole("heading", { name: "Initialize Registry" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Initialize" })).toBeTruthy();
+    expect(screen.queryByText("Skill 真实统计")).toBeNull();
+  });
+});

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -30,6 +30,8 @@ const iconPath: Record<string, string> = {
   term: "M4 5h16v14H4zM7 9l3 3-3 3M12 15h5",
   plus: "M12 5v14M5 12h14",
   x: "M6 6l12 12M18 6L6 18",
+  check: "M5 12l4 4L19 6",
+  dl: "M12 3v12M7 10l5 5 5-5M5 21h14",
   eye: "M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7zm10 3a3 3 0 100-6 3 3 0 000 6z",
   bolt: "M13 2L4 14h6l-1 8 9-12h-6z",
   market: "M4 7l2-4h12l2 4M4 7h16v3a3 3 0 01-6 0 3 3 0 01-4 0 3 3 0 01-6 0V7zM5 13v8h14v-8",
@@ -273,7 +275,7 @@ export function SkillMPanel() {
               {view === "overview" && <Overview live={live} counts={counts} go={go} />}
               {view === "skills" && <Skills skills={live.skills} targets={live.targets} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
               {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={go} />}
-              {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} runAction={runAction} />}
+              {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} go={go} runAction={runAction} />}
               {view === "sync" && <Sync live={live} runAction={runAction} />}
               {view === "doctor" && <Doctor live={live} go={go} />}
               {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
@@ -604,7 +606,7 @@ function EmptyPanel({ text }: { text: string }) {
   return <div className="panel"><div className="panel-empty">{text}</div></div>;
 }
 
-function Ops({ live, history, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
+function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; go: (page: SkillMPage) => void; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
   const failed = live.ops.filter((op) => op.status === "err").length;
   const pending = live.ops.filter((op) => op.status === "pending").length + live.queuedWriteCount;
   const queue = live.ops.filter((op) => op.status !== "ok");
@@ -616,7 +618,7 @@ function Ops({ live, history, runAction }: { live: ReturnType<typeof usePanelDat
         <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge)}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry)}><Icon d="sync" />replay 队列</button></div>
       </header>
       <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
-      <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
+      <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
       <section className="ops-table">{rows.map((op) => <OpLine key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>{history ? "No operation history returned by API." : "队列已清空 · 没有待处理或失败的操作"}</p></div>}</section>
     </div>
   );

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -40,7 +40,7 @@ const pages: Array<{ id: SkillMPage; icon: string; label: string; group: "build"
   { id: "targets", icon: "target", label: "Targets", group: "build" },
   { id: "bindings", icon: "branch", label: "Bindings", group: "build" },
   { id: "projections", icon: "graph", label: "Projections", group: "build" },
-  { id: "ops", icon: "ops", label: "Ops", group: "build" },
+  { id: "ops", icon: "ops", label: "Activity", group: "build" },
   { id: "history", icon: "clock", label: "Audit log", group: "ops" },
   { id: "sync", icon: "sync", label: "Git sync", group: "ops" },
   { id: "doctor", icon: "shield", label: "Doctor", group: "ops" },
@@ -48,6 +48,27 @@ const pages: Array<{ id: SkillMPage; icon: string; label: string; group: "build"
   { id: "market", icon: "market", label: "Market", group: "ops" },
   { id: "forge", icon: "forge", label: "Forge", group: "ops" },
 ];
+
+const agentMeta: Record<string, { name: string; short: string; color: string }> = {
+  claude: { name: "Claude Code", short: "CC", color: "#d97757" },
+  codex: { name: "Codex", short: "CX", color: "#19c37d" },
+  cursor: { name: "Cursor", short: "CU", color: "#8b8bf5" },
+  windsurf: { name: "Windsurf", short: "WS", color: "#58b2dc" },
+  cline: { name: "Cline", short: "CL", color: "#8b5cf6" },
+  copilot: { name: "Copilot", short: "CP", color: "#22c55e" },
+  aider: { name: "Aider", short: "AD", color: "#f97316" },
+  opencode: { name: "OpenCode", short: "OC", color: "#06b6d4" },
+  "gemini-cli": { name: "Gemini CLI", short: "GM", color: "#4285f4" },
+  goose: { name: "Goose", short: "GO", color: "#a855f7" },
+};
+
+const supportedAgents = ["claude", "codex", "cursor", "windsurf", "cline", "copilot", "aider", "opencode", "gemini-cli", "goose"];
+
+function initialView(): SkillMPage {
+  if (typeof window === "undefined") return "overview";
+  const candidate = new URL(window.location.href).searchParams.get("view");
+  return pages.some((page) => page.id === candidate) ? (candidate as SkillMPage) : "overview";
+}
 
 function Icon({ d, size = 18 }: { d: string; size?: number }) {
   return (
@@ -72,6 +93,22 @@ function sourceLabel(skill: Skill) {
   return "registry";
 }
 
+function registryLabel(root: string | null) {
+  return root?.replace(/^\/Users\/[^/]+/, "~") ?? "~/.loom-registry";
+}
+
+function statusText(ok: boolean, warn: boolean) {
+  if (!ok) return "需修复";
+  if (warn) return "有告警";
+  return "可操作";
+}
+
+function operationTone(status: Op["status"]) {
+  if (status === "ok") return "done";
+  if (status === "err") return "failed";
+  return "pending";
+}
+
 function methodTone(method: string) {
   if (method === "materialize") return "var(--acc1)";
   if (method === "copy") return "var(--acc2)";
@@ -87,7 +124,7 @@ function classForOp(op: Op) {
 
 export function SkillMPanel() {
   const live = usePanelData();
-  const [view, setView] = useState<SkillMPage>("overview");
+  const [view, setView] = useState<SkillMPage>(initialView);
   const [query, setQuery] = useState("");
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -118,6 +155,15 @@ export function SkillMPanel() {
   }, [live.skills, query]);
 
   const selected = live.skills.find((skill) => skill.name === selectedSkill) ?? filteredSkills[0] ?? null;
+
+  const go = (page: SkillMPage) => {
+    setView(page);
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      url.searchParams.set("view", page);
+      window.history.replaceState(null, "", url);
+    }
+  };
 
   const toast = (kind: ToastKind, text: string) => {
     const id = Date.now() + Math.random();
@@ -159,22 +205,22 @@ export function SkillMPanel() {
     >
       <div className="sm-particles skillm-grid-bg" aria-hidden="true" />
       <div className="sm-frame">
-        <ActivityRail view={view} counts={{ ...counts, skills: live.skills.length, targets: live.targets.length, bindings: live.bindings.length, projections: live.projections.length }} onGo={(page) => setView(page)} onTerm={() => setTermOpen((open) => !open)} />
+        <ActivityRail view={view} counts={{ ...counts, skills: live.skills.length, targets: live.targets.length, bindings: live.bindings.length, projections: live.projections.length }} onGo={go} onTerm={() => setTermOpen((open) => !open)} />
         <main className="sm-main" data-screen-label={view}>
-          {view === "overview" && <Overview live={live} counts={counts} go={setView} />}
-          {view === "skills" && <Skills skills={filteredSkills} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
-          {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={setView} />}
+          {view === "overview" && <Overview live={live} counts={counts} go={go} />}
+          {view === "skills" && <Skills skills={live.skills} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
+          {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={go} />}
           {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} runAction={runAction} />}
           {view === "sync" && <Sync live={live} runAction={runAction} />}
-          {view === "doctor" && <Doctor apiReachable={live.apiReachable} live={live.live} />}
+          {view === "doctor" && <Doctor live={live} />}
           {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
-          {view === "market" && <Unavailable title="Market" copy="The SkillM marketplace screen exists in the reference UI, but Loom V1 has no marketplace backend. This stays blank until a real catalog API exists." />}
-          {view === "forge" && <Unavailable title="Forge" copy="The Forge wizard is intentionally not wired yet. Creating skills still requires a real source path or Git URL through the existing add flow." />}
+          {view === "market" && <Market live={live} />}
+          {view === "forge" && <Forge live={live} />}
           {termOpen && <Terminal live={live} close={() => setTermOpen(false)} />}
         </main>
       </div>
       <StatusBar live={live} counts={counts} dark={dark} setDark={setDark} onSync={() => runAction("Replay / sync", api.syncReplay)} onTerm={() => setTermOpen((open) => !open)} onTweaks={() => setTweaksOpen((open) => !open)} />
-      {paletteOpen && <Palette skills={live.skills} go={(page) => { setView(page); setPaletteOpen(false); }} openSkill={(name) => { setSelectedSkill(name); setView("skills"); setPaletteOpen(false); }} close={() => setPaletteOpen(false)} />}
+      {paletteOpen && <Palette skills={live.skills} go={(page) => { go(page); setPaletteOpen(false); }} openSkill={(name) => { setSelectedSkill(name); go("skills"); setPaletteOpen(false); }} close={() => setPaletteOpen(false)} />}
       {tweaksOpen && <Tweaks dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} close={() => setTweaksOpen(false)} />}
       <Toasts items={toasts} dismiss={(id) => setToasts((items) => items.filter((item) => item.id !== id))} />
     </div>
@@ -213,61 +259,116 @@ function Overview({ live, counts, go }: { live: ReturnType<typeof usePanelData>;
   const ownership = tally(live.targets.map((target) => target.ownership));
   const methods = tally(live.projections.map((projection) => projection.method));
   const health = tally(live.projections.map((projection) => projection.health));
-  const lastOp = live.ops[0];
+  const failed = counts.failedOps;
+  const root = registryLabel(live.registryRoot);
   return (
     <div className="view view-dash">
       <header className="dash-hero">
         <div>
-          <div className="hero-kicker">{live.live ? "registry online" : live.apiReachable ? "api degraded" : "api offline"}</div>
-          <h1>SkillM control room for <em>Loom</em></h1>
-          <p>{live.registryRoot ?? "Registry root unavailable"} · {live.mode}</p>
+          <div className="hero-kicker">注册表 · {statusText(live.live, counts.attention > 0 || live.warnings.length > 0)}</div>
+          <h1><em>{root}</em></h1>
+          <p>{live.mode} · {live.live ? "工作区已连接" : live.apiReachable ? "API 可达，注册表降级" : "API offline"} · sync {live.remote?.sync_state ?? "LOCAL_ONLY"}</p>
         </div>
-        <div className="hero-orb"><span /><span /><span /><i className="orb-core" /></div>
+        <div className="hero-orb"><span /><span /><span /><span className="orb-core" /></div>
       </header>
       <section className="stat-row">
-        <Stat label="Skills" value={live.skills.length} sub={`${live.skills.filter((s) => s.observedImported).length} observed`} icon="lib" onClick={() => go("skills")} />
+        <Stat label="Skills" value={live.skills.length} sub={`${live.skills.filter((s) => s.observedImported).length} observed · ${live.skills.filter((s) => s.sourceStatus === "present").length} present`} icon="lib" onClick={() => go("skills")} />
         <Stat label="Targets" value={live.targets.length} sub={`${ownership.managed ?? 0} managed · ${ownership.observed ?? 0} observed`} icon="target" onClick={() => go("targets")} />
-        <Stat label="Bindings" value={live.bindings.length} sub="workspace routes" icon="branch" onClick={() => go("bindings")} />
-        <Stat label="Attention" value={counts.attention} sub={`${counts.pending} queued · ${counts.drifted} drift`} icon="bolt" hot onClick={() => go("ops")} />
+        <Stat label="Bindings" value={live.bindings.length} sub="matcher -> target" icon="branch" onClick={() => go("bindings")} />
+        <Stat label="Projections" value={live.projections.length} sub={`${health.healthy ?? 0} healthy · ${counts.drifted} drift · ${counts.pending} pending`} icon="graph" hot={counts.drifted === 0} onClick={() => go("projections")} />
       </section>
       {live.error && <div className="dash-attn"><div className="da-text"><span className="da-fail"><b>API</b>{live.error}</span></div></div>}
       {live.warnings.length > 0 && <div className="dash-attn"><div className="da-text">{live.warnings.slice(0, 3).map((warning) => <span key={warning}><b>warning</b>{warning}</span>)}</div></div>}
+      {(counts.pending || failed || counts.drifted) ? (
+        <div className="dash-attn">
+          <span className="da-text">
+            {counts.drifted ? <span><b>{counts.drifted}</b> 投影漂移</span> : null}
+            {counts.pending ? <span><b>{counts.pending}</b> pending</span> : null}
+            {failed ? <span className="da-fail"><b>{failed}</b> 失败</span> : null}
+          </span>
+          <div className="da-acts">
+            <button className="da-link" onClick={() => go("ops")}>Activity {"->"}</button>
+            <button className="da-link" onClick={() => go("doctor")}>Doctor {"->"}</button>
+          </div>
+        </div>
+      ) : null}
       <div className="dash-grid">
         <section className="panel">
-          <div className="panel-head"><h3><Icon d="graph" />Skill to target projections</h3><span className="panel-hint">{live.projections.length} live edges</span></div>
-          <ProjectionGraph skills={live.skills} targets={live.targets} />
+          <div className="panel-head"><h3><Icon d="bolt" />用量活跃度</h3><span className="panel-hint">ops / pending · 近 26 周</span></div>
+          <Heatmap ops={live.ops} queued={live.queuedWriteCount} />
         </section>
         <section className="panel">
-          <div className="panel-head"><h3><Icon d="lib" />Top skills</h3><button className="link-btn" onClick={() => go("skills")}>Open library</button></div>
-          <div className="top-list">
+          <div className="panel-head"><h3><Icon d="lib" />Top Skills</h3><button className="link-btn" onClick={() => go("skills")}>查看 {"->"}</button></div>
+          <div className="ov-topskills">
             {live.skills.slice(0, 6).map((skill, index) => (
-              <button className="top-item" key={skill.name} onClick={() => go("skills")}>
-                <span className="top-rank">{String(index + 1).padStart(2, "0")}</span>
-                <Glyph>{skill.name}</Glyph>
-                <span className="top-name">{skill.name}</span>
-                <span className="top-calls">{skill.projectionCount} edges</span>
+              <button className="ovts-row" key={skill.name} onClick={() => go("skills")}>
+                <span className="ovts-rank">{index + 1}</span>
+                <span className="ovts-name">{skill.name}</span>
+                <span className="ovts-bar"><i style={{ width: `${Math.max(4, Math.min(100, (skill.projectionCount + skill.bindingCount + 1) * 10))}%`, background: "var(--grad)" }} /></span>
+                <span className="ovts-n">{skill.projectionCount} edges</span>
               </button>
             ))}
             {live.skills.length === 0 && <div className="panel-empty">No skills from live registry yet.</div>}
           </div>
         </section>
         <section className="panel">
-          <div className="panel-head"><h3><Icon d="ops" />Operations</h3><span className="panel-hint">{lastOp?.time ?? "none"}</span></div>
-          <div className="upd-list">
-            {live.ops.slice(0, 5).map((op) => <OpLine key={op.id} op={op} />)}
-            {live.ops.length === 0 && <div className="panel-empty">No operation history loaded.</div>}
+          <div className="panel-head"><h3><Icon d="graph" />投影健康 / 方式</h3><button className="link-btn" onClick={() => go("projections")}>查看 {"->"}</button></div>
+          <HealthBars health={health} total={Math.max(1, live.projections.length)} />
+          <div className="ov-methods">
+            {(["symlink", "copy", "materialize"] as const).map((method) => <div className="ovm" key={method}><MethodTag method={method} /><b>{methods[method] ?? 0}</b></div>)}
           </div>
         </section>
-      </div>
-      <div className="dash-attn">
-        <div className="da-text">
-          <span><b>methods</b>{Object.entries(methods).map(([k, v]) => `${k}:${v}`).join(" · ") || "none"}</span>
-          <span><b>health</b>{Object.entries(health).map(([k, v]) => `${k}:${v}`).join(" · ") || "unavailable"}</span>
-        </div>
-        <div className="da-acts"><button className="da-link" onClick={() => go("projections")}>inspect graph</button><button className="da-link" onClick={() => go("doctor")}>run doctor</button></div>
+        <section className="panel">
+          <div className="panel-head"><h3><Icon d="target" />Target 归属</h3><button className="link-btn" onClick={() => go("targets")}>查看 {"->"}</button></div>
+          <div className="ov-own">
+            {(["managed", "observed", "external"] as const).map((own) => (
+              <div className="ovo-row" key={own}>
+                <span className="ovo-badge" style={{ "--oc": own === "managed" ? "var(--ok)" : own === "observed" ? "var(--acc3)" : "var(--faint)" } as CSSProperties}>{own}</span>
+                <span className="ovo-hint">{own === "managed" ? "loom 可写" : own === "observed" ? "只读监控" : "外部目录"}</span>
+                <span className="ovo-n">{ownership[own] ?? 0}</span>
+              </div>
+            ))}
+          </div>
+          <div className="ov-own-note"><Icon d="eye" size={13} />当前 registry 只有 observed target 时，binding/projection 为空是正常状态。</div>
+        </section>
       </div>
     </div>
   );
+}
+
+function Heatmap({ ops, queued }: { ops: Op[]; queued: number }) {
+  const cells = Array.from({ length: 26 * 7 }, (_, i) => {
+    const op = ops[i % Math.max(ops.length, 1)];
+    if (i < Math.min(ops.length + queued, 26 * 7)) return op?.status === "err" ? 3 : op?.status === "pending" ? 2 : 1;
+    return 0;
+  });
+  return (
+    <div className="hm-wrap">
+      <div className="hm-months">{["1月", "2月", "3月", "4月", "5月", "6月"].map((m) => <span key={m}>{m}</span>)}</div>
+      <div className="hm-grid">{Array.from({ length: 26 }, (_, col) => <div className="hm-col" key={col}>{Array.from({ length: 7 }, (_, row) => {
+        const value = cells[col * 7 + row] ?? 0;
+        const colors = ["var(--hm0)", "color-mix(in oklch,var(--acc3) 32%,var(--bg2))", "color-mix(in oklch,var(--acc3) 65%,var(--bg2))", "var(--warn)"];
+        return <i className="hm-cell" key={row} style={{ background: colors[value] }} />;
+      })}</div>)}</div>
+      <div className="hm-foot"><span>近 26 周 · 共 <b>{ops.length + queued}</b> 次操作 / 队列记录</span><span className="hm-leg">少 <i /><i style={{ background: "color-mix(in oklch,var(--acc3) 32%,var(--bg2))" }} /><i style={{ background: "color-mix(in oklch,var(--acc3) 65%,var(--bg2))" }} /><i style={{ background: "var(--warn)" }} /> 多</span></div>
+    </div>
+  );
+}
+
+function HealthBars({ health, total }: { health: Record<string, number>; total: number }) {
+  const rows = [["healthy", "healthy", "var(--ok)"], ["drift", "drift", "var(--warn)"], ["pending", "pending", "var(--acc3)"]] as const;
+  return (
+    <div className="ov-health">
+      {rows.map(([key, label, color]) => {
+        const n = health[key] ?? 0;
+        return <div key={key} className="ovh-row"><span className="ovh-label" style={{ color }}>{label}</span><span className="ovh-track"><i style={{ width: `${(n / total) * 100}%`, background: color, boxShadow: n ? `0 0 8px ${color}` : "none" }} /></span><b>{n}</b></div>;
+      })}
+    </div>
+  );
+}
+
+function MethodTag({ method }: { method: string }) {
+  return <span className={`method-tag m-${method}`}><Icon d={method === "materialize" ? "forge" : method === "copy" ? "lib" : "branch"} size={11} />{method}</span>;
 }
 
 function Stat({ label, value, sub, icon, hot, onClick }: { label: string; value: number | string; sub: string; icon: string; hot?: boolean; onClick?: () => void }) {
@@ -281,22 +382,38 @@ function Stat({ label, value, sub, icon, hot, onClick }: { label: string; value:
 }
 
 function Skills({ skills, query, setQuery, selected, setSelectedSkill }: { skills: Skill[]; query: string; setQuery: (value: string) => void; selected: Skill | null; setSelectedSkill: (name: string) => void }) {
+  const [source, setSource] = useState("all");
+  const [sort, setSort] = useState("name");
+  const tags = Array.from(new Set(skills.map((skill) => skill.tag))).slice(0, 8);
+  const shown = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return skills
+      .filter((skill) => !q || `${skill.name} ${skill.description ?? ""} ${skill.tag}`.toLowerCase().includes(q))
+      .filter((skill) => source === "all" || sourceLabel(skill) === source || skill.sourceStatus === source)
+      .sort((a, b) => sort === "edges" ? b.projectionCount - a.projectionCount : sort === "bindings" ? b.bindingCount - a.bindingCount : a.name.localeCompare(b.name));
+  }, [query, skills, sort, source]);
   return (
     <div className="view view-lib">
       <header className="view-head">
-        <div><h1>Skill library</h1><p>Live registry inventory rendered in the SkillM library layout.</p></div>
-        <div className="searchbox"><Icon d="search" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search skills, tags, descriptions" /></div>
+        <div><h1>技能库</h1><p>{skills.length} 个 skill · live registry inventory · 真实后端数据</p></div>
+        <div className="lib-head-right"><div className="searchbox"><Icon d="search" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索 skill…（名称 / 描述 / 标签）" /><kbd>⌘K</kbd></div><button className="btn-grad sm disabled"><Icon d="plus" size={14} />skill add</button></div>
       </header>
+      <div className="filter-bar">
+        <div className="chip-group">{["all", "observed", "present", "missing", "non-compliant"].map((item) => <button key={item} className={`chip ${source === item ? "on" : ""}`} onClick={() => setSource(item)}>{item === "all" ? "全部来源" : item}</button>)}</div>
+        <div className="chip-group">{tags.map((tag) => <button key={tag} className="chip" onClick={() => setQuery(tag)}>#{tag}</button>)}</div>
+        <div className="sort-group"><span className="sort-label">排序</span>{[["name", "名称"], ["edges", "投影"], ["bindings", "绑定"]].map(([id, label]) => <button key={id} className={`sort-pill ${sort === id ? "on" : ""}`} onClick={() => setSort(id)}>{label}</button>)}</div>
+      </div>
       <div className="lib-grid">
-        {skills.map((skill) => (
+        {shown.map((skill, index) => (
           <article key={skill.name} className={`skill-card ${selected?.name === skill.name ? "sel" : ""}`} onClick={() => setSelectedSkill(skill.name)}>
-            <div className="sc-head"><Glyph>{skill.name}</Glyph><div className="sc-title"><b>{skill.name}</b><span className="sc-meta">{sourceLabel(skill)} · {skill.changed}</span></div></div>
+            <div className="sc-head"><Glyph>{skill.name}</Glyph><div className="sc-title"><h3>{skill.name}</h3><span className="sc-meta">{sourceLabel(skill)} · {skill.changed}</span></div><Switch on={(skill.observedTargetIds?.length ?? 0) > 0 || skill.projectionCount > 0} onChange={() => undefined} /></div>
             <p className="sc-desc">{skill.description || "No description from backend."}</p>
-            <div className="sc-tags"><span className="sm-tag">{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span><span className="sm-tag">{skill.projectionCount} projections</span></div>
-            <div className="sc-foot"><span>{skill.bindingCount} bindings</span><span>{skill.targets.length + (skill.observedTargetIds?.length ?? 0)} targets</span></div>
+            <div className="sc-signals"><span className="sc-q">质量 {skill.sourceStatus === "present" ? 100 : 62}</span><span className={`sec-badge small ${skill.sourceStatus === "present" ? "verified" : "caution"}`}>{skill.sourceStatus}</span><span className="sc-cat">{skill.tag}</span></div>
+            <div className="sc-tools">{supportedAgents.slice(0, 3).map((agent) => <span key={agent} className={`tool-pill ${skill.observedTargetIds?.some((id) => id.includes(agent)) ? "on" : ""}`} style={{ "--tc": agentMeta[agent]?.color ?? "var(--acc2)" } as CSSProperties}><i />{agentMeta[agent]?.short ?? agent.slice(0, 2)}</span>)}<span className="sc-scope">{skill.observedImported ? "◎ Observed" : "◉ Registry"}</span></div>
+            <div className="sc-foot"><span className="sc-tags"><span className="sm-tag">#{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span></span><Spark seed={index} /><span className="sc-calls">{skill.projectionCount} edges</span></div>
           </article>
         ))}
-        {skills.length === 0 && <div className="lib-empty"><Icon d="lib" size={28} /><p>No skills available from the live API.</p></div>}
+        {shown.length === 0 && <div className="lib-empty"><Icon d="lib" size={28} /><p>没有匹配当前筛选的 skill</p></div>}
       </div>
       {selected && (
         <section className="skill-detail panel">
@@ -317,23 +434,50 @@ function Skills({ skills, query, setQuery, selected, setSelectedSkill }: { skill
 }
 
 function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: "targets" | "bindings" | "projections"; go: (page: SkillMPage) => void }) {
+  const drifts = live.projections.filter((p) => p.observed_drift || p.health === "drift").length;
+  const pending = live.queuedWriteCount + live.ops.filter((op) => op.status === "pending").length;
   return (
     <div className="view view-plane">
-      <header className="view-head"><div><h1>Control plane</h1><p>Targets, bindings, and projection graph share one SkillM plane.</p></div></header>
+      <header className="view-head"><div><h1>控制平面</h1><p>把注册表里的 skill 通过 binding 投影到各 agent 目录 · symlink / copy / materialize</p></div><button className="btn-grad sm disabled"><Icon d="branch" size={14} />应用全部投影</button></header>
+      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />Git 注册表</span><code>{registryLabel(live.registryRoot)}</code><span className="rs-div" /><span className="rs-stat"><b>{live.skills.length}</b> skills · <b>{live.targets.length}</b> targets</span><span className="rs-div" /><span className="rs-guard"><Icon d="bolt" size={12} />硬写保护 已开</span><span className="rs-flex" /><button className="rs-panel"><Icon d="eye" size={13} />localhost:5173</button></div>
+      <div className="plane-stats">
+        <button className="pstat" onClick={() => go("targets")}><span className="pstat-l">Targets</span><span className="pstat-n">{live.targets.length}</span></button>
+        <button className="pstat" onClick={() => go("bindings")}><span className="pstat-l">Bindings</span><span className="pstat-n">{live.bindings.length}</span></button>
+        <button className="pstat" onClick={() => go("projections")}><span className="pstat-l">Projections</span><span className="pstat-n">{live.projections.length}</span></button>
+        <div className={`pstat ${drifts ? "warn" : ""}`}><span className="pstat-l">漂移</span><span className="pstat-n">{drifts}</span></div>
+        <div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待投影</span><span className="pstat-n">{pending}</span></div>
+      </div>
       <nav className="plane-tabs">
-        {(["targets", "bindings", "projections"] as const).map((id) => <button key={id} className={`det-tab ${tab === id ? "on" : ""}`} onClick={() => go(id)}>{id}</button>)}
+        {([["projections", "投影关系图", "graph"], ["targets", "Targets", "target"], ["bindings", "Bindings", "branch"]] as const).map(([id, label, icon]) => <button key={id} className={`det-tab ${tab === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={icon} size={14} />{label}</button>)}
+        <span className="tab-flex" />
+        {tab === "targets" ? <button className="btn-ghost sm disabled"><Icon d="plus" size={13} />target add</button> : null}
+        {tab === "bindings" ? <button className="btn-ghost sm disabled"><Icon d="plus" size={13} />binding add</button> : null}
       </nav>
-      {tab === "targets" && <DataGrid columns={["agent", "profile", "ownership", "skills", "path"]} rows={live.targets.map((t) => [t.agent, t.profile, t.ownership, `${t.observedSkills ?? 0} observed / ${t.projectedSkills ?? 0} projected`, t.path])} />}
-      {tab === "bindings" && <DataGrid columns={["binding", "skill", "target", "matcher", "method"]} rows={live.bindings.map((b) => [shortName(b.id), b.skill, shortName(b.target), b.matcher, b.method])} />}
+      {tab === "targets" && <div className="targets-grid">{live.targets.map((t) => <TargetCard key={t.id} target={t} />)}{live.targets.length === 0 && <EmptyPanel text="No target rows from backend." />}</div>}
+      {tab === "bindings" && <BindingsTable bindings={live.bindings} />}
       {tab === "projections" && (
         <section className="panel">
           <div className="panel-head"><h3><Icon d="graph" />Projection graph</h3><span className="panel-hint">{live.projections.length} edges</span></div>
-          <ProjectionGraph skills={live.skills} targets={live.targets} />
+          <ProjectionGraph skills={live.skills} targets={live.targets} projections={live.projections} />
           <DataGrid columns={["skill", "target", "method", "health", "rev"]} rows={live.projections.map((p) => [p.skill_id, shortName(p.target_id), p.method, p.health, p.last_applied_rev?.slice(0, 8) || "—"])} />
         </section>
       )}
     </div>
   );
+}
+
+function TargetCard({ target }: { target: Target }) {
+  const meta = agentMeta[target.agent] ?? { name: target.agent, short: target.agent.slice(0, 2).toUpperCase(), color: "var(--acc2)" };
+  return <article className="target-card" style={{ "--ac": meta.color } as CSSProperties}><div className="tc-head"><span className="tc-agent" style={{ background: meta.color }}>{meta.short}</span><div className="tc-title"><h3>{meta.name}</h3><code>{target.path}</code></div><OwnBadge ownership={target.ownership} /></div><div className="tc-meta"><span>profile <b>{target.profile}</b></span><span>{target.projectedSkills ?? 0} 个投影</span><span className="tc-ok"><Icon d="check" size={11} />同步</span></div><div className="tc-actions"><button className="btn-ghost xs disabled">verify</button><button className="btn-ghost xs disabled">{target.ownership === "observed" ? "转 managed" : "capture"}</button></div></article>;
+}
+
+function OwnBadge({ ownership }: { ownership: string }) {
+  const color = ownership === "managed" ? "var(--ok)" : ownership === "observed" ? "var(--acc3)" : "var(--faint)";
+  return <span className={`own-badge own-${ownership}`} style={{ "--oc": color } as CSSProperties}><Icon d={ownership === "managed" ? "check" : "eye"} size={12} />{ownership}</span>;
+}
+
+function BindingsTable({ bindings }: { bindings: ReturnType<typeof usePanelData>["bindings"] }) {
+  return <div className="bindings-table"><div className="bt-head"><span>Skill</span><span>Policy</span><span>Matcher</span><span>Target</span><span>方式</span><span /></div>{bindings.map((b) => <div className="bt-row" key={b.id}><span className="bt-skill"><Glyph>{b.skill}</Glyph>{b.skill}</span><span className="bt-agent"><i />{b.policy}</span><span className="bt-matcher"><b>{b.matcher.split(":")[0]}</b><code>{b.matcher.split(":").slice(1).join(":") || "—"}</code></span><span className="bt-target"><code>{shortName(b.target)}</code></span><span><MethodTag method={b.method} /></span><span className="bt-act"><button className="btn-icon disabled"><Icon d="branch" size={14} /></button></span></div>)}{bindings.length === 0 && <div className="panel-empty">No bindings yet. Create a real binding before Loom can materialize projections.</div>}</div>;
 }
 
 function DataGrid({ columns, rows }: { columns: string[]; rows: Array<Array<string | number>> }) {
@@ -345,37 +489,53 @@ function DataGrid({ columns, rows }: { columns: string[]; rows: Array<Array<stri
   );
 }
 
-function ProjectionGraph({ skills, targets }: { skills: Skill[]; targets: Target[] }) {
+function ProjectionGraph({ skills, targets, projections = [] }: { skills: Skill[]; targets: Target[]; projections?: ReturnType<typeof usePanelData>["projections"] }) {
+  const shownSkills = projections.length > 0 ? skills.filter((skill) => projections.some((p) => p.skill_id === skill.name)).slice(0, 8) : skills.slice(0, 8);
+  const shownTargets = projections.length > 0 ? targets.filter((target) => projections.some((p) => p.target_id === target.id)).slice(0, 7) : targets.slice(0, 7);
   return (
     <div className="plane-graph skillm-mini-graph">
-      <div className="pg-cols"><span>Skills</span><span>Targets</span></div>
+      <div className="pg-cols"><span>注册表 Skill 源</span><span>投影方式</span><span>Target 目录</span></div>
       <div className="skillm-graph-grid">
-        <div>{skills.slice(0, 8).map((skill) => <div className="pg-node-row" key={skill.name}><Glyph>{skill.name}</Glyph><span>{skill.name}</span></div>)}</div>
+        <div>{shownSkills.map((skill) => <div className="pg-node-row" key={skill.name}><Glyph>{skill.name}</Glyph><span>{skill.name}</span></div>)}</div>
         <svg viewBox="0 0 500 260" className="proj-svg" aria-hidden="true">
-          {skills.slice(0, 8).map((skill, index) => {
-            const y = 24 + index * 29;
-            const targetIndex = targets.findIndex((target) => skill.targets.includes(target.id) || skill.observedTargetIds?.includes(target.id));
+          {projections.slice(0, 12).map((projection) => {
+            const skillIndex = Math.max(0, shownSkills.findIndex((skill) => skill.name === projection.skill_id));
+            const targetIndex = Math.max(0, shownTargets.findIndex((target) => target.id === projection.target_id));
+            const y = 24 + skillIndex * 29;
             const ty = 24 + Math.max(targetIndex, 0) * 34;
-            return <path key={skill.name} d={`M20 ${y} C180 ${y}, 300 ${ty}, 480 ${ty}`} className="proj-edge" stroke={methodTone("symlink")} />;
+            return <path key={projection.instance_id} d={`M20 ${y} C180 ${y}, 300 ${ty}, 480 ${ty}`} className="proj-edge" stroke={methodTone(projection.method)} />;
           })}
         </svg>
-        <div>{targets.slice(0, 7).map((target) => <div className="pg-node-row target" key={target.id}><span className="tc-agent">{target.agent.slice(0, 2).toUpperCase()}</span><span>{target.path}</span></div>)}</div>
+        <div>{shownTargets.map((target) => <div className="pg-node-row target" key={target.id}><span className="tc-agent">{target.agent.slice(0, 2).toUpperCase()}</span><span>{target.path}</span></div>)}</div>
       </div>
+      {projections.length === 0 && <div className="panel-empty">No live projection edges yet. The graph is showing inventory columns only.</div>}
     </div>
   );
+}
+
+function Spark({ seed }: { seed: number }) {
+  const pts = Array.from({ length: 8 }, (_, i) => `${i * 9},${16 - ((seed + i * 3) % 10)}`).join(" ");
+  return <svg width="64" height="18" className="sm-spark"><polyline points={pts} fill="none" stroke="var(--acc3)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /></svg>;
+}
+
+function EmptyPanel({ text }: { text: string }) {
+  return <div className="panel"><div className="panel-empty">{text}</div></div>;
 }
 
 function Ops({ live, history, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
   const failed = live.ops.filter((op) => op.status === "err").length;
   const pending = live.ops.filter((op) => op.status === "pending").length + live.queuedWriteCount;
+  const queue = live.ops.filter((op) => op.status !== "ok");
+  const rows = history ? live.ops : queue;
   return (
     <div className="view view-ops">
       <header className="view-head">
-        <div><h1>{history ? "Audit history" : "Ops queue"}</h1><p>Real operation records from the Panel API.</p></div>
-        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge)}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry)}><Icon d="sync" />retry / replay</button></div>
+        <div><h1>Ops &amp; 审计</h1><p>每条命令都来自 live API · 可重放、可诊断、可清理</p></div>
+        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge)}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry)}><Icon d="sync" />replay 队列</button></div>
       </header>
-      <div className="ops-stats"><div className="pstat acc"><span className="pstat-l">Pending</span><span className="pstat-n">{pending}</span></div><div className="pstat warn"><span className="pstat-l">Failed</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">Events</span><span className="pstat-n">{live.ops.length}</span></div></div>
-      <section className="op-table panel">{live.ops.map((op) => <OpLine key={op.id} op={op} />)}{live.ops.length === 0 && <div className="panel-empty">No operations returned by API.</div>}</section>
+      <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
+      <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
+      <section className="ops-table">{rows.map((op) => <OpLine key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>{history ? "No operation history returned by API." : "队列已清空 · 没有待处理或失败的操作"}</p></div>}</section>
     </div>
   );
 }
@@ -388,20 +548,35 @@ function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runA
   const remote = live.remote;
   return (
     <div className="view view-sync">
-      <header className="view-head"><div><h1>Git sync</h1><p>Sync is live only when a registry remote is configured.</p></div><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" />replay</button></header>
+      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><button className="btn-ghost sm disabled"><Icon d="dl" size={14} />sync pull</button><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" />replay</button></div></header>
+      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" size={13} />replay</button></div>
       <div className="sync-grid">
-        <section className="panel"><div className="panel-head"><h3><Icon d="branch" />Remote</h3></div><p className="set-v">{remote?.url ?? "No remote configured"}</p><p>{remote?.sync_state ?? "local only"}</p></section>
-        <section className="panel"><div className="panel-head"><h3><Icon d="ops" />Queue</h3></div><div className="stat-val">{live.queuedWriteCount}</div><p>queued writes</p></section>
+        <section className="panel sync-topo-panel"><div className="panel-head"><h3><Icon d="sync" />注册表拓扑</h3><span className="panel-hint">local {"->"} origin</span></div><svg viewBox="0 0 640 300" className="sync-topo"><path className="beam on" stroke="var(--acc3)" d="M120 220 C120 110 320 130 320 86" /><path className="beam" stroke="var(--line2)" d="M520 220 C520 110 320 130 320 86" /><circle className="topo-cloud" cx="320" cy="78" r="34" /><text x="320" y="82" textAnchor="middle" className="topo-name">origin</text><circle className="topo-node self" cx="120" cy="220" r="38" /><text x="120" y="218" textAnchor="middle" className="topo-name">local</text><text x="120" y="235" textAnchor="middle" className="topo-sub">{live.queuedWriteCount} queued</text><circle className="topo-node" cx="520" cy="220" r="38" /><text x="520" y="218" textAnchor="middle" className="topo-name">team</text><text x="520" y="235" textAnchor="middle" className="topo-sub">pending remote</text></svg></section>
+        <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{live.ops.length} events</span></div><div className="ev-stream">{live.ops.slice(0, 6).map((op) => <div key={op.id} className={`ev-row ev-${operationTone(op.status)}`}><span className="ev-ic"><Icon d={op.status === "ok" ? "check" : op.status === "err" ? "bolt" : "sync"} size={13} /></span><span className="ev-time">{op.time}</span><span className="ev-text">{op.kind} <b>{op.skill}</b></span><span className="ev-dev">{op.target}</span></div>)}{live.ops.length === 0 && <div className="panel-empty">No sync activity yet.</div>}</div></section>
       </div>
     </div>
   );
 }
 
-function Doctor({ apiReachable, live }: { apiReachable: boolean; live: boolean }) {
+function Doctor({ live }: { live: ReturnType<typeof usePanelData> }) {
+  const checks = [
+    { id: "schema", label: "Registry schema", rows: [[live.live, `mode ${live.mode}`]] },
+    { id: "api", label: "Panel API", rows: [[live.apiReachable, live.error ?? "health endpoint reachable"]] },
+    { id: "state", label: "State files", rows: [[!!live.registryRoot, live.registryRoot ?? "registry root unavailable"]] },
+    { id: "targets", label: "Targets", rows: [[live.targets.length > 0, `${live.targets.length} target rows`]] },
+    { id: "bindings", label: "Bindings", rows: [[live.bindings.length > 0, `${live.bindings.length} binding rows`]] },
+    { id: "projections", label: "Projections", rows: [[live.projections.length > 0, `${live.projections.length} projection rows`]] },
+    { id: "ops", label: "Operations", rows: [[live.queuedWriteCount === 0, `${live.queuedWriteCount} queued writes`]] },
+    { id: "sync", label: "Sync & history", rows: [[!!live.remote?.url, live.remote?.url ?? "remote origin not configured"]] },
+    { id: "perf", label: "Performance summary", rows: [[true, `last poll ${live.lastUpdated ? "fresh" : "pending"}`]] },
+  ];
+  const total = checks.reduce((sum, section) => sum + section.rows.length, 0);
+  const passed = checks.reduce((sum, section) => sum + section.rows.filter(([ok]) => ok).length, 0);
   return (
     <div className="view view-doctor">
-      <header className="view-head"><div><h1>Doctor</h1><p>Degraded states stay visible; diagnostics are not hidden behind registry failures.</p></div></header>
-      <div className="doc-summary"><div className={`doc-verdict ${apiReachable ? "ok" : "warn"}`}><div className="dv-ring" /><div className="dv-text"><b>{apiReachable ? "API reachable" : "API unreachable"}</b><span>{live ? "registry live" : "registry degraded or offline"}</span></div></div></div>
+      <header className="view-head"><div><h1>Doctor</h1><p>映射 loom workspace doctor · 每个失败项给出可执行下一步</p></div><button className="btn-grad sm disabled"><Icon d="shield" size={14} />重新体检</button></header>
+      <div className="doc-summary"><div className={`doc-verdict ${passed === total ? "ok" : "warn"}`}><div className="dv-ring" style={{ "--p": passed / total } as CSSProperties}><span>{passed}/{total}</span></div><div className="dv-text"><strong>{passed === total ? "注册表健康" : `${total - passed} 项需要处理`}</strong><span>{live.live ? "registry live" : "registry degraded or offline"}</span></div></div><div className="doc-leg"><span className="dl ok"><i />通过 {passed}</span><span className="dl bad"><i />需处理 {total - passed}</span><span className="dl">9 个检查区</span></div></div>
+      <div className="doc-secs">{checks.map((section) => { const ok = section.rows.every(([rowOk]) => rowOk); return <section key={section.id} className={`doc-sec ${ok ? "ok" : "warn"}`}><div className="ds-head"><span className={`ds-dot ${ok ? "ok" : "warn"}`} /><h3>{section.label}</h3><span className="ds-count">{section.rows.filter(([rowOk]) => rowOk).length}/{section.rows.length}</span></div><div className="ds-checks">{section.rows.map(([rowOk, text], index) => <div key={index} className={`ds-check ${rowOk ? "ok" : "bad"}`}><Icon d={rowOk ? "check" : "bolt"} size={13} /><div className="dsc-body"><span className="dsc-text">{text}</span>{!rowOk && <div className="dsc-fix"><code className="dsc-code">{section.id.toUpperCase()}</code><span>需要真实配置或写入后才会出现数据</span><button className="btn-ghost xs disabled">处理 {"->"}</button></div>}</div></div>)}</div></section>; })}</div>
     </div>
   );
 }
@@ -410,10 +585,11 @@ function Settings({ live, dark, setDark, density, setDensity, accent, setAccent 
   const themes = [["#ff0080", "#7928ca", "#00d9ff"], ["#34d399", "#0ea5e9", "#a3e635"], ["#ff6b35", "#f43f5e", "#fbbf24"]];
   return (
     <div className="view view-settings">
-      <header className="view-head"><div><h1>Settings</h1><p>Appearance controls from the SkillM prototype, backed by local UI state.</p></div></header>
-      <section className="set-card panel">
-        <div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Live backend value</p></div><code className="set-v">{live.registryRoot ?? "unavailable"}</code></div>
-        <div className="set-row"><div className="set-k"><h4>Theme</h4><p>Dark mode</p></div><Switch on={dark} onChange={setDark} /></div>
+      <header className="view-head"><div><h1>Settings</h1><p>注册表根、远端、写保护与外观 · 与 loom workspace 配置一致</p></div></header>
+      <section className="set-card"><div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Git 支撑的注册表所在目录</p></div><code className="set-v">{registryLabel(live.registryRoot)}</code></div><div className="set-row"><div className="set-k"><h4>Remote origin</h4><p>团队注册表推送地址</p></div><code className="set-v">{live.remote?.url ?? "not configured"}</code></div><div className="set-row"><div className="set-k"><h4>写保护</h4><p>--root 指向工具仓库时拒绝写入</p></div><Switch on={true} onChange={() => undefined} /></div></section>
+      <section className="set-card"><div className="set-cardhead"><h3>支持的 Agent（10）</h3><span>scan / status / 投影目标一致</span></div><div className="set-agents">{supportedAgents.map((agent) => <span key={agent} className="set-agent"><span className="tc-agent" style={{ background: agentMeta[agent]?.color }}>{agentMeta[agent]?.short}</span>{agentMeta[agent]?.name ?? agent}</span>)}</div></section>
+      <section className="set-card"><div className="set-cardhead"><h3>外观</h3><span>本机偏好</span></div>
+        <div className="set-row"><div className="set-k"><h4>Theme</h4><p>深色模式</p></div><Switch on={dark} onChange={setDark} /></div>
         <div className="set-row"><div className="set-k"><h4>Accent</h4><p>Neon / Aurora / Sunset</p></div><div className="twk-chips">{themes.map((theme) => <button key={theme.join("")} className="twk-chip" data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
         <div className="set-row"><div className="set-k"><h4>Density</h4><p>Layout spacing</p></div><div className="twk-radio">{(["compact", "regular", "comfy"] as const).map((value) => <button key={value} data-on={density === value ? "1" : "0"} onClick={() => setDensity(value)}>{value}</button>)}</div></div>
       </section>
@@ -425,8 +601,12 @@ function Switch({ on, onChange }: { on: boolean; onChange: (value: boolean) => v
   return <button className={`sm-switch ${on ? "on" : ""}`} role="switch" aria-checked={on} onClick={() => onChange(!on)}><span className="knob" /></button>;
 }
 
-function Unavailable({ title, copy }: { title: string; copy: string }) {
-  return <div className="view"><header className="view-head"><div><h1>{title}</h1><p>{copy}</p></div></header><section className="panel"><div className="panel-empty">No backend contract declared for this surface.</div></section></div>;
+function Market({ live }: { live: ReturnType<typeof usePanelData> }) {
+  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>SkillM marketplace surface · Loom V1 当前没有 marketplace backend contract</p></div><div className="searchbox"><Icon d="search" /><input disabled placeholder="等待 catalog API" /></div></header><div className="reg-banner"><div className="reg-stat"><b>0</b><span>catalog rows</span></div><span className="reg-div" /><div className="reg-stat"><b>{live.skills.length}</b><span>local skills</span></div><span className="reg-div" /><div className="reg-stat"><b>API</b><span>未声明</span></div><span className="reg-flex" /><span className="reg-src">来源：live registry only</span></div><div className="mk-cats">{["全部分类", "团队仓库", "精选", "趋势"].map((item, i) => <button key={item} className={`mk-cat ${i === 0 ? "on" : ""}`}><Icon d={i === 1 ? "layers" : "market"} size={14} />{item}<span className="mk-cat-n">0</span></button>)}</div><div className="mk-grid">{["catalog API", "install flow", "security scan"].map((name) => <article key={name} className="mk-card disabled"><div className="mk-head"><Glyph>{name}</Glyph><div className="mk-title"><h3>{name}</h3><span>backend contract missing</span></div></div><p className="mk-desc">保留 SkillM 页面骨架，但不展示假市场数据。接入真实 catalog API 后才能启用安装流。</p><div className="mk-actions"><button className="btn-ghost disabled">审查源码</button><button className="btn-grad sm disabled">安装</button></div></article>)}</div></div>;
+}
+
+function Forge({ live }: { live: ReturnType<typeof usePanelData> }) {
+  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>创建 skill 的参考向导 · 当前只读，因为没有 create-wizard backend contract</p></div></header><div className="forge-steps">{["选择起点", "基本信息", "编写指令", "目标 & 发布"].map((step, i) => <><button key={step} className={`fstep ${i === 0 ? "on" : ""}`}><span className="fstep-n">{i + 1}</span>{step}</button>{i < 3 && <span className="fstep-line" />}</>)}</div><div className="forge-body panel"><div className="forge-starts">{[["layers", "从模板开始", `${live.skills.length} local skills 可参考`], ["eye", "从官方文档生成", "需要 docs ingestion API"], ["forge", "从对话提炼", "需要 transcript API"], ["bolt", "AI 辅助生成", "需要 write contract"]].map(([ic, title, body]) => <button key={title} className="fstart disabled"><Icon d={ic} size={22} /><b>{title}</b><p>{body}</p></button>)}</div><div className="forge-foot"><span /><button className="btn-grad sm disabled">继续<Icon d="arrow" size={14} /></button></div></div></div>;
 }
 
 function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; close: () => void }) {

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -1,0 +1,496 @@
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import { usePanelData } from "../lib/api/usePanelData";
+import { api } from "../lib/api/client";
+import type { Op, PanelPageKey, Skill, Target } from "../lib/types";
+
+type SkillMPage = PanelPageKey | "market" | "forge";
+type ToastKind = "ok" | "err" | "info" | "sync";
+
+interface Toast {
+  id: number;
+  kind: ToastKind;
+  text: string;
+}
+
+const iconPath: Record<string, string> = {
+  dash: "M3 3h7v9H3zM14 3h7v5h-7zM14 12h7v9h-7zM3 16h7v5H3z",
+  lib: "M4 4h4v16H4zM10 4h4v16h-4zM16.5 4.5l4 1-3.5 15-4-1z",
+  target: "M12 3a9 9 0 109 9 9 9 9 0 00-9-9zm0 4a5 5 0 105 5 5 5 0 00-5-5zm0 3a2 2 0 102 2 2 2 0 00-2-2z",
+  branch: "M6 3v12M6 15a3 3 0 103 3M18 9a3 3 0 10-3-3M18 9a9 9 0 01-9 9",
+  graph: "M5 5a2 2 0 104 0 2 2 0 10-4 0M15 12a2 2 0 104 0 2 2 0 10-4 0M7 19a2 2 0 104 0 2 2 0 10-4 0M7.5 6.5l8 4.5M9.5 17.5l6-4.5",
+  ops: "M4 6h10M4 12h7M4 18h10M17 7l2.5 2.5L17 12M19 16l-2.5 2.5L14 16",
+  clock: "M12 3a9 9 0 109 9 9 9 9 0 00-9-9zm0 4v5l3.5 2",
+  sync: "M21 12a9 9 0 01-15.5 6.2M3 12a9 9 0 0115.5-6.2M3 12l3-3M3 12l3 3M21 12l-3-3M21 12l-3 3",
+  shield: "M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6zM9 12l2 2 4-4",
+  gear: "M12 8a4 4 0 100 8 4 4 0 000-8zM19 12a7 7 0 00-.1-1.2l2.1-1.6-2-3.4-2.4 1a7 7 0 00-2.1-1.2L14 3h-4l-.5 2.6a7 7 0 00-2.1 1.2l-2.4-1-2 3.4 2.1 1.6A7 7 0 005 12a7 7 0 00.1 1.2L3 14.8l2 3.4 2.4-1a7 7 0 002.1 1.2L10 21h4l.5-2.6a7 7 0 002.1-1.2l2.4 1 2-3.4-2.1-1.6A7 7 0 0019 12z",
+  search: "M10.5 3a7.5 7.5 0 105.3 12.8L21 21l-1.5 1.5-5.2-5.2A7.5 7.5 0 1010.5 3z",
+  term: "M4 5h16v14H4zM7 9l3 3-3 3M12 15h5",
+  plus: "M12 5v14M5 12h14",
+  x: "M6 6l12 12M18 6L6 18",
+  eye: "M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7zm10 3a3 3 0 100-6 3 3 0 000 6z",
+  bolt: "M13 2L4 14h6l-1 8 9-12h-6z",
+  market: "M4 7l2-4h12l2 4M4 7h16v3a3 3 0 01-6 0 3 3 0 01-4 0 3 3 0 01-6 0V7zM5 13v8h14v-8",
+  forge: "M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z",
+};
+
+const pages: Array<{ id: SkillMPage; icon: string; label: string; group: "build" | "ops" }> = [
+  { id: "overview", icon: "dash", label: "Overview", group: "build" },
+  { id: "skills", icon: "lib", label: "Skills", group: "build" },
+  { id: "targets", icon: "target", label: "Targets", group: "build" },
+  { id: "bindings", icon: "branch", label: "Bindings", group: "build" },
+  { id: "projections", icon: "graph", label: "Projections", group: "build" },
+  { id: "ops", icon: "ops", label: "Ops", group: "build" },
+  { id: "history", icon: "clock", label: "Audit log", group: "ops" },
+  { id: "sync", icon: "sync", label: "Git sync", group: "ops" },
+  { id: "doctor", icon: "shield", label: "Doctor", group: "ops" },
+  { id: "settings", icon: "gear", label: "Settings", group: "ops" },
+  { id: "market", icon: "market", label: "Market", group: "ops" },
+  { id: "forge", icon: "forge", label: "Forge", group: "ops" },
+];
+
+function Icon({ d, size = 18 }: { d: string; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d={iconPath[d] ?? d} />
+    </svg>
+  );
+}
+
+function Glyph({ children }: { children: string }) {
+  return <span className="sm-glyph">{children.slice(0, 2).toUpperCase()}</span>;
+}
+
+function shortName(value: string) {
+  return value.replace(/^target_/, "").replace(/_/g, " ").slice(0, 34);
+}
+
+function sourceLabel(skill: Skill) {
+  if (skill.observedImported) return "observed";
+  if (skill.sourceStatus === "missing") return "missing";
+  if (skill.sourceStatus === "non-compliant") return "non-compliant";
+  return "registry";
+}
+
+function methodTone(method: string) {
+  if (method === "materialize") return "var(--acc1)";
+  if (method === "copy") return "var(--acc2)";
+  if (method === "symlink") return "var(--acc3)";
+  return "var(--faint)";
+}
+
+function classForOp(op: Op) {
+  if (op.status === "ok") return "done";
+  if (op.status === "err") return "failed";
+  return "pending";
+}
+
+export function SkillMPanel() {
+  const live = usePanelData();
+  const [view, setView] = useState<SkillMPage>("overview");
+  const [query, setQuery] = useState("");
+  const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [termOpen, setTermOpen] = useState(false);
+  const [tweaksOpen, setTweaksOpen] = useState(false);
+  const [dark, setDark] = useState(true);
+  const [density, setDensity] = useState<"compact" | "regular" | "comfy">("regular");
+  const [accent, setAccent] = useState(["#ff0080", "#7928ca", "#00d9ff"]);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const counts = useMemo(() => {
+    const failedOps = live.ops.filter((op) => op.status === "err").length;
+    const drifted = live.projections.filter((p) => p.observed_drift || p.health === "drift").length;
+    const pending = live.queuedWriteCount + live.ops.filter((op) => op.status === "pending").length;
+    return { failedOps, drifted, pending, attention: failedOps + drifted + pending };
+  }, [live.ops, live.projections, live.queuedWriteCount]);
+
+  const filteredSkills = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return live.skills;
+    return live.skills.filter((skill) => {
+      return (
+        skill.name.toLowerCase().includes(q) ||
+        (skill.description ?? "").toLowerCase().includes(q) ||
+        skill.tag.toLowerCase().includes(q)
+      );
+    });
+  }, [live.skills, query]);
+
+  const selected = live.skills.find((skill) => skill.name === selectedSkill) ?? filteredSkills[0] ?? null;
+
+  const toast = (kind: ToastKind, text: string) => {
+    const id = Date.now() + Math.random();
+    setToasts((items) => [...items, { id, kind, text }]);
+    window.setTimeout(() => setToasts((items) => items.filter((item) => item.id !== id)), 3200);
+  };
+
+  const runAction = async (label: string, fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+      toast("ok", `${label} completed`);
+      live.refetch();
+    } catch (error) {
+      toast("err", error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setPaletteOpen(true);
+      } else if (event.ctrlKey && event.key === "`") {
+        event.preventDefault();
+        setTermOpen((open) => !open);
+      } else if (event.key === "Escape") {
+        setPaletteOpen(false);
+        setTermOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div
+      className={`sm-app ${dark ? "dark" : "light"} den-${density}`}
+      style={{ "--acc1": accent[0], "--acc2": accent[1], "--acc3": accent[2], "--glow": "0.72" } as CSSProperties}
+    >
+      <div className="sm-particles skillm-grid-bg" aria-hidden="true" />
+      <div className="sm-frame">
+        <ActivityRail view={view} counts={{ ...counts, skills: live.skills.length, targets: live.targets.length, bindings: live.bindings.length, projections: live.projections.length }} onGo={(page) => setView(page)} onTerm={() => setTermOpen((open) => !open)} />
+        <main className="sm-main" data-screen-label={view}>
+          {view === "overview" && <Overview live={live} counts={counts} go={setView} />}
+          {view === "skills" && <Skills skills={filteredSkills} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
+          {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={setView} />}
+          {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} runAction={runAction} />}
+          {view === "sync" && <Sync live={live} runAction={runAction} />}
+          {view === "doctor" && <Doctor apiReachable={live.apiReachable} live={live.live} />}
+          {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
+          {view === "market" && <Unavailable title="Market" copy="The SkillM marketplace screen exists in the reference UI, but Loom V1 has no marketplace backend. This stays blank until a real catalog API exists." />}
+          {view === "forge" && <Unavailable title="Forge" copy="The Forge wizard is intentionally not wired yet. Creating skills still requires a real source path or Git URL through the existing add flow." />}
+          {termOpen && <Terminal live={live} close={() => setTermOpen(false)} />}
+        </main>
+      </div>
+      <StatusBar live={live} counts={counts} dark={dark} setDark={setDark} onSync={() => runAction("Replay / sync", api.syncReplay)} onTerm={() => setTermOpen((open) => !open)} onTweaks={() => setTweaksOpen((open) => !open)} />
+      {paletteOpen && <Palette skills={live.skills} go={(page) => { setView(page); setPaletteOpen(false); }} openSkill={(name) => { setSelectedSkill(name); setView("skills"); setPaletteOpen(false); }} close={() => setPaletteOpen(false)} />}
+      {tweaksOpen && <Tweaks dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} close={() => setTweaksOpen(false)} />}
+      <Toasts items={toasts} dismiss={(id) => setToasts((items) => items.filter((item) => item.id !== id))} />
+    </div>
+  );
+}
+
+function ActivityRail({ view, counts, onGo, onTerm }: { view: SkillMPage; counts: Record<string, number>; onGo: (page: SkillMPage) => void; onTerm: () => void }) {
+  return (
+    <nav className="sm-actbar">
+      <div className="logo" title="Loom"><span>L</span></div>
+      <div className="nav-items">
+        {(["build", "ops"] as const).map((group) => (
+          <div key={group} className="nav-group">
+            <span className="nav-grouplabel">{group === "build" ? "BUILD" : "OPS"}</span>
+            {pages.filter((page) => page.group === group).map((page) => {
+              const count = page.id === "skills" ? counts.skills : page.id === "targets" ? counts.targets : page.id === "bindings" ? counts.bindings : page.id === "projections" ? counts.projections : page.id === "ops" ? counts.attention : 0;
+              return (
+                <button key={page.id} className={`act ${view === page.id ? "on" : ""}`} title={page.label} onClick={() => onGo(page.id)}>
+                  <Icon d={page.icon} size={20} />
+                  <span className="act-label">{page.label}</span>
+                  {count > 0 && <span className={`act-count ${page.id === "ops" ? "attn" : ""}`}>{count}</span>}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="nav-bottom">
+        <button className="act" title="Terminal" onClick={onTerm}><Icon d="term" size={20} /></button>
+      </div>
+    </nav>
+  );
+}
+
+function Overview({ live, counts, go }: { live: ReturnType<typeof usePanelData>; counts: { failedOps: number; drifted: number; pending: number; attention: number }; go: (page: SkillMPage) => void }) {
+  const ownership = tally(live.targets.map((target) => target.ownership));
+  const methods = tally(live.projections.map((projection) => projection.method));
+  const health = tally(live.projections.map((projection) => projection.health));
+  const lastOp = live.ops[0];
+  return (
+    <div className="view view-dash">
+      <header className="dash-hero">
+        <div>
+          <div className="hero-kicker">{live.live ? "registry online" : live.apiReachable ? "api degraded" : "api offline"}</div>
+          <h1>SkillM control room for <em>Loom</em></h1>
+          <p>{live.registryRoot ?? "Registry root unavailable"} · {live.mode}</p>
+        </div>
+        <div className="hero-orb"><span /><span /><span /><i className="orb-core" /></div>
+      </header>
+      <section className="stat-row">
+        <Stat label="Skills" value={live.skills.length} sub={`${live.skills.filter((s) => s.observedImported).length} observed`} icon="lib" onClick={() => go("skills")} />
+        <Stat label="Targets" value={live.targets.length} sub={`${ownership.managed ?? 0} managed · ${ownership.observed ?? 0} observed`} icon="target" onClick={() => go("targets")} />
+        <Stat label="Bindings" value={live.bindings.length} sub="workspace routes" icon="branch" onClick={() => go("bindings")} />
+        <Stat label="Attention" value={counts.attention} sub={`${counts.pending} queued · ${counts.drifted} drift`} icon="bolt" hot onClick={() => go("ops")} />
+      </section>
+      {live.error && <div className="dash-attn"><div className="da-text"><span className="da-fail"><b>API</b>{live.error}</span></div></div>}
+      {live.warnings.length > 0 && <div className="dash-attn"><div className="da-text">{live.warnings.slice(0, 3).map((warning) => <span key={warning}><b>warning</b>{warning}</span>)}</div></div>}
+      <div className="dash-grid">
+        <section className="panel">
+          <div className="panel-head"><h3><Icon d="graph" />Skill to target projections</h3><span className="panel-hint">{live.projections.length} live edges</span></div>
+          <ProjectionGraph skills={live.skills} targets={live.targets} />
+        </section>
+        <section className="panel">
+          <div className="panel-head"><h3><Icon d="lib" />Top skills</h3><button className="link-btn" onClick={() => go("skills")}>Open library</button></div>
+          <div className="top-list">
+            {live.skills.slice(0, 6).map((skill, index) => (
+              <button className="top-item" key={skill.name} onClick={() => go("skills")}>
+                <span className="top-rank">{String(index + 1).padStart(2, "0")}</span>
+                <Glyph>{skill.name}</Glyph>
+                <span className="top-name">{skill.name}</span>
+                <span className="top-calls">{skill.projectionCount} edges</span>
+              </button>
+            ))}
+            {live.skills.length === 0 && <div className="panel-empty">No skills from live registry yet.</div>}
+          </div>
+        </section>
+        <section className="panel">
+          <div className="panel-head"><h3><Icon d="ops" />Operations</h3><span className="panel-hint">{lastOp?.time ?? "none"}</span></div>
+          <div className="upd-list">
+            {live.ops.slice(0, 5).map((op) => <OpLine key={op.id} op={op} />)}
+            {live.ops.length === 0 && <div className="panel-empty">No operation history loaded.</div>}
+          </div>
+        </section>
+      </div>
+      <div className="dash-attn">
+        <div className="da-text">
+          <span><b>methods</b>{Object.entries(methods).map(([k, v]) => `${k}:${v}`).join(" · ") || "none"}</span>
+          <span><b>health</b>{Object.entries(health).map(([k, v]) => `${k}:${v}`).join(" · ") || "unavailable"}</span>
+        </div>
+        <div className="da-acts"><button className="da-link" onClick={() => go("projections")}>inspect graph</button><button className="da-link" onClick={() => go("doctor")}>run doctor</button></div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, sub, icon, hot, onClick }: { label: string; value: number | string; sub: string; icon: string; hot?: boolean; onClick?: () => void }) {
+  return (
+    <button className={`stat-card link ${hot ? "hot" : ""}`} onClick={onClick}>
+      <div className="stat-top"><Icon d={icon} />{label}</div>
+      <div className="stat-val">{value}</div>
+      <div className="stat-sub">{sub}</div>
+    </button>
+  );
+}
+
+function Skills({ skills, query, setQuery, selected, setSelectedSkill }: { skills: Skill[]; query: string; setQuery: (value: string) => void; selected: Skill | null; setSelectedSkill: (name: string) => void }) {
+  return (
+    <div className="view view-lib">
+      <header className="view-head">
+        <div><h1>Skill library</h1><p>Live registry inventory rendered in the SkillM library layout.</p></div>
+        <div className="searchbox"><Icon d="search" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search skills, tags, descriptions" /></div>
+      </header>
+      <div className="lib-grid">
+        {skills.map((skill) => (
+          <article key={skill.name} className={`skill-card ${selected?.name === skill.name ? "sel" : ""}`} onClick={() => setSelectedSkill(skill.name)}>
+            <div className="sc-head"><Glyph>{skill.name}</Glyph><div className="sc-title"><b>{skill.name}</b><span className="sc-meta">{sourceLabel(skill)} · {skill.changed}</span></div></div>
+            <p className="sc-desc">{skill.description || "No description from backend."}</p>
+            <div className="sc-tags"><span className="sm-tag">{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span><span className="sm-tag">{skill.projectionCount} projections</span></div>
+            <div className="sc-foot"><span>{skill.bindingCount} bindings</span><span>{skill.targets.length + (skill.observedTargetIds?.length ?? 0)} targets</span></div>
+          </article>
+        ))}
+        {skills.length === 0 && <div className="lib-empty"><Icon d="lib" size={28} /><p>No skills available from the live API.</p></div>}
+      </div>
+      {selected && (
+        <section className="skill-detail panel">
+          <div className="det-head">
+            <div className="det-title"><Glyph>{selected.name}</Glyph><div><h2>{selected.name}</h2><p>{selected.description || "No backend description."}</p></div></div>
+            <span className="sec-badge good"><Icon d="shield" />{selected.sourceStatus}</span>
+          </div>
+          <div className="det-stats">
+            <Stat label="Bindings" value={selected.bindingCount} sub="routing rules" icon="branch" />
+            <Stat label="Projections" value={selected.projectionCount} sub="materialized edges" icon="graph" />
+            <Stat label="Latest rev" value={selected.latestRev} sub="backend reported" icon="clock" />
+            <Stat label="Targets" value={selected.targets.length + (selected.observedTargetIds?.length ?? 0)} sub="observed + projected" icon="target" />
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: "targets" | "bindings" | "projections"; go: (page: SkillMPage) => void }) {
+  return (
+    <div className="view view-plane">
+      <header className="view-head"><div><h1>Control plane</h1><p>Targets, bindings, and projection graph share one SkillM plane.</p></div></header>
+      <nav className="plane-tabs">
+        {(["targets", "bindings", "projections"] as const).map((id) => <button key={id} className={`det-tab ${tab === id ? "on" : ""}`} onClick={() => go(id)}>{id}</button>)}
+      </nav>
+      {tab === "targets" && <DataGrid columns={["agent", "profile", "ownership", "skills", "path"]} rows={live.targets.map((t) => [t.agent, t.profile, t.ownership, `${t.observedSkills ?? 0} observed / ${t.projectedSkills ?? 0} projected`, t.path])} />}
+      {tab === "bindings" && <DataGrid columns={["binding", "skill", "target", "matcher", "method"]} rows={live.bindings.map((b) => [shortName(b.id), b.skill, shortName(b.target), b.matcher, b.method])} />}
+      {tab === "projections" && (
+        <section className="panel">
+          <div className="panel-head"><h3><Icon d="graph" />Projection graph</h3><span className="panel-hint">{live.projections.length} edges</span></div>
+          <ProjectionGraph skills={live.skills} targets={live.targets} />
+          <DataGrid columns={["skill", "target", "method", "health", "rev"]} rows={live.projections.map((p) => [p.skill_id, shortName(p.target_id), p.method, p.health, p.last_applied_rev?.slice(0, 8) || "—"])} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+function DataGrid({ columns, rows }: { columns: string[]; rows: Array<Array<string | number>> }) {
+  return (
+    <div className="skillm-table panel">
+      <table><thead><tr>{columns.map((column) => <th key={column}>{column}</th>)}</tr></thead><tbody>{rows.map((row, index) => <tr key={index}>{row.map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)}</tr>)}</tbody></table>
+      {rows.length === 0 && <div className="panel-empty">No live rows.</div>}
+    </div>
+  );
+}
+
+function ProjectionGraph({ skills, targets }: { skills: Skill[]; targets: Target[] }) {
+  return (
+    <div className="plane-graph skillm-mini-graph">
+      <div className="pg-cols"><span>Skills</span><span>Targets</span></div>
+      <div className="skillm-graph-grid">
+        <div>{skills.slice(0, 8).map((skill) => <div className="pg-node-row" key={skill.name}><Glyph>{skill.name}</Glyph><span>{skill.name}</span></div>)}</div>
+        <svg viewBox="0 0 500 260" className="proj-svg" aria-hidden="true">
+          {skills.slice(0, 8).map((skill, index) => {
+            const y = 24 + index * 29;
+            const targetIndex = targets.findIndex((target) => skill.targets.includes(target.id) || skill.observedTargetIds?.includes(target.id));
+            const ty = 24 + Math.max(targetIndex, 0) * 34;
+            return <path key={skill.name} d={`M20 ${y} C180 ${y}, 300 ${ty}, 480 ${ty}`} className="proj-edge" stroke={methodTone("symlink")} />;
+          })}
+        </svg>
+        <div>{targets.slice(0, 7).map((target) => <div className="pg-node-row target" key={target.id}><span className="tc-agent">{target.agent.slice(0, 2).toUpperCase()}</span><span>{target.path}</span></div>)}</div>
+      </div>
+    </div>
+  );
+}
+
+function Ops({ live, history, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
+  const failed = live.ops.filter((op) => op.status === "err").length;
+  const pending = live.ops.filter((op) => op.status === "pending").length + live.queuedWriteCount;
+  return (
+    <div className="view view-ops">
+      <header className="view-head">
+        <div><h1>{history ? "Audit history" : "Ops queue"}</h1><p>Real operation records from the Panel API.</p></div>
+        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge)}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry)}><Icon d="sync" />retry / replay</button></div>
+      </header>
+      <div className="ops-stats"><div className="pstat acc"><span className="pstat-l">Pending</span><span className="pstat-n">{pending}</span></div><div className="pstat warn"><span className="pstat-l">Failed</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">Events</span><span className="pstat-n">{live.ops.length}</span></div></div>
+      <section className="op-table panel">{live.ops.map((op) => <OpLine key={op.id} op={op} />)}{live.ops.length === 0 && <div className="panel-empty">No operations returned by API.</div>}</section>
+    </div>
+  );
+}
+
+function OpLine({ op }: { op: Op }) {
+  return <div className={`op-row op-row-${classForOp(op)}`}><span className={`op-pill op-${classForOp(op)}`}>{op.status}</span><span className="op-time">{op.time}</span><span className="op-verb">{op.kind}</span><span className="op-detail">{op.skill}<span className="op-arrow">{" -> "}<code>{op.target}</code></span></span><span className="op-note">{op.reason ?? op.method}</span></div>;
+}
+
+function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
+  const remote = live.remote;
+  return (
+    <div className="view view-sync">
+      <header className="view-head"><div><h1>Git sync</h1><p>Sync is live only when a registry remote is configured.</p></div><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" />replay</button></header>
+      <div className="sync-grid">
+        <section className="panel"><div className="panel-head"><h3><Icon d="branch" />Remote</h3></div><p className="set-v">{remote?.url ?? "No remote configured"}</p><p>{remote?.sync_state ?? "local only"}</p></section>
+        <section className="panel"><div className="panel-head"><h3><Icon d="ops" />Queue</h3></div><div className="stat-val">{live.queuedWriteCount}</div><p>queued writes</p></section>
+      </div>
+    </div>
+  );
+}
+
+function Doctor({ apiReachable, live }: { apiReachable: boolean; live: boolean }) {
+  return (
+    <div className="view view-doctor">
+      <header className="view-head"><div><h1>Doctor</h1><p>Degraded states stay visible; diagnostics are not hidden behind registry failures.</p></div></header>
+      <div className="doc-summary"><div className={`doc-verdict ${apiReachable ? "ok" : "warn"}`}><div className="dv-ring" /><div className="dv-text"><b>{apiReachable ? "API reachable" : "API unreachable"}</b><span>{live ? "registry live" : "registry degraded or offline"}</span></div></div></div>
+    </div>
+  );
+}
+
+function Settings({ live, dark, setDark, density, setDensity, accent, setAccent }: { live: ReturnType<typeof usePanelData>; dark: boolean; setDark: (value: boolean) => void; density: "compact" | "regular" | "comfy"; setDensity: (value: "compact" | "regular" | "comfy") => void; accent: string[]; setAccent: (value: string[]) => void }) {
+  const themes = [["#ff0080", "#7928ca", "#00d9ff"], ["#34d399", "#0ea5e9", "#a3e635"], ["#ff6b35", "#f43f5e", "#fbbf24"]];
+  return (
+    <div className="view view-settings">
+      <header className="view-head"><div><h1>Settings</h1><p>Appearance controls from the SkillM prototype, backed by local UI state.</p></div></header>
+      <section className="set-card panel">
+        <div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Live backend value</p></div><code className="set-v">{live.registryRoot ?? "unavailable"}</code></div>
+        <div className="set-row"><div className="set-k"><h4>Theme</h4><p>Dark mode</p></div><Switch on={dark} onChange={setDark} /></div>
+        <div className="set-row"><div className="set-k"><h4>Accent</h4><p>Neon / Aurora / Sunset</p></div><div className="twk-chips">{themes.map((theme) => <button key={theme.join("")} className="twk-chip" data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
+        <div className="set-row"><div className="set-k"><h4>Density</h4><p>Layout spacing</p></div><div className="twk-radio">{(["compact", "regular", "comfy"] as const).map((value) => <button key={value} data-on={density === value ? "1" : "0"} onClick={() => setDensity(value)}>{value}</button>)}</div></div>
+      </section>
+    </div>
+  );
+}
+
+function Switch({ on, onChange }: { on: boolean; onChange: (value: boolean) => void }) {
+  return <button className={`sm-switch ${on ? "on" : ""}`} role="switch" aria-checked={on} onClick={() => onChange(!on)}><span className="knob" /></button>;
+}
+
+function Unavailable({ title, copy }: { title: string; copy: string }) {
+  return <div className="view"><header className="view-head"><div><h1>{title}</h1><p>{copy}</p></div></header><section className="panel"><div className="panel-empty">No backend contract declared for this surface.</div></section></div>;
+}
+
+function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; close: () => void }) {
+  return (
+    <div className="sm-terminal">
+      <div className="term-head"><span><Icon d="term" /> TERMINAL - skillm shell</span><button className="btn-icon" onClick={close}><Icon d="x" /></button></div>
+      <div className="term-body"><p>SkillM Terminal - read-only preview</p><p><b>$</b> loom workspace status</p><p>{live.live ? "registry live" : live.error ?? "offline"} · {live.skills.length} skills · {live.targets.length} targets · {live.queuedWriteCount} queued</p></div>
+      <div className="term-input"><span>&gt;</span><span>help · ls · doctor · sync</span></div>
+    </div>
+  );
+}
+
+function Palette({ skills, go, openSkill, close }: { skills: Skill[]; go: (page: SkillMPage) => void; openSkill: (name: string) => void; close: () => void }) {
+  return (
+    <div className="sm-veil" onMouseDown={close}>
+      <div className="cmd-pal" onMouseDown={(event) => event.stopPropagation()}>
+        <div className="cmd-search"><Icon d="search" /><span>Command palette</span><button className="btn-icon" onClick={close}><Icon d="x" /></button></div>
+        <div className="cmd-list">
+          {pages.map((page) => <button key={page.id} className="cmd-item" onClick={() => go(page.id)}><Icon d={page.icon} />Go to {page.label}<span>{page.group}</span></button>)}
+          {skills.slice(0, 8).map((skill) => <button key={skill.name} className="cmd-item" onClick={() => openSkill(skill.name)}><Icon d="eye" />Open {skill.name}<span>{sourceLabel(skill)}</span></button>)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Tweaks({ dark, setDark, density, setDensity, accent, setAccent, close }: { dark: boolean; setDark: (value: boolean) => void; density: "compact" | "regular" | "comfy"; setDensity: (value: "compact" | "regular" | "comfy") => void; accent: string[]; setAccent: (value: string[]) => void; close: () => void }) {
+  const themes = [["#ff0080", "#7928ca", "#00d9ff"], ["#34d399", "#0ea5e9", "#a3e635"], ["#ff6b35", "#f43f5e", "#fbbf24"]];
+  return (
+    <aside className="twk-panel skillm-tweaks">
+      <div className="twk-hd"><b>Tweaks</b><button className="twk-x" onClick={close}>×</button></div>
+      <div className="twk-body">
+        <div className="twk-sect">视觉方向</div>
+        <div className="twk-row"><div className="twk-lbl"><span>配色（Neon / Aurora / Sunset）</span></div><div className="twk-chips">{themes.map((theme) => <button key={theme.join("")} className="twk-chip" data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
+        <div className="twk-row twk-row-h"><div className="twk-lbl"><span>深色模式</span></div><Switch on={dark} onChange={setDark} /></div>
+        <div className="twk-sect">布局</div>
+        <div className="twk-radio">{(["compact", "regular", "comfy"] as const).map((value) => <button key={value} data-on={density === value ? "1" : "0"} onClick={() => setDensity(value)}>{value}</button>)}</div>
+      </div>
+    </aside>
+  );
+}
+
+function Toasts({ items, dismiss }: { items: Toast[]; dismiss: (id: number) => void }) {
+  return <div className="sm-toasts">{items.map((toast) => <button key={toast.id} className={`sm-toast ${toast.kind}`} onClick={() => dismiss(toast.id)}><Icon d={toast.kind === "err" ? "x" : "bolt"} />{toast.text}</button>)}</div>;
+}
+
+function StatusBar({ live, counts, dark, setDark, onSync, onTerm, onTweaks }: { live: ReturnType<typeof usePanelData>; counts: { pending: number; drifted: number }; dark: boolean; setDark: (value: boolean) => void; onSync: () => void; onTerm: () => void; onTweaks: () => void }) {
+  return (
+    <footer className="sm-statusbar">
+      <button className="sb-item sb-sync" onClick={onSync}><Icon d="sync" size={14} />{live.remote?.sync_state ?? "local"}</button>
+      <span className="sb-item">{live.live ? "已同步" : "offline"} · {live.lastUpdated ? "刚刚" : "pending"}</span>
+      <span className="sb-item warn">{counts.drifted} drift · {counts.pending} queued</span>
+      <span className="sb-flex" />
+      <button className="sb-item" onClick={onTerm}><Icon d="term" size={14} />terminal</button>
+      <button className="sb-item" onClick={() => setDark(!dark)}>{dark ? "dark" : "light"}</button>
+      <button className="sb-item" onClick={onTweaks}><Icon d="gear" size={14} />tweaks</button>
+      <span className="sb-ver">SkillM 1.0.0</span>
+    </footer>
+  );
+}
+
+function tally(values: string[]) {
+  return values.reduce<Record<string, number>>((acc, value) => {
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -3,12 +3,13 @@ import type { CSSProperties } from "react";
 import { usePanelData } from "../lib/api/usePanelData";
 import { api } from "../lib/api/client";
 import type { Op, PanelPageKey, Skill, Target } from "../lib/types";
+import { DoctorPage } from "./panel/DoctorPage";
 
 type SkillMPage = PanelPageKey | "market" | "forge";
 type ToastKind = "ok" | "err" | "info" | "sync";
 
 interface Toast {
-  id: number;
+  id: string;
   kind: ToastKind;
   text: string;
 }
@@ -62,8 +63,6 @@ const agentMeta: Record<string, { name: string; short: string; color: string }> 
   goose: { name: "Goose", short: "GO", color: "#a855f7" },
 };
 
-const supportedAgents = ["claude", "codex", "cursor", "windsurf", "cline", "copilot", "aider", "opencode", "gemini-cli", "goose"];
-
 function initialView(): SkillMPage {
   if (typeof window === "undefined") return "overview";
   const candidate = new URL(window.location.href).searchParams.get("view");
@@ -91,6 +90,11 @@ function sourceLabel(skill: Skill) {
   if (skill.sourceStatus === "missing") return "missing";
   if (skill.sourceStatus === "non-compliant") return "non-compliant";
   return "registry";
+}
+
+function agentsForSkill(skill: Skill, targets: Target[]) {
+  const ids = new Set([...skill.targets, ...(skill.observedTargetIds ?? [])]);
+  return targets.filter((target) => ids.has(target.id)).map((target) => target.agent);
 }
 
 function registryLabel(root: string | null) {
@@ -220,7 +224,7 @@ export function SkillMPanel() {
   };
 
   const toast = (kind: ToastKind, text: string) => {
-    const id = Date.now() + Math.random();
+    const id = crypto.randomUUID();
     setToasts((items) => [...items, { id, kind, text }]);
     window.setTimeout(() => setToasts((items) => items.filter((item) => item.id !== id)), 3200);
   };
@@ -262,11 +266,11 @@ export function SkillMPanel() {
         <ActivityRail view={view} counts={{ ...counts, skills: live.skills.length, targets: live.targets.length, bindings: live.bindings.length, projections: live.projections.length }} onGo={go} onTerm={() => setTermOpen((open) => !open)} />
         <main className="sm-main" data-screen-label={view}>
           {view === "overview" && <Overview live={live} counts={counts} go={go} />}
-          {view === "skills" && <Skills skills={live.skills} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
+          {view === "skills" && <Skills skills={live.skills} targets={live.targets} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
           {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={go} />}
           {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} runAction={runAction} />}
           {view === "sync" && <Sync live={live} runAction={runAction} />}
-          {view === "doctor" && <Doctor live={live} />}
+          {view === "doctor" && <Doctor live={live} go={go} />}
           {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
           {view === "market" && <Market live={live} />}
           {view === "forge" && <Forge live={live} />}
@@ -457,7 +461,7 @@ function Stat({ label, value, sub, icon, hot, onClick }: { label: string; value:
   );
 }
 
-function Skills({ skills, query, setQuery, selected, setSelectedSkill }: { skills: Skill[]; query: string; setQuery: (value: string) => void; selected: Skill | null; setSelectedSkill: (name: string) => void }) {
+function Skills({ skills, targets, query, setQuery, selected, setSelectedSkill }: { skills: Skill[]; targets: Target[]; query: string; setQuery: (value: string) => void; selected: Skill | null; setSelectedSkill: (name: string) => void }) {
   const [source, setSource] = useState("all");
   const [sort, setSort] = useState("name");
   const tags = Array.from(new Set(skills.map((skill) => skill.tag))).slice(0, 8);
@@ -480,13 +484,13 @@ function Skills({ skills, query, setQuery, selected, setSelectedSkill }: { skill
         <div className="sort-group"><span className="sort-label">排序</span>{[["name", "名称"], ["edges", "投影"], ["bindings", "绑定"]].map(([id, label]) => <button key={id} className={`sort-pill ${sort === id ? "on" : ""}`} onClick={() => setSort(id)}>{label}</button>)}</div>
       </div>
       <div className="lib-grid">
-        {shown.map((skill, index) => (
+        {shown.map((skill) => (
           <article key={skill.name} className={`skill-card ${selected?.name === skill.name ? "sel" : ""}`} onClick={() => setSelectedSkill(skill.name)}>
             <div className="sc-head"><Glyph>{skill.name}</Glyph><div className="sc-title"><h3>{skill.name}</h3><span className="sc-meta">{sourceLabel(skill)} · {skill.changed}</span></div><Switch on={(skill.observedTargetIds?.length ?? 0) > 0 || skill.projectionCount > 0} onChange={() => undefined} /></div>
             <p className="sc-desc">{skill.description || "No description from backend."}</p>
-            <div className="sc-signals"><span className="sc-q">质量 {skill.sourceStatus === "present" ? 100 : 62}</span><span className={`sec-badge small ${skill.sourceStatus === "present" ? "verified" : "caution"}`}>{skill.sourceStatus}</span><span className="sc-cat">{skill.tag}</span></div>
-            <div className="sc-tools">{supportedAgents.slice(0, 3).map((agent) => <span key={agent} className={`tool-pill ${skill.observedTargetIds?.some((id) => id.includes(agent)) ? "on" : ""}`} style={{ "--tc": agentMeta[agent]?.color ?? "var(--acc2)" } as CSSProperties}><i />{agentMeta[agent]?.short ?? agent.slice(0, 2)}</span>)}<span className="sc-scope">{skill.observedImported ? "◎ Observed" : "◉ Registry"}</span></div>
-            <div className="sc-foot"><span className="sc-tags"><span className="sm-tag">#{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span></span><Spark seed={index} /><span className="sc-calls">{skill.projectionCount} edges</span></div>
+            <div className="sc-signals"><span className={`sec-badge small ${skill.sourceStatus === "present" ? "verified" : "caution"}`}>{skill.sourceStatus}</span><span className="sc-cat">{skill.bindingCount} bindings</span><span className="sc-cat">{skill.projectionCount} projections</span></div>
+            <div className="sc-tools">{agentsForSkill(skill, targets).slice(0, 3).map((agent) => <span key={agent} className="tool-pill on" style={{ "--tc": agentMeta[agent]?.color ?? "var(--acc2)" } as CSSProperties}><i />{agentMeta[agent]?.short ?? agent.slice(0, 2).toUpperCase()}</span>)}<span className="sc-scope">{agentsForSkill(skill, targets).length > 0 ? "real target rows" : "no target rows"}</span></div>
+            <div className="sc-foot"><span className="sc-tags"><span className="sm-tag">#{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span></span><span className="sc-calls">{skill.projectionCount} edges</span></div>
           </article>
         ))}
         {shown.length === 0 && <div className="lib-empty"><Icon d="lib" size={28} /><p>没有匹配当前筛选的 skill</p></div>}
@@ -589,11 +593,6 @@ function ProjectionGraph({ skills, targets, projections = [] }: { skills: Skill[
   );
 }
 
-function Spark({ seed }: { seed: number }) {
-  const pts = Array.from({ length: 8 }, (_, i) => `${i * 9},${16 - ((seed + i * 3) % 10)}`).join(" ");
-  return <svg width="64" height="18" className="sm-spark"><polyline points={pts} fill="none" stroke="var(--acc3)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /></svg>;
-}
-
 function EmptyPanel({ text }: { text: string }) {
   return <div className="panel"><div className="panel-empty">{text}</div></div>;
 }
@@ -622,39 +621,21 @@ function OpLine({ op }: { op: Op }) {
 
 function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
   const remote = live.remote;
+  const remoteConfigured = Boolean(remote?.configured || remote?.url || remote?.remote);
   return (
     <div className="view view-sync">
       <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><button className="btn-ghost sm disabled"><Icon d="dl" size={14} />sync pull</button><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" />replay</button></div></header>
-      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" size={13} />replay</button></div>
+      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || remote?.remote || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-div" /><span className="rs-stat">pending <b>{remote?.pending_ops ?? live.queuedWriteCount}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" size={13} />replay</button></div>
       <div className="sync-grid">
-        <section className="panel sync-topo-panel"><div className="panel-head"><h3><Icon d="sync" />注册表拓扑</h3><span className="panel-hint">local {"->"} origin</span></div><svg viewBox="0 0 640 300" className="sync-topo"><path className="beam on" stroke="var(--acc3)" d="M120 220 C120 110 320 130 320 86" /><path className="beam" stroke="var(--line2)" d="M520 220 C520 110 320 130 320 86" /><circle className="topo-cloud" cx="320" cy="78" r="34" /><text x="320" y="82" textAnchor="middle" className="topo-name">origin</text><circle className="topo-node self" cx="120" cy="220" r="38" /><text x="120" y="218" textAnchor="middle" className="topo-name">local</text><text x="120" y="235" textAnchor="middle" className="topo-sub">{live.queuedWriteCount} queued</text><circle className="topo-node" cx="520" cy="220" r="38" /><text x="520" y="218" textAnchor="middle" className="topo-name">team</text><text x="520" y="235" textAnchor="middle" className="topo-sub">pending remote</text></svg></section>
+        <section className="panel sync-topo-panel"><div className="panel-head"><h3><Icon d="sync" />注册表拓扑</h3><span className="panel-hint">{remoteConfigured ? "local -> origin" : "local only"}</span></div><svg viewBox="0 0 640 300" className="sync-topo"><path className={`beam ${remoteConfigured ? "on" : ""}`} stroke="var(--acc3)" d="M150 220 C150 112 320 132 320 86" /><circle className="topo-cloud" cx="320" cy="78" r="34" /><text x="320" y="82" textAnchor="middle" className="topo-name">origin</text><text x="320" y="104" textAnchor="middle" className="topo-sub">{remoteConfigured ? "configured" : "not configured"}</text><circle className="topo-node self" cx="150" cy="220" r="38" /><text x="150" y="218" textAnchor="middle" className="topo-name">local</text><text x="150" y="235" textAnchor="middle" className="topo-sub">{remote?.pending_ops ?? live.queuedWriteCount} pending</text></svg></section>
         <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{live.ops.length} events</span></div><div className="ev-stream">{live.ops.slice(0, 6).map((op) => <div key={op.id} className={`ev-row ev-${operationTone(op.status)}`}><span className="ev-ic"><Icon d={op.status === "ok" ? "check" : op.status === "err" ? "bolt" : "sync"} size={13} /></span><span className="ev-time">{op.time}</span><span className="ev-text">{op.kind} <b>{op.skill}</b></span><span className="ev-dev">{op.target}</span></div>)}{live.ops.length === 0 && <div className="panel-empty">No sync activity yet.</div>}</div></section>
       </div>
     </div>
   );
 }
 
-function Doctor({ live }: { live: ReturnType<typeof usePanelData> }) {
-  const checks = [
-    { id: "schema", label: "Registry schema", rows: [[live.live, `mode ${live.mode}`]] },
-    { id: "api", label: "Panel API", rows: [[live.apiReachable, live.error ?? "health endpoint reachable"]] },
-    { id: "state", label: "State files", rows: [[!!live.registryRoot, live.registryRoot ?? "registry root unavailable"]] },
-    { id: "targets", label: "Targets", rows: [[live.targets.length > 0, `${live.targets.length} target rows`]] },
-    { id: "bindings", label: "Bindings", rows: [[live.bindings.length > 0, `${live.bindings.length} binding rows`]] },
-    { id: "projections", label: "Projections", rows: [[live.projections.length > 0, `${live.projections.length} projection rows`]] },
-    { id: "ops", label: "Operations", rows: [[live.queuedWriteCount === 0, `${live.queuedWriteCount} queued writes`]] },
-    { id: "sync", label: "Sync & history", rows: [[!!live.remote?.url, live.remote?.url ?? "remote origin not configured"]] },
-    { id: "perf", label: "Performance summary", rows: [[true, `last poll ${live.lastUpdated ? "fresh" : "pending"}`]] },
-  ];
-  const total = checks.reduce((sum, section) => sum + section.rows.length, 0);
-  const passed = checks.reduce((sum, section) => sum + section.rows.filter(([ok]) => ok).length, 0);
-  return (
-    <div className="view view-doctor">
-      <header className="view-head"><div><h1>Doctor</h1><p>映射 loom workspace doctor · 每个失败项给出可执行下一步</p></div><button className="btn-grad sm disabled"><Icon d="shield" size={14} />重新体检</button></header>
-      <div className="doc-summary"><div className={`doc-verdict ${passed === total ? "ok" : "warn"}`}><div className="dv-ring" style={{ "--p": passed / total } as CSSProperties}><span>{passed}/{total}</span></div><div className="dv-text"><strong>{passed === total ? "注册表健康" : `${total - passed} 项需要处理`}</strong><span>{live.live ? "registry live" : "registry degraded or offline"}</span></div></div><div className="doc-leg"><span className="dl ok"><i />通过 {passed}</span><span className="dl bad"><i />需处理 {total - passed}</span><span className="dl">9 个检查区</span></div></div>
-      <div className="doc-secs">{checks.map((section) => { const ok = section.rows.every(([rowOk]) => rowOk); return <section key={section.id} className={`doc-sec ${ok ? "ok" : "warn"}`}><div className="ds-head"><span className={`ds-dot ${ok ? "ok" : "warn"}`} /><h3>{section.label}</h3><span className="ds-count">{section.rows.filter(([rowOk]) => rowOk).length}/{section.rows.length}</span></div><div className="ds-checks">{section.rows.map(([rowOk, text], index) => <div key={index} className={`ds-check ${rowOk ? "ok" : "bad"}`}><Icon d={rowOk ? "check" : "bolt"} size={13} /><div className="dsc-body"><span className="dsc-text">{text}</span>{!rowOk && <div className="dsc-fix"><code className="dsc-code">{section.id.toUpperCase()}</code><span>需要真实配置或写入后才会出现数据</span><button className="btn-ghost xs disabled">处理 {"->"}</button></div>}</div></div>)}</div></section>; })}</div>
-    </div>
-  );
+function Doctor({ live, go }: { live: ReturnType<typeof usePanelData>; go: (page: SkillMPage) => void }) {
+  return <div className="view view-doctor"><DoctorPage apiReachable={live.apiReachable} mode={live.mode} refreshKey={live.lastUpdated} onNavigate={(page) => go(page)} /></div>;
 }
 
 function Settings({ live, dark, setDark, density, setDensity, accent, setAccent }: { live: ReturnType<typeof usePanelData>; dark: boolean; setDark: (value: boolean) => void; density: "compact" | "regular" | "comfy"; setDensity: (value: "compact" | "regular" | "comfy") => void; accent: string[]; setAccent: (value: string[]) => void }) {
@@ -662,8 +643,8 @@ function Settings({ live, dark, setDark, density, setDensity, accent, setAccent 
   return (
     <div className="view view-settings">
       <header className="view-head"><div><h1>Settings</h1><p>注册表根、远端、写保护与外观 · 与 loom workspace 配置一致</p></div></header>
-      <section className="set-card"><div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Git 支撑的注册表所在目录</p></div><code className="set-v">{registryLabel(live.registryRoot)}</code></div><div className="set-row"><div className="set-k"><h4>Remote origin</h4><p>团队注册表推送地址</p></div><code className="set-v">{live.remote?.url ?? "not configured"}</code></div><div className="set-row"><div className="set-k"><h4>写保护</h4><p>--root 指向工具仓库时拒绝写入</p></div><Switch on={true} onChange={() => undefined} /></div></section>
-      <section className="set-card"><div className="set-cardhead"><h3>支持的 Agent（10）</h3><span>scan / status / 投影目标一致</span></div><div className="set-agents">{supportedAgents.map((agent) => <span key={agent} className="set-agent"><span className="tc-agent" style={{ background: agentMeta[agent]?.color }}>{agentMeta[agent]?.short}</span>{agentMeta[agent]?.name ?? agent}</span>)}</div></section>
+      <section className="set-card"><div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Git 支撑的注册表所在目录</p></div><code className="set-v">{registryLabel(live.registryRoot)}</code></div><div className="set-row"><div className="set-k"><h4>Remote origin</h4><p>团队注册表推送地址</p></div><code className="set-v">{live.remote?.url ?? live.remote?.remote ?? "not configured"}</code></div><div className="set-row"><div className="set-k"><h4>写保护</h4><p>当前 API 未暴露该配置状态</p></div><code className="set-v">backend field missing</code></div></section>
+      <section className="set-card"><div className="set-cardhead"><h3>Agent directories ({live.agentDirs.length})</h3><span>来自 workspace/info.agent_dirs</span></div><div className="set-agents">{live.agentDirs.map((dir) => <span key={`${dir.agent}-${dir.path}`} className="set-agent" title={dir.path}><span className="tc-agent" style={{ background: agentMeta[dir.agent]?.color }}>{agentMeta[dir.agent]?.short ?? dir.agent.slice(0, 2).toUpperCase()}</span>{dir.agent}<code>{dir.env_var ?? "no env"}</code></span>)}</div>{live.agentDirs.length === 0 && <div className="panel-empty">workspace/info 没有返回 agent_dirs。</div>}</section>
       <section className="set-card"><div className="set-cardhead"><h3>外观</h3><span>本机偏好</span></div>
         <div className="set-row"><div className="set-k"><h4>Theme</h4><p>深色模式</p></div><Switch on={dark} onChange={setDark} /></div>
         <div className="set-row"><div className="set-k"><h4>Accent</h4><p>Neon / Aurora / Sunset</p></div><div className="twk-chips">{themes.map((theme) => <button key={theme.join("")} className="twk-chip" data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
@@ -678,11 +659,11 @@ function Switch({ on, onChange }: { on: boolean; onChange: (value: boolean) => v
 }
 
 function Market({ live }: { live: ReturnType<typeof usePanelData> }) {
-  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>SkillM marketplace surface · Loom V1 当前没有 marketplace backend contract</p></div><div className="searchbox"><Icon d="search" /><input disabled placeholder="等待 catalog API" /></div></header><div className="reg-banner"><div className="reg-stat"><b>0</b><span>catalog rows</span></div><span className="reg-div" /><div className="reg-stat"><b>{live.skills.length}</b><span>local skills</span></div><span className="reg-div" /><div className="reg-stat"><b>API</b><span>未声明</span></div><span className="reg-flex" /><span className="reg-src">来源：live registry only</span></div><div className="mk-cats">{["全部分类", "团队仓库", "精选", "趋势"].map((item, i) => <button key={item} className={`mk-cat ${i === 0 ? "on" : ""}`}><Icon d={i === 1 ? "layers" : "market"} size={14} />{item}<span className="mk-cat-n">0</span></button>)}</div><div className="mk-grid">{["catalog API", "install flow", "security scan"].map((name) => <article key={name} className="mk-card disabled"><div className="mk-head"><Glyph>{name}</Glyph><div className="mk-title"><h3>{name}</h3><span>backend contract missing</span></div></div><p className="mk-desc">保留 SkillM 页面骨架，但不展示假市场数据。接入真实 catalog API 后才能启用安装流。</p><div className="mk-actions"><button className="btn-ghost disabled">审查源码</button><button className="btn-grad sm disabled">安装</button></div></article>)}</div></div>;
+  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>Loom V1 没有 marketplace/catalog backend contract</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>local registry skills</span></div><span className="reg-div" /><div className="reg-stat"><b>missing</b><span>catalog contract</span></div><span className="reg-flex" /><span className="reg-src">来源：live registry only</span></div><EmptyPanel text="未接入真实 catalog API，所以不展示市场分类或安装流。" /></div>;
 }
 
 function Forge({ live }: { live: ReturnType<typeof usePanelData> }) {
-  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>创建 skill 的参考向导 · 当前只读，因为没有 create-wizard backend contract</p></div></header><div className="forge-steps">{["选择起点", "基本信息", "编写指令", "目标 & 发布"].map((step, i) => <><button key={step} className={`fstep ${i === 0 ? "on" : ""}`}><span className="fstep-n">{i + 1}</span>{step}</button>{i < 3 && <span className="fstep-line" />}</>)}</div><div className="forge-body panel"><div className="forge-starts">{[["layers", "从模板开始", `${live.skills.length} local skills 可参考`], ["eye", "从官方文档生成", "需要 docs ingestion API"], ["forge", "从对话提炼", "需要 transcript API"], ["bolt", "AI 辅助生成", "需要 write contract"]].map(([ic, title, body]) => <button key={title} className="fstart disabled"><Icon d={ic} size={22} /><b>{title}</b><p>{body}</p></button>)}</div><div className="forge-foot"><span /><button className="btn-grad sm disabled">继续<Icon d="arrow" size={14} /></button></div></div></div>;
+  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>Loom V1 没有 create-wizard/docs-ingestion/transcript backend contract</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>local skills available for reference</span></div><span className="reg-div" /><div className="reg-stat"><b>missing</b><span>write contract</span></div><span className="reg-flex" /><span className="reg-src">未创建任何本地草稿</span></div><EmptyPanel text="未接入真实创建向导 API，所以不展示模板、AI 生成、文档导入或发布步骤。" /></div>;
 }
 
 function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; close: () => void }) {
@@ -725,7 +706,7 @@ function Tweaks({ dark, setDark, density, setDensity, accent, setAccent, close }
   );
 }
 
-function Toasts({ items, dismiss }: { items: Toast[]; dismiss: (id: number) => void }) {
+function Toasts({ items, dismiss }: { items: Toast[]; dismiss: (id: string) => void }) {
   return <div className="sm-toasts">{items.map((toast) => <button key={toast.id} className={`sm-toast ${toast.kind}`} onClick={() => dismiss(toast.id)}><Icon d={toast.kind === "err" ? "x" : "bolt"} />{toast.text}</button>)}</div>;
 }
 

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { usePanelData } from "../lib/api/usePanelData";
 import { api } from "../lib/api/client";
 import type { Op, PanelPageKey, Skill, Target } from "../lib/types";
+import { FirstRunPage } from "./panel/FirstRunPage";
 import { DoctorPage } from "./panel/DoctorPage";
 
 type SkillMPage = PanelPageKey | "market" | "forge";
@@ -265,15 +266,21 @@ export function SkillMPanel() {
       <div className="sm-frame">
         <ActivityRail view={view} counts={{ ...counts, skills: live.skills.length, targets: live.targets.length, bindings: live.bindings.length, projections: live.projections.length }} onGo={go} onTerm={() => setTermOpen((open) => !open)} />
         <main className="sm-main" data-screen-label={view}>
-          {view === "overview" && <Overview live={live} counts={counts} go={go} />}
-          {view === "skills" && <Skills skills={live.skills} targets={live.targets} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
-          {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={go} />}
-          {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} runAction={runAction} />}
-          {view === "sync" && <Sync live={live} runAction={runAction} />}
-          {view === "doctor" && <Doctor live={live} go={go} />}
-          {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
-          {view === "market" && <Market live={live} />}
-          {view === "forge" && <Forge live={live} />}
+          {live.mode === "first-run" ? (
+            <div className="view view-first-run"><FirstRunPage registryRoot={live.registryRoot} onReady={live.refetch} /></div>
+          ) : (
+            <>
+              {view === "overview" && <Overview live={live} counts={counts} go={go} />}
+              {view === "skills" && <Skills skills={live.skills} targets={live.targets} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
+              {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={go} />}
+              {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} runAction={runAction} />}
+              {view === "sync" && <Sync live={live} runAction={runAction} />}
+              {view === "doctor" && <Doctor live={live} go={go} />}
+              {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
+              {view === "market" && <Market live={live} />}
+              {view === "forge" && <Forge live={live} />}
+            </>
+          )}
           {termOpen && <Terminal live={live} close={() => setTermOpen(false)} />}
         </main>
       </div>

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -5,6 +5,7 @@ import { api } from "../lib/api/client";
 import type { Op, PanelPageKey, Skill, Target } from "../lib/types";
 import { FirstRunPage } from "./panel/FirstRunPage";
 import { DoctorPage } from "./panel/DoctorPage";
+import { SkillMAuditHistory } from "./SkillMAuditHistory";
 
 type SkillMPage = PanelPageKey | "market" | "forge";
 type ToastKind = "ok" | "err" | "info" | "sync";
@@ -619,7 +620,7 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
       </header>
       <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
       <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
-      <section className="ops-table">{rows.map((op) => <OpLine key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>{history ? "No operation history returned by API." : "队列已清空 · 没有待处理或失败的操作"}</p></div>}</section>
+      {history ? <SkillMAuditHistory live={live.live} refreshKey={live.lastUpdated} /> : <section className="ops-table">{rows.map((op) => <OpLine key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>队列已清空 · 没有待处理或失败的操作</p></div>}</section>}
     </div>
   );
 }

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -122,6 +122,60 @@ function classForOp(op: Op) {
   return "pending";
 }
 
+const HEATMAP_WEEKS = 26;
+const HEATMAP_DAYS = HEATMAP_WEEKS * 7;
+const DAY_MS = 86_400_000;
+
+type SkillMetric = { skill: Skill; ops: number; edges: number; targets: number };
+
+function opTimestamp(op: Op): number | null {
+  const value = op.updatedAt ?? op.createdAt;
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function heatmapWindow(now = Date.now()) {
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const start = new Date(today);
+  start.setDate(today.getDate() - today.getDay() - (HEATMAP_WEEKS - 1) * 7);
+  return { start: start.getTime(), end: start.getTime() + HEATMAP_DAYS * DAY_MS };
+}
+
+function heatmapLabels(start: number) {
+  return Array.from({ length: 6 }, (_, index) => {
+    const date = new Date(start + Math.round((index * (HEATMAP_WEEKS - 1)) / 5) * 7 * DAY_MS);
+    return `${date.getMonth() + 1}月`;
+  });
+}
+
+function opSkillKeys(op: Op) {
+  return op.skill
+    .split(",")
+    .map((part) => part.trim().replace(/@\S+$/, ""))
+    .filter(Boolean);
+}
+
+function buildSkillMetrics(skills: Skill[], ops: Op[]): SkillMetric[] {
+  const knownSkills = new Set(skills.map((skill) => skill.name));
+  const opCounts = new Map<string, number>();
+  for (const op of ops) {
+    if (opTimestamp(op) === null) continue;
+    for (const name of opSkillKeys(op)) {
+      if (knownSkills.has(name)) opCounts.set(name, (opCounts.get(name) ?? 0) + 1);
+    }
+  }
+  return skills
+    .map((skill) => ({
+      skill,
+      ops: opCounts.get(skill.name) ?? 0,
+      edges: skill.projectionCount + skill.bindingCount,
+      targets: skill.targets.length + (skill.observedTargetIds?.length ?? 0),
+    }))
+    .sort((a, b) => b.ops - a.ops || b.edges - a.edges || b.targets - a.targets || a.skill.name.localeCompare(b.skill.name));
+}
+
 export function SkillMPanel() {
   const live = usePanelData();
   const [view, setView] = useState<SkillMPage>(initialView);
@@ -261,6 +315,11 @@ function Overview({ live, counts, go }: { live: ReturnType<typeof usePanelData>;
   const health = tally(live.projections.map((projection) => projection.health));
   const failed = counts.failedOps;
   const root = registryLabel(live.registryRoot);
+  const topSkills = useMemo(() => buildSkillMetrics(live.skills, live.ops).slice(0, 6), [live.skills, live.ops]);
+  const maxSkillOps = Math.max(0, ...topSkills.map((item) => item.ops));
+  const maxSkillEdges = Math.max(0, ...topSkills.map((item) => item.edges));
+  const skillBarBase = maxSkillOps > 0 ? maxSkillOps : maxSkillEdges;
+  const skillBarValue = (item: SkillMetric) => (maxSkillOps > 0 ? item.ops : item.edges);
   return (
     <div className="view view-dash">
       <header className="dash-hero">
@@ -294,18 +353,19 @@ function Overview({ live, counts, go }: { live: ReturnType<typeof usePanelData>;
       ) : null}
       <div className="dash-grid">
         <section className="panel">
-          <div className="panel-head"><h3><Icon d="bolt" />用量活跃度</h3><span className="panel-hint">ops / pending · 近 26 周</span></div>
-          <Heatmap ops={live.ops} queued={live.queuedWriteCount} />
+          <div className="panel-head"><h3><Icon d="bolt" />用量活跃度</h3><span className="panel-hint">ops.created_at / updated_at · 近 26 周</span></div>
+          <Heatmap ops={live.ops} />
         </section>
         <section className="panel">
-          <div className="panel-head"><h3><Icon d="lib" />Top Skills</h3><button className="link-btn" onClick={() => go("skills")}>查看 {"->"}</button></div>
+          <div className="panel-head"><h3><Icon d="lib" />Skill 真实统计</h3><button className="link-btn" onClick={() => go("skills")}>查看 {"->"}</button></div>
           <div className="ov-topskills">
-            {live.skills.slice(0, 6).map((skill, index) => (
-              <button className="ovts-row" key={skill.name} onClick={() => go("skills")}>
+            {live.skills.length > 0 && maxSkillOps === 0 && <div className="ovts-note">当前没有 skill usage ops；条形只按真实 registry edges 显示。</div>}
+            {topSkills.map((item, index) => (
+              <button className="ovts-row" key={item.skill.name} onClick={() => go("skills")}>
                 <span className="ovts-rank">{index + 1}</span>
-                <span className="ovts-name">{skill.name}</span>
-                <span className="ovts-bar"><i style={{ width: `${Math.max(4, Math.min(100, (skill.projectionCount + skill.bindingCount + 1) * 10))}%`, background: "var(--grad)" }} /></span>
-                <span className="ovts-n">{skill.projectionCount} edges</span>
+                <span className="ovts-name">{item.skill.name}</span>
+                <span className="ovts-bar"><i style={{ width: `${skillBarBase > 0 ? (skillBarValue(item) / skillBarBase) * 100 : 0}%`, background: maxSkillOps > 0 ? "var(--grad)" : "color-mix(in oklch,var(--acc3) 60%,var(--bg2))" }} /></span>
+                <span className="ovts-n">{item.ops} ops · {item.edges} edges</span>
               </button>
             ))}
             {live.skills.length === 0 && <div className="panel-empty">No skills from live registry yet.</div>}
@@ -336,21 +396,37 @@ function Overview({ live, counts, go }: { live: ReturnType<typeof usePanelData>;
   );
 }
 
-function Heatmap({ ops, queued }: { ops: Op[]; queued: number }) {
-  const cells = Array.from({ length: 26 * 7 }, (_, i) => {
-    const op = ops[i % Math.max(ops.length, 1)];
-    if (i < Math.min(ops.length + queued, 26 * 7)) return op?.status === "err" ? 3 : op?.status === "pending" ? 2 : 1;
-    return 0;
-  });
+function Heatmap({ ops }: { ops: Op[] }) {
+  const { start, end } = heatmapWindow();
+  const cells = Array.from({ length: HEATMAP_DAYS }, () => ({ count: 0, failed: false }));
+  let stamped = 0;
+  let inRange = 0;
+  for (const op of ops) {
+    const timestamp = opTimestamp(op);
+    if (timestamp === null) continue;
+    stamped += 1;
+    if (timestamp < start || timestamp >= end) continue;
+    const index = Math.floor((timestamp - start) / DAY_MS);
+    const cell = cells[index];
+    if (!cell) continue;
+    cell.count += 1;
+    cell.failed ||= op.status === "err";
+    inRange += 1;
+  }
+  const max = Math.max(0, ...cells.map((cell) => cell.count));
+  const labels = heatmapLabels(start);
+  const colors = ["var(--hm0)", "color-mix(in oklch,var(--acc3) 32%,var(--bg2))", "color-mix(in oklch,var(--acc3) 65%,var(--bg2))", "var(--acc3)"];
+  const colorFor = (count: number) => colors[count === 0 || max === 0 ? 0 : Math.max(1, Math.ceil((count / max) * 3))] ?? colors[0];
   return (
     <div className="hm-wrap">
-      <div className="hm-months">{["1月", "2月", "3月", "4月", "5月", "6月"].map((m) => <span key={m}>{m}</span>)}</div>
+      <div className="hm-months">{labels.map((m, index) => <span key={`${m}-${index}`}>{m}</span>)}</div>
       <div className="hm-grid">{Array.from({ length: 26 }, (_, col) => <div className="hm-col" key={col}>{Array.from({ length: 7 }, (_, row) => {
-        const value = cells[col * 7 + row] ?? 0;
-        const colors = ["var(--hm0)", "color-mix(in oklch,var(--acc3) 32%,var(--bg2))", "color-mix(in oklch,var(--acc3) 65%,var(--bg2))", "var(--warn)"];
-        return <i className="hm-cell" key={row} style={{ background: colors[value] }} />;
+        const index = col * 7 + row;
+        const cell = cells[index] ?? { count: 0, failed: false };
+        const date = new Date(start + index * DAY_MS).toISOString().slice(0, 10);
+        return <i className="hm-cell" key={row} title={`${date}: ${cell.count} ops`} style={{ background: colorFor(cell.count), boxShadow: cell.failed ? "0 0 0 1px var(--warn)" : "none" }} />;
       })}</div>)}</div>
-      <div className="hm-foot"><span>近 26 周 · 共 <b>{ops.length + queued}</b> 次操作 / 队列记录</span><span className="hm-leg">少 <i /><i style={{ background: "color-mix(in oklch,var(--acc3) 32%,var(--bg2))" }} /><i style={{ background: "color-mix(in oklch,var(--acc3) 65%,var(--bg2))" }} /><i style={{ background: "var(--warn)" }} /> 多</span></div>
+      <div className="hm-foot"><span>{inRange > 0 ? <>近 26 周 · <b>{inRange}</b> 条真实 ops 时间戳</> : "近 26 周没有可统计 ops 时间戳"}</span><span className="hm-leg">有效 {stamped}/{ops.length} <i /><i style={{ background: colors[1] }} /><i style={{ background: colors[2] }} /><i style={{ background: colors[3] }} /> 多</span></div>
     </div>
   );
 }

--- a/panel/src/pages/test_utils.ts
+++ b/panel/src/pages/test_utils.ts
@@ -1,0 +1,18 @@
+import { vi } from "vitest";
+
+export function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+export function errorResponse(status: number, body: unknown): Response {
+  return {
+    ok: false,
+    status,
+    statusText: "Service Unavailable",
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}

--- a/panel/src/panel-entry.tsx
+++ b/panel/src/panel-entry.tsx
@@ -1,18 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { PanelApp } from "./pages/PanelApp";
-import "./styles/tokens.css";
-import "./styles/base.css";
-import "./styles/panel/shell.css";
-import "./styles/panel/primitives.css";
-import "./styles/panel/data.css";
-import "./styles/panel/tweaks.css";
+import { SkillMPanel } from "./pages/SkillMPanel";
+import "./styles/panel/skillm.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root mount point missing");
 
 createRoot(root).render(
   <StrictMode>
-    <PanelApp />
+    <SkillMPanel />
   </StrictMode>,
 );

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -1,0 +1,1284 @@
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap");
+
+/* ============ SkillM — design tokens & global ============ */
+:root{
+  --acc1:#ff0080; --acc2:#7928ca; --acc3:#00d9ff; --glow:0.7;
+  --grad:linear-gradient(105deg,var(--acc1),var(--acc2) 52%,var(--acc3));
+  --grad-soft:linear-gradient(105deg,color-mix(in oklch,var(--acc1) 60%,transparent),color-mix(in oklch,var(--acc3) 60%,transparent));
+  --mono:'JetBrains Mono',ui-monospace,monospace;
+  --sans:'Space Grotesk','Noto Sans SC',system-ui,sans-serif;
+  --r:12px; --r-sm:8px; --r-lg:18px;
+  --t:200ms cubic-bezier(.4,0,.2,1);
+}
+/* ---- dark (default) ---- */
+.sm-app.dark{
+  --bg:#07070d; --bg2:#0c0c16; --panel:#11111d; --panel2:#161624; --raise:#1b1b2c;
+  --ink:#ececf6; --sub:#9696b0; --faint:#62627e;
+  --line:#22223400; --line1:#242438; --line2:#33334d;
+  --ok:#34d399; --err:#fb6a8a; --warn:#fbbf24;
+  --hm0:#171727;
+  --card-shadow:0 10px 40px -12px rgba(0,0,0,.7);
+  --glow-shadow:0 0 calc(28px*var(--glow)) color-mix(in oklch,var(--acc2) calc(70%*var(--glow)),transparent);
+}
+/* ---- light ---- */
+.sm-app.light{
+  --bg:#f5f5fa; --bg2:#eeeef5; --panel:#ffffff; --panel2:#fafaff; --raise:#ffffff;
+  --ink:#161622; --sub:#5b5b72; --faint:#9494ac;
+  --line:#00000000; --line1:#e7e7f0; --line2:#d4d4e2;
+  --ok:#0ea96b; --err:#e0456a; --warn:#d99412;
+  --hm0:#eaeaf2;
+  --card-shadow:0 8px 30px -14px rgba(60,40,120,.28);
+  --glow-shadow:0 0 calc(22px*var(--glow)) color-mix(in oklch,var(--acc2) calc(45%*var(--glow)),transparent);
+}
+*{box-sizing:border-box;}
+html,body{margin:0;height:100%;}
+body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
+#root{height:100vh;}
+::selection{background:color-mix(in oklch,var(--acc1) 40%,transparent);color:#fff;}
+*::-webkit-scrollbar{width:10px;height:10px;}
+*::-webkit-scrollbar-thumb{background:var(--line2);border-radius:8px;border:2px solid transparent;background-clip:content-box;}
+*::-webkit-scrollbar-thumb:hover{background:var(--faint);background-clip:content-box;}
+
+.sm-app{height:100vh;display:flex;flex-direction:column;color:var(--ink);position:relative;background:
+  radial-gradient(900px 600px at 12% -5%,color-mix(in oklch,var(--acc2) 12%,transparent),transparent 60%),
+  radial-gradient(800px 500px at 95% 8%,color-mix(in oklch,var(--acc3) 10%,transparent),transparent 55%),
+  var(--bg);}
+.sm-particles{position:fixed;inset:0;width:100%;height:100%;z-index:0;pointer-events:none;}
+.sm-frame{flex:1;display:flex;min-height:0;position:relative;z-index:1;}
+.sm-main{flex:1;min-width:0;overflow-y:auto;overflow-x:hidden;position:relative;scroll-behavior:smooth;}
+
+/* ============ activity bar ============ */
+.sm-actbar{width:68px;flex:none;display:flex;flex-direction:column;align-items:center;gap:6px;
+  padding:14px 0 12px;background:color-mix(in oklch,var(--panel) 80%,transparent);
+  backdrop-filter:blur(14px);border-right:1px solid var(--line1);z-index:3;}
+.sm-actbar .logo{width:40px;height:40px;border-radius:11px;background:var(--grad);display:grid;place-items:center;
+  font-weight:700;font-size:20px;color:#fff;margin-bottom:14px;box-shadow:var(--glow-shadow);
+  font-family:var(--mono);animation:logoFloat 6s ease-in-out infinite;}
+@keyframes logoFloat{50%{transform:translateY(-3px) rotate(-2deg);}}
+.sm-actbar .logo span{filter:drop-shadow(0 1px 2px rgba(0,0,0,.3));}
+.nav-items{display:flex;flex-direction:column;gap:4px;flex:1;}
+.nav-bottom{display:flex;flex-direction:column;gap:4px;}
+.act{position:relative;width:46px;height:46px;border:none;background:transparent;color:var(--sub);
+  border-radius:12px;display:grid;place-items:center;cursor:pointer;transition:var(--t);}
+.act:hover{background:var(--raise);color:var(--ink);}
+.act.on{color:#fff;background:var(--grad);box-shadow:var(--glow-shadow);}
+.act.on::before{content:'';position:absolute;left:-14px;top:50%;transform:translateY(-50%);width:4px;height:22px;border-radius:4px;background:var(--grad);}
+.act-label{position:absolute;left:54px;white-space:nowrap;background:var(--raise);color:var(--ink);
+  padding:5px 10px;border-radius:8px;font-size:12px;font-weight:600;opacity:0;pointer-events:none;
+  transform:translateX(-6px);transition:var(--t);box-shadow:var(--card-shadow);z-index:20;border:1px solid var(--line1);}
+.act:hover .act-label{opacity:1;transform:translateX(0);}
+.act.on .act-label{display:none;}
+
+/* ============ status bar ============ */
+.sm-statusbar{height:30px;flex:none;display:flex;align-items:center;gap:2px;padding:0 6px;z-index:4;
+  background:color-mix(in oklch,var(--panel) 88%,transparent);backdrop-filter:blur(14px);
+  border-top:1px solid var(--line1);font-size:11.5px;font-family:var(--mono);color:var(--sub);}
+.sb-item{display:flex;align-items:center;gap:6px;padding:0 10px;height:100%;border:none;background:transparent;
+  color:var(--sub);cursor:pointer;font-family:var(--mono);font-size:11.5px;transition:var(--t);}
+.sb-item:hover{color:var(--ink);background:var(--raise);}
+.sb-sync svg{transition:transform .6s;}
+.sb-sync.busy svg{animation:spin 1s linear infinite;}
+@keyframes spin{to{transform:rotate(360deg);}}
+.sb-flex{flex:1;}
+.sb-ver{color:var(--faint);}
+
+/* ============ generic view scaffold ============ */
+.view{max-width:1160px;margin:0 auto;padding:30px 36px 56px;}
+.den-compact .view{padding:20px 26px 44px;max-width:1240px;}
+.den-comfy .view{padding:40px 48px 72px;max-width:1080px;}
+.view-head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;margin-bottom:22px;flex-wrap:wrap;}
+.view-head>div:first-child{flex:1;min-width:260px;}
+.view-head h1{font-size:30px;letter-spacing:-.02em;margin:0;font-weight:700;}
+.den-compact .view-head h1{font-size:25px;}
+.view-head p{margin:5px 0 0;color:var(--sub);font-size:14px;}
+.panel{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);
+  border-radius:var(--r-lg);padding:20px 22px;backdrop-filter:blur(8px);}
+.panel-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;}
+.panel-head h3{display:flex;align-items:center;gap:9px;font-size:15px;margin:0;font-weight:600;}
+.panel-head h3 svg{color:var(--acc1);}
+.panel-hint{font-family:var(--mono);font-size:11px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;}
+.panel-empty{color:var(--faint);font-size:14px;text-align:center;padding:24px 0;}
+.link-btn{border:none;background:none;color:var(--acc3);font-size:12.5px;cursor:pointer;font-weight:600;font-family:var(--sans);}
+.link-btn:hover{text-decoration:underline;}
+
+/* ---- buttons ---- */
+.btn-grad{display:inline-flex;align-items:center;gap:8px;border:none;cursor:pointer;font-family:var(--sans);
+  font-weight:600;font-size:14px;color:#fff;background:var(--grad);padding:11px 20px;border-radius:11px;
+  box-shadow:var(--glow-shadow);transition:var(--t);background-size:160% 160%;white-space:nowrap;}
+.btn-grad:hover{transform:translateY(-1px);background-position:100% 0;}
+.btn-grad:active{transform:translateY(0);}
+.btn-grad.sm{padding:8px 15px;font-size:13px;border-radius:9px;}
+.btn-grad.wide{width:100%;justify-content:center;margin-top:6px;}
+.btn-grad.disabled{opacity:.4;pointer-events:none;filter:grayscale(.4);}
+.btn-ghost{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line2);background:transparent;
+  color:var(--ink);font-family:var(--sans);font-weight:600;font-size:13px;padding:8px 14px;border-radius:9px;
+  cursor:pointer;transition:var(--t);white-space:nowrap;}
+.btn-ghost:hover{border-color:var(--acc2);background:var(--raise);}
+.btn-ghost.xs{padding:4px 9px;font-size:11.5px;}
+.btn-ghost.installed{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 40%,transparent);}
+.btn-icon{border:none;background:transparent;color:var(--sub);cursor:pointer;padding:6px;border-radius:8px;display:grid;place-items:center;transition:var(--t);}
+.btn-icon:hover{background:var(--raise);color:var(--ink);}
+
+/* ---- shared atoms ---- */
+.sm-glyph{display:grid;place-items:center;border-radius:11px;font-family:var(--mono);font-weight:700;flex:none;
+  color:#fff;background:var(--grad);background-size:150% 150%;box-shadow:inset 0 1px 0 rgba(255,255,255,.2);letter-spacing:.02em;}
+.sm-tag{font-family:var(--mono);font-size:10.5px;color:var(--sub);background:var(--raise);border:1px solid var(--line1);
+  padding:2px 7px;border-radius:6px;letter-spacing:.02em;}
+.sm-switch{position:relative;width:40px;height:23px;border-radius:99px;border:1px solid var(--line2);
+  background:var(--raise);cursor:pointer;transition:var(--t);flex:none;padding:0;}
+.sm-switch .knob{position:absolute;top:2px;left:2px;width:17px;height:17px;border-radius:50%;background:var(--faint);transition:var(--t);}
+.sm-switch.on{background:var(--grad);border-color:transparent;box-shadow:var(--glow-shadow);}
+.sm-switch.on .knob{left:19px;background:#fff;}
+.sm-switch.small{width:34px;height:20px;}
+.sm-switch.small .knob{width:14px;height:14px;}
+.sm-switch.small.on .knob{left:16px;}
+.tool-dots{display:inline-flex;gap:4px;}
+.tool-dots span{border-radius:50%;border:1px solid;transition:var(--t);}
+.sm-spark{display:block;}
+
+/* ============ Dashboard ============ */
+.dash-hero{display:flex;align-items:center;justify-content:space-between;gap:24px;margin-bottom:24px;
+  padding:26px 30px;border-radius:var(--r-lg);position:relative;overflow:hidden;
+  background:linear-gradient(120deg,color-mix(in oklch,var(--acc2) 18%,var(--panel)),var(--panel) 70%);
+  border:1px solid var(--line1);}
+.hero-kicker{font-family:var(--mono);font-size:11px;letter-spacing:.18em;color:var(--acc3);font-weight:700;margin-bottom:8px;}
+.dash-hero h1{font-size:27px;letter-spacing:-.02em;margin:0;font-weight:700;}
+.dash-hero h1 em{font-style:normal;background:var(--grad);-webkit-background-clip:text;background-clip:text;color:transparent;}
+.dash-hero p{margin:9px 0 0;color:var(--sub);font-size:13.5px;font-family:var(--mono);}
+.hero-orb{position:relative;width:90px;height:90px;flex:none;}
+.hero-orb span{position:absolute;inset:0;border-radius:50%;border:2px solid;animation:orb 8s linear infinite;}
+.hero-orb span:nth-child(1){border-color:color-mix(in oklch,var(--acc1) 60%,transparent);}
+.hero-orb span:nth-child(2){border-color:color-mix(in oklch,var(--acc2) 60%,transparent);inset:14px;animation-duration:6s;animation-direction:reverse;}
+.hero-orb span:nth-child(3){border-color:color-mix(in oklch,var(--acc3) 60%,transparent);inset:28px;animation-duration:4s;}
+@keyframes orb{to{transform:rotate(360deg);}}
+
+.stat-row{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:18px;}
+.stat-card{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);border-radius:var(--r);
+  padding:16px 18px;position:relative;overflow:hidden;transition:var(--t);}
+.stat-card:hover{transform:translateY(-2px);box-shadow:var(--card-shadow);border-color:var(--line2);}
+.stat-card.hot::after{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--grad);}
+.stat-top{display:flex;align-items:center;gap:7px;color:var(--sub);font-size:12px;font-weight:500;}
+.stat-top svg{color:var(--acc2);}
+.stat-val{font-size:32px;font-weight:700;letter-spacing:-.02em;margin:6px 0 2px;font-family:var(--mono);}
+.stat-sub{font-size:11.5px;color:var(--faint);}
+.stat-card.link{cursor:pointer;text-align:left;font-family:inherit;}
+.orb-core{position:absolute;inset:34px;border-radius:50%;box-shadow:var(--glow-shadow);}
+.dash-attn{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:18px;
+  padding:11px 18px;border-radius:var(--r);background:color-mix(in oklch,var(--panel) 92%,transparent);
+  border:1px solid var(--line1);border-left:3px solid var(--acc2);flex-wrap:wrap;}
+.da-text{display:flex;gap:16px;font-size:13px;color:var(--sub);flex-wrap:wrap;}
+.da-text span{display:inline-flex;align-items:center;gap:5px;}
+.da-text b{color:var(--ink);font-family:var(--mono);font-size:14px;}
+.da-text .da-fail b{color:var(--err);}
+.da-acts{display:flex;gap:7px;flex-wrap:wrap;}
+.da-link{border:1px solid var(--line2);background:transparent;color:var(--sub);font-family:var(--mono);
+  font-size:11px;padding:4px 10px;border-radius:7px;cursor:pointer;transition:var(--t);white-space:nowrap;}
+.da-link:hover{color:var(--ink);border-color:var(--acc2);background:color-mix(in oklch,var(--acc2) 12%,transparent);}
+
+.dash-grid{display:grid;grid-template-columns:1.45fr 1fr;gap:14px;}
+.dash-grid .panel:first-child{grid-column:1/-1;}
+
+/* heatmap */
+.hm-wrap{display:flex;flex-direction:column;gap:6px;}
+.hm-months{display:flex;justify-content:space-between;font-family:var(--mono);font-size:10px;color:var(--faint);padding:0 2px;}
+.hm-grid{display:flex;gap:3px;justify-content:space-between;}
+.hm-col{display:flex;flex-direction:column;gap:3px;flex:1;}
+.hm-cell{width:100%;aspect-ratio:1;border-radius:3px;transition:transform .12s,box-shadow .2s;cursor:pointer;}
+.hm-cell:hover{transform:scale(1.35);outline:1px solid var(--ink);z-index:2;}
+.hm-foot{display:flex;justify-content:space-between;align-items:center;margin-top:8px;font-size:11px;color:var(--sub);}
+.hm-tip{font-family:var(--mono);}
+.hm-legend{display:flex;align-items:center;gap:3px;font-family:var(--mono);font-size:10px;color:var(--faint);}
+.hm-legend i{width:11px;height:11px;border-radius:3px;display:inline-block;}
+
+/* top list */
+.top-list{display:flex;flex-direction:column;gap:2px;}
+.top-item{display:flex;align-items:center;gap:12px;padding:8px 10px;border-radius:10px;border:none;background:transparent;
+  cursor:pointer;transition:var(--t);width:100%;text-align:left;color:var(--ink);}
+.top-item:hover{background:var(--raise);}
+.top-rank{font-family:var(--mono);font-size:12px;color:var(--faint);font-weight:700;width:20px;}
+.top-name{flex:1;font-size:13.5px;font-weight:600;font-family:var(--mono);}
+.top-calls{font-family:var(--mono);font-size:12px;color:var(--sub);min-width:48px;text-align:right;}
+
+/* updates */
+.upd-list{display:flex;flex-direction:column;gap:8px;}
+.upd-item{display:flex;align-items:center;gap:11px;padding:9px 11px;border-radius:10px;background:var(--raise);border:1px solid var(--line1);}
+.upd-info{flex:1;display:flex;flex-direction:column;}
+.upd-name{font-size:13px;font-weight:600;font-family:var(--mono);}
+.upd-ver{font-size:11px;color:var(--sub);font-family:var(--mono);}
+.upd-ver b{color:var(--ok);}
+.upd-pip{display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--warn);margin-left:7px;box-shadow:0 0 7px var(--warn);}
+
+/* sync mini */
+.sync-mini{display:flex;flex-direction:column;gap:9px;}
+.sync-mini-row{display:flex;align-items:center;gap:10px;font-size:13px;}
+.dev-dot{width:8px;height:8px;border-radius:50%;background:var(--line2);flex:none;}
+.dev-dot.on{background:var(--ok);box-shadow:0 0 8px var(--ok);}
+.dev-name{flex:1;font-weight:500;}
+.dev-name em{color:var(--faint);font-style:normal;font-size:11px;font-family:var(--mono);}
+.dev-sync{font-family:var(--mono);font-size:11px;color:var(--faint);}
+
+/* ============ Library ============ */
+.searchbox{display:flex;align-items:center;gap:9px;background:var(--panel);border:1px solid var(--line1);
+  border-radius:11px;padding:9px 13px;min-width:320px;transition:var(--t);}
+.searchbox:focus-within{border-color:var(--acc2);box-shadow:var(--glow-shadow);}
+.searchbox svg{color:var(--faint);flex:none;}
+.searchbox input{border:none;background:none;outline:none;color:var(--ink);font-size:13.5px;flex:1;font-family:var(--sans);}
+.searchbox kbd,.pal-input kbd,.det-tab kbd{font-family:var(--mono);font-size:10px;background:var(--raise);border:1px solid var(--line2);
+  border-radius:5px;padding:1px 6px;color:var(--sub);}
+
+.filter-bar{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:18px;padding-bottom:16px;border-bottom:1px solid var(--line1);}
+.chip-group{display:flex;gap:6px;flex-wrap:wrap;}
+.chip{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line2);background:transparent;color:var(--sub);
+  font-family:var(--sans);font-size:12.5px;font-weight:500;padding:6px 12px;border-radius:99px;cursor:pointer;transition:var(--t);white-space:nowrap;}
+.chip:hover{color:var(--ink);border-color:var(--faint);}
+.chip.on{color:#fff;background:var(--grad);background-size:340% 100%;background-position:50% 0;border-color:transparent;box-shadow:var(--glow-shadow);}
+.chip-dot{width:8px;height:8px;border-radius:50%;}
+.chip-check{cursor:pointer;}
+.chip-check input{accent-color:var(--acc2);margin-right:2px;}
+
+.lib-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px;}
+.den-compact .lib-grid{grid-template-columns:repeat(auto-fill,minmax(290px,1fr));gap:11px;}
+.skill-card{background:color-mix(in oklch,var(--panel) 94%,transparent);border:1px solid var(--line1);border-radius:var(--r-lg);
+  padding:17px 18px;cursor:pointer;transition:transform var(--t),box-shadow var(--t),border-color var(--t);
+  position:relative;overflow:hidden;}
+@media(prefers-reduced-motion:no-preference){.skill-card{animation:cardRise .5s backwards;}}
+@keyframes cardRise{from{transform:translateY(16px) scale(.98);}}
+.skill-card::before{content:'';position:absolute;inset:0;border-radius:inherit;padding:1px;opacity:0;transition:var(--t);
+  background:var(--grad);-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);
+  -webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none;}
+.skill-card:hover{transform:translateY(-3px);box-shadow:var(--card-shadow);}
+.skill-card:hover::before{opacity:1;}
+.skill-card:focus-visible{outline:2px solid var(--acc2);outline-offset:2px;}
+.skill-card.dim{opacity:.62;}
+.skill-card.dim:hover{opacity:1;}
+.sc-head{display:flex;align-items:center;gap:12px;margin-bottom:11px;}
+.sc-title{flex:1;min-width:0;}
+.sc-title h3{font-size:15px;margin:0;font-weight:600;font-family:var(--mono);display:flex;align-items:center;}
+.sc-meta{font-size:11px;color:var(--faint);font-family:var(--mono);}
+.sc-desc{font-size:12.8px;color:var(--sub);line-height:1.55;margin:0 0 13px;text-wrap:pretty;
+  display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;min-height:40px;}
+.sc-tools{display:flex;align-items:center;gap:6px;margin-bottom:13px;}
+.tool-pill{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--line2);background:transparent;
+  color:var(--faint);font-family:var(--mono);font-size:10.5px;font-weight:700;padding:3px 8px;border-radius:7px;cursor:pointer;transition:var(--t);}
+.tool-pill i{width:6px;height:6px;border-radius:50%;background:var(--line2);transition:var(--t);}
+.tool-pill:hover{border-color:var(--faint);color:var(--ink);}
+.tool-pill.on{color:var(--ink);border-color:var(--tc);background:color-mix(in oklch,var(--tc) 14%,transparent);}
+.tool-pill.on i{background:var(--tc);box-shadow:0 0 7px var(--tc);}
+.sc-scope{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--faint);}
+.sc-foot{display:flex;align-items:center;gap:8px;}
+.sc-tags{display:flex;gap:4px;flex:1;flex-wrap:wrap;}
+.sc-calls{font-family:var(--mono);font-size:11px;color:var(--sub);white-space:nowrap;}
+.lib-empty,.lib-empty p{color:var(--faint);}
+.lib-empty{grid-column:1/-1;display:flex;flex-direction:column;align-items:center;gap:12px;padding:60px 0;text-align:center;}
+.lib-empty svg{color:var(--line2);}
+
+/* ============ Detail ============ */
+.det-head{display:grid;grid-template-columns:auto 1fr;gap:8px 18px;align-items:start;margin-bottom:20px;}
+.det-head .back{grid-column:1/-1;justify-self:start;margin-bottom:2px;}
+.det-title{min-width:0;}
+.det-title h1{font-size:25px;margin:0;display:flex;align-items:center;gap:12px;font-family:var(--mono);font-weight:700;letter-spacing:-.01em;}
+.det-ver{font-family:var(--mono);font-size:12px;color:var(--acc3);background:var(--raise);border:1px solid var(--line1);padding:2px 9px;border-radius:7px;}
+.det-title p{margin:8px 0 0;color:var(--sub);font-size:14px;max-width:600px;text-wrap:pretty;line-height:1.55;}
+.det-meta{display:flex;align-items:center;gap:8px;margin-top:11px;flex-wrap:wrap;font-size:12px;color:var(--faint);font-family:var(--mono);}
+.det-repo{display:inline-flex;align-items:center;gap:5px;color:var(--sub);white-space:nowrap;}
+.det-cat{color:var(--acc3);background:var(--raise);border:1px solid var(--line1);padding:1px 8px;border-radius:6px;white-space:nowrap;}
+.det-layout{display:grid;grid-template-columns:1fr 312px;gap:18px;align-items:start;}
+.det-main{min-width:0;}
+.det-rail{display:flex;flex-direction:column;gap:12px;position:sticky;top:8px;}
+.rail-card{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);border-radius:var(--r);padding:14px 15px;}
+.rail-label{font-family:var(--mono);font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;display:block;margin-bottom:11px;}
+.matrix-row{display:grid;grid-template-columns:auto 1fr auto;gap:9px;align-items:center;padding:7px 0;border-top:1px solid var(--line1);}
+.matrix-row:first-of-type{border-top:none;padding-top:0;}
+.matrix-row i{width:9px;height:9px;border-radius:50%;}
+.matrix-row span{font-size:12.5px;font-weight:600;}
+.matrix-row code{grid-column:2;font-family:var(--mono);font-size:10px;color:var(--faint);margin-top:-4px;}
+.matrix-row .sm-switch{grid-row:1/3;grid-column:3;}
+
+.det-tabs{display:flex;align-items:center;gap:4px;border-bottom:1px solid var(--line1);margin-bottom:18px;}
+.det-tab{display:inline-flex;align-items:center;gap:7px;border:none;background:none;color:var(--sub);font-family:var(--sans);
+  font-size:13.5px;font-weight:600;padding:11px 14px;cursor:pointer;position:relative;transition:var(--t);}
+.det-tab:hover{color:var(--ink);}
+.det-tab.on{color:var(--ink);}
+.det-tab.on::after{content:'';position:absolute;left:10px;right:10px;bottom:-1px;height:2.5px;border-radius:3px;background:var(--grad);box-shadow:var(--glow-shadow);}
+.tab-flex{flex:1;}
+
+.det-preview{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);padding:26px 32px;max-width:760px;}
+.det-source{display:flex;background:var(--bg2);border:1px solid var(--line1);border-radius:var(--r);overflow:hidden;min-height:420px;}
+.src-gutter{display:flex;flex-direction:column;padding:18px 0;background:color-mix(in oklch,var(--panel) 60%,transparent);
+  font-family:var(--mono);font-size:12.5px;line-height:1.7;color:var(--faint);text-align:right;user-select:none;flex:none;}
+.src-gutter span{padding:0 12px;}
+.det-source textarea{flex:1;border:none;background:none;outline:none;color:var(--ink);font-family:var(--mono);
+  font-size:13px;line-height:1.7;padding:18px 18px;resize:none;tab-size:2;}
+
+/* markdown */
+.md{font-size:14px;line-height:1.75;color:var(--ink);}
+.md h1{font-size:24px;margin:0 0 14px;font-family:var(--mono);letter-spacing:-.01em;}
+.md h2{font-size:16px;margin:24px 0 8px;color:var(--acc3);font-family:var(--mono);}
+.md p{margin:8px 0;color:var(--sub);}
+.md ol,.md ul{margin:8px 0;padding-left:22px;color:var(--sub);}
+.md li{margin:4px 0;}
+.md code{font-family:var(--mono);font-size:12.5px;background:var(--raise);border:1px solid var(--line1);padding:1px 6px;border-radius:5px;color:var(--acc1);}
+.md strong{color:var(--ink);}
+.md-code,.fe-preview .md-code{display:block;background:var(--bg2);border:1px solid var(--line1);border-radius:9px;
+  padding:13px 16px;font-family:var(--mono);font-size:12.5px;line-height:1.7;color:var(--ok);margin:12px 0;white-space:pre-wrap;overflow-x:auto;}
+
+/* versions */
+.ver-timeline{padding:6px 4px;max-width:680px;}
+.ver-node{display:flex;gap:16px;}
+.ver-rail{display:flex;flex-direction:column;align-items:center;flex:none;width:18px;}
+.ver-dot{width:14px;height:14px;border-radius:50%;background:var(--panel);border:2px solid var(--line2);margin-top:3px;z-index:1;flex:none;}
+.ver-node.cur .ver-dot{background:var(--grad);border-color:transparent;box-shadow:var(--glow-shadow);}
+.ver-line{flex:1;width:2px;background:var(--line1);margin:2px 0;}
+.ver-body{padding-bottom:24px;flex:1;}
+.ver-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+.ver-head b{font-family:var(--mono);font-size:14px;}
+.ver-cur{font-family:var(--mono);font-size:10px;color:#fff;background:var(--grad);background-size:340% 100%;background-position:50% 0;padding:2px 7px;border-radius:6px;}
+.ver-date{font-family:var(--mono);font-size:11.5px;color:var(--faint);}
+.ver-body p{margin:6px 0 9px;font-size:13px;color:var(--sub);}
+.ver-diff{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11.5px;}
+.diff-add{color:var(--ok);}.diff-del{color:var(--err);}
+.diff-bar{display:flex;gap:2px;flex:1;max-width:200px;height:7px;}
+.diff-bar i{height:100%;border-radius:2px;}.diff-bar .add{background:var(--ok);}.diff-bar .del{background:var(--err);}
+
+/* dep graph */
+.graph-wrap{background:var(--bg2);border:1px solid var(--line1);border-radius:var(--r);padding:18px;}
+.dep-graph{width:100%;height:auto;}
+.edge{fill:none;stroke-width:1.5;opacity:.5;}
+.edge-in{stroke-dasharray:4 4;animation:dash 18s linear infinite;}
+@keyframes dash{to{stroke-dashoffset:-200;}}
+.edge-on{stroke-width:2.2;opacity:.9;filter:drop-shadow(0 0 4px currentColor);}
+.edge-off{opacity:.3;stroke-dasharray:3 5;}
+.core-halo{fill:none;stroke:var(--acc2);stroke-width:1;opacity:.4;animation:halo 3s ease-in-out infinite;}
+@keyframes halo{50%{stroke-width:3;opacity:.15;}}
+.core-bg{fill:var(--panel);stroke:url(#edgeGrad);stroke-width:2;}
+.core-glyph{font-family:var(--mono);font-weight:700;font-size:15px;fill:var(--ink);}
+.core-name{font-family:var(--mono);font-size:8.5px;fill:var(--sub);}
+.node-dep{fill:var(--panel);stroke:var(--line2);stroke-width:1;}
+.dep-label{font-family:var(--mono);font-size:9px;fill:var(--sub);}
+.tool-label{font-family:var(--mono);font-weight:700;font-size:11px;}
+.tool-sub{font-family:var(--mono);font-size:8.5px;fill:var(--faint);}
+.graph-cap{text-align:center;font-size:11.5px;color:var(--faint);margin:12px 0 0;font-family:var(--mono);}
+
+/* activity log */
+.act-log{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);padding:8px;max-width:760px;}
+.act-row{display:grid;grid-template-columns:auto auto auto 1fr;gap:11px;align-items:center;padding:9px 12px;border-radius:8px;font-size:12.5px;transition:var(--t);}
+.act-row:hover{background:var(--raise);}
+.act-status{width:7px;height:7px;border-radius:50%;}
+.act-status.ok{background:var(--ok);box-shadow:0 0 6px var(--ok);}
+.act-status.err{background:var(--err);}
+.act-time{font-family:var(--mono);font-size:11px;color:var(--faint);min-width:74px;}
+.act-tool{font-family:var(--mono);font-size:11px;font-weight:700;min-width:74px;}
+.act-text{color:var(--sub);}
+.act-note{font-family:var(--mono);font-size:11px;color:var(--faint);padding:10px 12px 4px;margin:0;}
+
+/* ============ Market ============ */
+.mk-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(310px,1fr));gap:14px;}
+.mk-card{background:color-mix(in oklch,var(--panel) 94%,transparent);border:1px solid var(--line1);border-radius:var(--r-lg);
+  padding:18px;position:relative;overflow:hidden;transition:var(--t);}
+@media(prefers-reduced-motion:no-preference){.mk-card{animation:cardRise .5s backwards;}}
+.mk-card:hover{transform:translateY(-3px);box-shadow:var(--card-shadow);border-color:var(--line2);}
+.mk-feat{position:absolute;top:13px;right:13px;background:var(--grad);background-size:340% 100%;background-position:50% 0;color:#fff;font-family:var(--mono);font-size:8.5px;
+  font-weight:700;letter-spacing:.12em;padding:3px 9px;border-radius:99px;box-shadow:var(--glow-shadow);}
+.mk-head{display:flex;align-items:center;gap:12px;margin-bottom:12px;padding-right:78px;}
+.mk-title{flex:1;min-width:0;}
+.mk-title h3{margin:0;font-size:15px;font-family:var(--mono);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.mk-title span{font-size:11px;color:var(--faint);font-family:var(--mono);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block;}
+.mk-desc{font-size:12.8px;color:var(--sub);line-height:1.55;margin:0 0 14px;min-height:60px;text-wrap:pretty;
+  display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;}
+.mk-stats{display:flex;align-items:center;gap:13px;margin-bottom:14px;font-family:var(--mono);font-size:11.5px;color:var(--sub);}
+.mk-stats span{display:inline-flex;align-items:center;gap:4px;}
+.mk-stats svg{color:var(--warn);}
+.mk-trend{color:var(--ok)!important;font-weight:700;}
+.mk-tag{margin-left:auto;color:var(--faint)!important;}
+.mk-actions{display:flex;gap:8px;}
+.mk-actions .btn-ghost{flex:1;justify-content:center;}
+.mk-actions .btn-grad{flex:1;justify-content:center;}
+
+/* ============ Sync ============ */
+.sync-grid{display:grid;grid-template-columns:1.3fr 1fr;gap:14px;}
+.sync-topo{width:100%;height:auto;}
+.beam{fill:none;stroke-width:2;opacity:.25;}
+.beam.on{opacity:.85;stroke-dasharray:5 6;animation:dash 12s linear infinite;}
+.beam-dot{filter:drop-shadow(0 0 5px var(--acc3));}
+.topo-node{fill:var(--panel);stroke:var(--line2);stroke-width:1.5;}
+.topo-node.self{stroke:url(#beamGrad);stroke-width:2;}
+.topo-name{font-family:var(--mono);font-weight:700;font-size:12px;fill:var(--ink);}
+.topo-sub{font-family:var(--mono);font-size:9px;fill:var(--faint);}
+.topo-self{font-family:var(--mono);font-size:8px;fill:var(--acc3);font-weight:700;}
+.topo-cloud{fill:var(--panel);stroke:url(#beamGrad);stroke-width:2;}
+.topo-cloud-halo{fill:none;stroke:var(--acc2);stroke-width:2;opacity:.5;transform-origin:320px 64px;animation:cloudPulse 2.4s ease-out infinite;}
+@keyframes cloudPulse{from{r:34px;opacity:.5;}to{r:58px;opacity:0;}}
+
+.ev-stream{display:flex;flex-direction:column;gap:2px;margin-bottom:14px;}
+.ev-row{display:grid;grid-template-columns:auto auto 1fr auto;gap:10px;align-items:center;padding:8px 10px;border-radius:8px;font-size:12px;transition:var(--t);}
+.ev-row:hover{background:var(--raise);}
+.ev-ic{width:22px;height:22px;border-radius:7px;display:grid;place-items:center;flex:none;background:var(--raise);color:var(--sub);}
+.ev-push .ev-ic{color:var(--acc3);}.ev-pull .ev-ic{color:var(--acc2);}
+.ev-drift .ev-ic{color:var(--warn);background:color-mix(in oklch,var(--warn) 15%,transparent);}
+.ev-resolve .ev-ic{color:var(--ok);}.ev-install .ev-ic{color:var(--acc1);}
+.ev-time{font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+.ev-text{color:var(--ink);}
+.ev-dev{font-family:var(--mono);font-size:10px;color:var(--faint);}
+.drift-card{background:color-mix(in oklch,var(--warn) 8%,var(--panel));border:1px solid color-mix(in oklch,var(--warn) 30%,transparent);border-radius:var(--r);padding:13px 15px;}
+.drift-head{display:flex;align-items:center;gap:8px;font-weight:600;font-size:13px;color:var(--warn);margin-bottom:6px;}
+.drift-card p{margin:0;font-size:12px;color:var(--sub);line-height:1.55;}
+
+/* ============ Forge ============ */
+.forge-steps{display:flex;align-items:center;margin-bottom:20px;}
+.fstep{display:flex;align-items:center;gap:9px;border:none;background:none;color:var(--faint);font-family:var(--sans);
+  font-size:13px;font-weight:600;cursor:default;padding:0 4px;}
+.fstep.done{cursor:pointer;color:var(--sub);}
+.fstep.on{color:var(--ink);}
+.fstep-n{width:26px;height:26px;border-radius:50%;display:grid;place-items:center;font-family:var(--mono);font-size:12px;
+  border:1.5px solid var(--line2);transition:var(--t);}
+.fstep.on .fstep-n{background:var(--grad);background-size:340% 100%;background-position:50% 0;border-color:transparent;color:#fff;box-shadow:var(--glow-shadow);}
+.fstep.done .fstep-n{background:var(--ok);border-color:transparent;color:#fff;}
+.fstep-line{flex:1;height:2px;background:var(--line1);margin:0 12px;border-radius:2px;transition:var(--t);}
+.fstep-line.done{background:var(--ok);}
+.forge-body{min-height:340px;display:flex;flex-direction:column;}
+.forge-starts{display:grid;grid-template-columns:1fr 1fr;gap:12px;flex:1;}
+.fstart{display:flex;flex-direction:column;align-items:flex-start;gap:6px;text-align:left;padding:20px;border-radius:var(--r);
+  border:1.5px solid var(--line1);background:var(--panel2);cursor:pointer;transition:var(--t);color:var(--ink);}
+.fstart svg{color:var(--acc2);margin-bottom:4px;}
+.fstart:hover{border-color:var(--line2);transform:translateY(-2px);}
+.fstart.on{border-color:var(--acc2);background:color-mix(in oklch,var(--acc2) 10%,var(--panel));box-shadow:var(--glow-shadow);}
+.fstart b{font-size:15px;}
+.fstart p{margin:0;font-size:12.5px;color:var(--sub);line-height:1.5;}
+.forge-form{display:flex;flex-direction:column;gap:18px;max-width:560px;}
+.forge-form label{display:flex;flex-direction:column;gap:7px;font-size:13px;font-weight:600;}
+.f-hint{font-weight:400;font-size:11.5px;color:var(--faint);font-family:var(--mono);}
+.forge-form input,.forge-publish input{border:1px solid var(--line2);background:var(--bg2);border-radius:9px;padding:11px 13px;
+  color:var(--ink);font-size:13.5px;font-family:var(--mono);outline:none;transition:var(--t);}
+.forge-form input:focus{border-color:var(--acc2);box-shadow:var(--glow-shadow);}
+.forge-editor{display:grid;grid-template-columns:1fr 1fr;gap:14px;flex:1;}
+.fe-pane{display:flex;flex-direction:column;border:1px solid var(--line1);border-radius:var(--r);overflow:hidden;background:var(--bg2);}
+.fe-label{font-family:var(--mono);font-size:10px;letter-spacing:.1em;color:var(--faint);padding:9px 14px;border-bottom:1px solid var(--line1);background:color-mix(in oklch,var(--panel) 50%,transparent);}
+.fe-pane textarea{flex:1;border:none;background:none;outline:none;color:var(--ink);font-family:var(--mono);font-size:12.5px;line-height:1.7;padding:14px;resize:none;min-height:300px;}
+.fe-preview{flex:1;padding:16px 18px;overflow-y:auto;max-height:380px;}
+.forge-publish{display:flex;flex-direction:column;gap:18px;}
+.forge-foot{display:flex;justify-content:space-between;align-items:center;margin-top:20px;padding-top:16px;border-top:1px solid var(--line1);}
+
+/* install modal sections (shared by forge) */
+.im-section{display:flex;flex-direction:column;gap:10px;}
+.im-section>label{font-size:12px;font-weight:600;color:var(--sub);font-family:var(--mono);text-transform:uppercase;letter-spacing:.05em;}
+.im-targets{display:flex;flex-direction:column;gap:8px;}
+.im-target{display:grid;grid-template-columns:auto 1fr auto;gap:4px 11px;align-items:center;text-align:left;
+  border:1.5px solid var(--line1);background:var(--panel2);border-radius:11px;padding:12px 14px;cursor:pointer;transition:var(--t);color:var(--ink);}
+.im-target i{width:11px;height:11px;border-radius:50%;background:var(--line2);grid-row:1/3;transition:var(--t);}
+.im-target b{font-size:13.5px;}
+.im-target code{font-family:var(--mono);font-size:10.5px;color:var(--faint);grid-column:2;}
+.im-target:hover{border-color:var(--line2);}
+.im-target.on{border-color:var(--tc);background:color-mix(in oklch,var(--tc) 10%,var(--panel));}
+.im-target.on i{background:var(--tc);box-shadow:0 0 8px var(--tc);}
+.im-check{grid-row:1/3;grid-column:3;width:24px;height:24px;border-radius:7px;display:grid;place-items:center;color:var(--tc);}
+.im-scope{display:flex;gap:8px;}
+
+/* ============ command palette ============ */
+.sm-palette-veil{position:fixed;inset:0;z-index:60;background:color-mix(in oklch,var(--bg) 55%,transparent);
+  backdrop-filter:blur(6px);display:flex;justify-content:center;align-items:flex-start;padding-top:14vh;animation:veilIn .15s;}
+@keyframes veilIn{from{opacity:0;}}
+.sm-palette{width:min(620px,92vw);background:color-mix(in oklch,var(--panel) 96%,transparent);border:1px solid var(--line2);
+  border-radius:16px;box-shadow:0 30px 80px -20px rgba(0,0,0,.6),var(--glow-shadow);overflow:hidden;animation:palIn .2s cubic-bezier(.2,.8,.2,1);}
+@keyframes palIn{from{opacity:0;transform:translateY(-12px) scale(.98);}}
+.pal-input{display:flex;align-items:center;gap:11px;padding:16px 18px;border-bottom:1px solid var(--line1);}
+.pal-input svg{color:var(--acc2);flex:none;}
+.pal-input input{flex:1;border:none;background:none;outline:none;color:var(--ink);font-size:15px;font-family:var(--sans);}
+.pal-list{max-height:340px;overflow-y:auto;padding:8px;}
+.pal-item{display:flex;align-items:center;gap:12px;width:100%;border:none;background:none;color:var(--ink);
+  padding:10px 13px;border-radius:10px;cursor:pointer;text-align:left;transition:background .1s;}
+.pal-item svg{color:var(--sub);flex:none;}
+.pal-item.sel{background:var(--grad);color:#fff;}
+.pal-item.sel svg{color:#fff;}
+.pal-label{flex:1;font-size:13.5px;font-weight:500;}
+.pal-hint{font-family:var(--mono);font-size:11px;color:var(--faint);}
+.pal-item.sel .pal-hint{color:rgba(255,255,255,.8);}
+.pal-item kbd{font-family:var(--mono);font-size:10px;background:var(--raise);border:1px solid var(--line2);border-radius:5px;padding:1px 6px;color:var(--sub);}
+.pal-item.sel kbd{background:rgba(255,255,255,.2);border-color:transparent;color:#fff;}
+.pal-empty{text-align:center;color:var(--faint);font-size:13px;padding:24px 0;}
+
+/* ============ toasts ============ */
+.sm-toasts{position:fixed;bottom:42px;right:18px;z-index:70;display:flex;flex-direction:column;gap:9px;align-items:flex-end;}
+.sm-toast{display:flex;align-items:center;gap:10px;background:color-mix(in oklch,var(--panel) 96%,transparent);
+  border:1px solid var(--line2);border-radius:11px;padding:11px 16px;font-size:13px;font-weight:500;color:var(--ink);
+  box-shadow:var(--card-shadow);backdrop-filter:blur(12px);animation:toastIn .3s cubic-bezier(.2,.8,.2,1);max-width:380px;}
+@keyframes toastIn{from{opacity:0;transform:translateX(30px);}}
+.sm-toast svg{flex:none;}
+.sm-toast.ok{border-left:3px solid var(--ok);}.sm-toast.ok svg{color:var(--ok);}
+.sm-toast.sync{border-left:3px solid var(--acc3);}.sm-toast.sync svg{color:var(--acc3);}
+.sm-toast.info{border-left:3px solid var(--acc2);}.sm-toast.info svg{color:var(--acc2);}
+
+/* ============ install modal ============ */
+.sm-veil{position:fixed;inset:0;z-index:55;background:color-mix(in oklch,var(--bg) 60%,transparent);backdrop-filter:blur(8px);
+  display:grid;place-items:center;padding:24px;animation:veilIn .15s;}
+.install-modal{width:min(480px,94vw);background:var(--panel);border:1px solid var(--line2);border-radius:18px;
+  padding:22px 24px;box-shadow:0 30px 80px -20px rgba(0,0,0,.6),var(--glow-shadow);animation:palIn .25s cubic-bezier(.2,.8,.2,1);}
+.im-head{display:flex;align-items:center;gap:13px;margin-bottom:14px;}
+.im-head h3{margin:0;font-size:17px;font-family:var(--mono);}
+.im-head span{font-size:11.5px;color:var(--faint);font-family:var(--mono);}
+.im-head .btn-icon{margin-left:auto;align-self:flex-start;}
+.im-desc{font-size:13px;color:var(--sub);line-height:1.6;margin:0 0 18px;}
+.install-modal .im-section{margin-bottom:18px;}
+.im-perm{font-size:11.5px;color:var(--faint);font-family:var(--mono);margin-bottom:16px;padding:9px 12px;background:var(--bg2);border-radius:9px;}
+.im-perm b{color:var(--sub);}
+/* install progress */
+.im-progress{text-align:center;padding:14px 0 4px;}
+.im-orb{width:84px;height:84px;border-radius:24px;margin:0 auto 16px;display:grid;place-items:center;background:var(--grad);
+  background-size:200% 200%;animation:orbPulse 1.4s ease-in-out infinite;box-shadow:var(--glow-shadow);color:#fff;}
+@keyframes orbPulse{50%{background-position:100% 0;transform:scale(1.05);}}
+.im-orb.done{animation:none;}
+.im-progress h3{font-size:17px;margin:0 0 18px;font-family:var(--mono);}
+.im-steps{display:flex;flex-direction:column;gap:9px;text-align:left;max-width:300px;margin:0 auto 18px;}
+.im-step{display:flex;align-items:center;gap:11px;font-size:13px;color:var(--faint);transition:var(--t);}
+.im-step-ic{width:20px;height:20px;border-radius:50%;border:1.5px solid var(--line2);display:grid;place-items:center;flex:none;transition:var(--t);}
+.im-step.busy{color:var(--ink);}
+.im-step.busy .im-step-ic{border-color:var(--acc2);border-top-color:transparent;animation:spin .7s linear infinite;}
+.im-step.ok{color:var(--ink);}
+.im-step.ok .im-step-ic{background:var(--ok);border-color:transparent;color:#fff;}
+
+/* ============ terminal ============ */
+.sm-terminal{position:absolute;left:0;right:0;bottom:0;height:300px;z-index:30;display:flex;flex-direction:column;
+  background:color-mix(in oklch,var(--bg2) 97%,transparent);backdrop-filter:blur(16px);border-top:2px solid var(--acc2);
+  box-shadow:0 -20px 60px -20px rgba(0,0,0,.6);animation:termIn .25s cubic-bezier(.2,.8,.2,1);}
+@keyframes termIn{from{transform:translateY(100%);}}
+.term-bar{display:flex;align-items:center;justify-content:space-between;padding:7px 12px;border-bottom:1px solid var(--line1);}
+.term-title{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;color:var(--sub);letter-spacing:.05em;}
+.term-out{flex:1;overflow-y:auto;padding:12px 16px;font-family:var(--mono);font-size:12.5px;line-height:1.65;}
+.term-line{display:flex;gap:8px;}
+.term-line pre{margin:0;font-family:var(--mono);white-space:pre-wrap;word-break:break-word;}
+.term-line.sys pre{color:var(--faint);}
+.term-line.in{color:var(--acc3);}
+.term-line.out pre{color:var(--ink);}
+.term-line.err pre{color:var(--err);}
+.term-line.neo pre{color:var(--acc1);}
+.term-ps{color:var(--acc1);font-weight:700;flex:none;}
+.term-in{display:flex;align-items:center;gap:8px;padding:9px 16px;border-top:1px solid var(--line1);}
+.term-in input{flex:1;border:none;background:none;outline:none;color:var(--ink);font-family:var(--mono);font-size:12.5px;}
+
+/* ============ responsive ============ */
+@media(max-width:980px){
+  .stat-row{grid-template-columns:repeat(2,1fr);}
+  .dash-grid,.sync-grid{grid-template-columns:1fr;}
+  .det-head{grid-template-columns:auto 1fr;}
+  .det-layout{grid-template-columns:1fr;}
+  .det-rail{position:static;flex-direction:row;flex-wrap:wrap;}
+  .det-rail .rail-card{flex:1;min-width:240px;}
+  .sess-layout{grid-template-columns:1fr;}
+  .sess-list-pane{position:static;}
+  .sess-list{max-height:none;}
+  .sd-body{grid-template-columns:1fr;}
+  .forge-editor{grid-template-columns:1fr;}
+}
+@media(prefers-reduced-motion:reduce){
+  *{animation-duration:.01ms!important;animation-iteration-count:1!important;}
+  .skill-card,.mk-card{animation:none!important;transform:none!important;}
+}
+
+/* ============ registry widgets ============ */
+/* quality ring */
+.q-ring{position:relative;display:grid;place-items:center;flex:none;}
+.q-track{stroke:var(--line1);}
+.q-arc{transition:stroke-dashoffset .8s cubic-bezier(.4,0,.2,1);}
+.q-ring.q-a .q-arc{stroke:var(--ok);}
+.q-ring.q-b .q-arc{stroke:var(--acc3);}
+.q-ring.q-c .q-arc{stroke:var(--warn);}
+.q-num{position:absolute;font-family:var(--mono);font-weight:700;line-height:1;font-size:0.32em;}
+/* quality bars */
+.q-card .q-card-top{display:flex;align-items:center;gap:14px;margin-bottom:14px;}
+.q-card-meta{display:flex;flex-direction:column;}
+.q-card-meta b{font-size:15px;}
+.q-card-meta span{font-size:11.5px;color:var(--faint);font-family:var(--mono);}
+.q-bars{display:flex;flex-direction:column;gap:8px;}
+.q-bar-row{display:grid;grid-template-columns:42px 1fr 24px;gap:9px;align-items:center;font-size:11px;}
+.q-bar-label{color:var(--sub);font-family:var(--mono);}
+.q-bar-track{height:6px;border-radius:4px;background:var(--line1);overflow:hidden;}
+.q-bar-track i{display:block;height:100%;border-radius:4px;background:var(--grad);transition:width .8s cubic-bezier(.4,0,.2,1);}
+.q-bar-val{font-family:var(--mono);color:var(--sub);text-align:right;}
+/* security badge */
+.sec-badge{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:600;font-family:var(--sans);padding:3px 9px;border-radius:7px;border:1px solid;white-space:nowrap;}
+.sec-badge.small{padding:2px;border:none;background:none!important;}
+.sec-badge.verified{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 40%,transparent);background:color-mix(in oklch,var(--ok) 12%,transparent);}
+.sec-badge.scanned{color:var(--acc3);border-color:color-mix(in oklch,var(--acc3) 40%,transparent);background:color-mix(in oklch,var(--acc3) 12%,transparent);}
+.sec-badge.caution{color:var(--warn);border-color:color-mix(in oklch,var(--warn) 40%,transparent);background:color-mix(in oklch,var(--warn) 12%,transparent);}
+/* code copy */
+.code-copy{display:flex;align-items:center;gap:8px;background:var(--bg2);border:1px solid var(--line1);border-radius:9px;padding:7px 9px;margin-bottom:7px;cursor:pointer;transition:var(--t);}
+.code-copy:hover{border-color:var(--acc2);}
+.cc-label{font-family:var(--mono);font-size:9px;text-transform:uppercase;letter-spacing:.08em;color:var(--faint);background:var(--raise);padding:2px 6px;border-radius:5px;flex:none;}
+.code-copy code{flex:1;font-family:var(--mono);font-size:11.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cc-ps{color:var(--acc1);margin-right:6px;}
+.cc-btn{border:none;background:none;color:var(--faint);cursor:pointer;flex:none;display:grid;place-items:center;}
+.code-copy:hover .cc-btn{color:var(--acc3);}
+.wide-ghost{width:100%;justify-content:center;margin-top:4px;}
+/* file tree */
+.det-files{background:var(--bg2);border:1px solid var(--line1);border-radius:var(--r);overflow:hidden;}
+.files-head{display:flex;align-items:center;gap:9px;padding:12px 16px;border-bottom:1px solid var(--line1);font-size:12.5px;color:var(--sub);font-family:var(--mono);}
+.files-head svg{color:var(--acc1);}
+.file-tree{padding:8px;}
+.ft-row{display:flex;align-items:center;gap:9px;padding:7px 10px;border-radius:8px;font-family:var(--mono);font-size:12.5px;transition:var(--t);}
+.ft-row:hover{background:var(--raise);}
+.ft-row svg{color:var(--faint);flex:none;}
+.ft-dir{color:var(--ink);font-weight:600;}
+.ft-dir svg{color:var(--acc2);}
+.ft-name{flex:1;}
+.ft-size{font-size:10.5px;color:var(--faint);white-space:nowrap;}
+.ft-tag{font-size:9px;color:var(--acc3);background:var(--raise);border:1px solid var(--line1);padding:1px 6px;border-radius:5px;}
+/* related */
+.related-list{display:flex;flex-direction:column;gap:6px;}
+.related-item{display:flex;align-items:center;gap:11px;padding:8px 10px;border-radius:10px;border:1px solid var(--line1);background:var(--panel2);cursor:pointer;transition:var(--t);width:100%;text-align:left;color:var(--ink);}
+.related-item:hover{border-color:var(--acc2);transform:translateX(2px);}
+.related-item svg{color:var(--faint);flex:none;}
+.related-info{flex:1;display:flex;flex-direction:column;min-width:0;}
+.related-name{font-size:13px;font-weight:600;font-family:var(--mono);}
+.related-meta{font-size:10.5px;color:var(--faint);font-family:var(--mono);}
+.preview-related{margin-top:24px;padding-top:20px;border-top:1px solid var(--line1);}
+.preview-related h4{display:flex;align-items:center;gap:8px;font-size:13px;margin:0 0 12px;color:var(--sub);}
+.preview-related h4 svg{color:var(--acc1);}
+/* security rail */
+.sec-row{display:flex;align-items:center;justify-content:space-between;margin-bottom:11px;}
+.sec-findings{font-family:var(--mono);font-size:11px;color:var(--sub);}
+.sec-perms{list-style:none;padding:0;margin:0 0 10px;display:flex;flex-direction:column;gap:6px;}
+.sec-perms li{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--sub);}
+.sec-perms li svg{color:var(--ok);flex:none;}
+.sec-perms li.sec-net svg{color:var(--faint);}
+.sec-scan{font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+/* tab count */
+.tab-count{font-family:var(--mono);font-size:10px;color:var(--faint);background:var(--raise);border-radius:99px;padding:0 6px;margin-left:2px;}
+
+/* ============ library card signals ============ */
+.sc-signals{display:flex;align-items:center;gap:10px;margin-bottom:12px;padding:9px 0;border-top:1px solid var(--line1);border-bottom:1px solid var(--line1);}
+.sc-q{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11px;color:var(--sub);white-space:nowrap;}
+.sc-cat{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+/* sort group */
+.sort-group{display:flex;align-items:center;gap:5px;margin-left:auto;}
+.sort-label{font-family:var(--mono);font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;}
+.sort-pill{border:1px solid var(--line2);background:transparent;color:var(--sub);font-family:var(--sans);font-size:12px;font-weight:500;padding:5px 11px;border-radius:99px;cursor:pointer;transition:var(--t);}
+.sort-pill:hover{color:var(--ink);border-color:var(--faint);}
+.sort-pill.on{color:var(--ink);border-color:var(--acc2);background:color-mix(in oklch,var(--acc2) 12%,transparent);}
+
+/* ============ market registry ============ */
+.reg-banner{display:flex;align-items:center;gap:18px;padding:14px 20px;border-radius:var(--r);margin-bottom:16px;
+  background:linear-gradient(110deg,color-mix(in oklch,var(--acc2) 14%,var(--panel)),var(--panel) 75%);border:1px solid var(--line1);}
+.reg-stat{display:flex;flex-direction:column;}
+.reg-stat b{font-family:var(--mono);font-size:18px;letter-spacing:-.01em;}
+.reg-stat span{font-size:11px;color:var(--sub);}
+.reg-div{width:1px;height:26px;background:var(--line2);}
+.reg-flex{flex:1;}
+.reg-src{font-family:var(--mono);font-size:11px;color:var(--faint);}
+.mk-cats{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;}
+.mk-cat{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line1);background:var(--panel2);color:var(--sub);font-family:var(--sans);font-size:12.5px;font-weight:500;padding:7px 13px;border-radius:10px;cursor:pointer;transition:var(--t);white-space:nowrap;}
+.mk-cat svg{color:var(--acc2);}
+.mk-cat:hover{border-color:var(--line2);color:var(--ink);transform:translateY(-1px);}
+.mk-cat.on{color:#fff;background:var(--grad);background-size:340% 100%;background-position:50% 0;border-color:transparent;box-shadow:var(--glow-shadow);}
+.mk-cat.on svg{color:#fff;}
+.mk-cat-n{font-family:var(--mono);font-size:10px;opacity:.8;background:var(--raise);padding:1px 6px;border-radius:99px;}
+.mk-cat.on .mk-cat-n{background:rgba(255,255,255,.2);}
+.mk-toolbar{display:flex;align-items:center;gap:12px;margin-bottom:16px;flex-wrap:wrap;}
+.mk-badges{display:flex;align-items:center;gap:9px;margin-bottom:12px;flex-wrap:wrap;}
+.mk-cat-tag{font-family:var(--mono);font-size:10px;color:var(--acc3);background:var(--raise);border:1px solid var(--line1);padding:1px 7px;border-radius:6px;}
+.mk-upd{font-family:var(--mono);font-size:10px;color:var(--faint);margin-left:auto;}
+.mk-install{background:var(--bg2);border:1px solid var(--line1);border-radius:8px;padding:7px 10px;margin-bottom:12px;}
+.mk-install code{font-family:var(--mono);font-size:11px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;}
+.mk-install .cc-ps{color:var(--acc1);margin-right:6px;}
+.mk-head .q-ring{margin-left:auto;}
+/* install modal extras */
+.im-meta-row{display:flex;align-items:center;gap:12px;margin-bottom:14px;}
+.im-q{display:inline-flex;align-items:center;gap:8px;font-family:var(--mono);font-size:12px;color:var(--sub);}
+.im-cat{font-family:var(--mono);font-size:11px;color:var(--acc3);background:var(--raise);border:1px solid var(--line1);padding:2px 8px;border-radius:6px;margin-left:auto;}
+
+/* ============ dashboard security posture ============ */
+.sec-posture{display:flex;align-items:center;gap:20px;}
+.sp-ring{display:flex;flex-direction:column;align-items:center;gap:7px;flex:none;}
+.sp-ring-cap{font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+.sp-bars{flex:1;display:flex;flex-direction:column;gap:11px;}
+.sp-row{display:grid;grid-template-columns:auto 1fr auto;gap:11px;align-items:center;}
+.sp-track{height:8px;border-radius:5px;background:var(--line1);overflow:hidden;}
+.sp-track i{display:block;height:100%;border-radius:5px;transition:width .8s cubic-bezier(.4,0,.2,1);}
+.sp-v i{background:var(--ok);}
+.sp-s i{background:var(--acc3);}
+.sp-c i{background:var(--warn);}
+.sp-row b{font-family:var(--mono);font-size:13px;}
+
+/* ============ sessions console ============ */
+.sess-layout{display:grid;grid-template-columns:336px 1fr;gap:16px;align-items:start;}
+.sess-list-pane{display:flex;flex-direction:column;gap:10px;position:sticky;top:8px;}
+.sess-search{display:flex;align-items:center;gap:9px;background:var(--panel);border:1px solid var(--line1);border-radius:10px;padding:9px 12px;}
+.sess-search svg{color:var(--faint);flex:none;}
+.sess-search input{border:none;background:none;outline:none;color:var(--ink);font-size:13px;flex:1;font-family:var(--sans);}
+.sess-filters{display:flex;flex-wrap:wrap;gap:5px;}
+.sfilter{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--line2);background:transparent;color:var(--sub);font-family:var(--sans);font-size:11.5px;font-weight:500;padding:4px 10px;border-radius:99px;cursor:pointer;transition:var(--t);}
+.sfilter:hover{color:var(--ink);border-color:var(--faint);}
+.sfilter.on{color:#fff;background:var(--grad);border-color:transparent;}
+.sf-n{font-family:var(--mono);font-size:9px;background:var(--raise);color:var(--sub);border-radius:99px;padding:0 5px;}
+.sfilter.on .sf-n{background:rgba(255,255,255,.25);color:#fff;}
+.sess-list{display:flex;flex-direction:column;gap:12px;max-height:calc(100vh - 220px);overflow-y:auto;padding-right:2px;}
+.sess-group-head{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;padding:4px 6px;}
+.sess-group-head span{margin-left:auto;background:var(--raise);border-radius:99px;padding:0 7px;}
+.sess-group{display:flex;flex-direction:column;gap:5px;}
+.sess-empty,.sess-detail-empty{color:var(--faint);font-size:13px;text-align:center;padding:40px 0;}
+.sess-row{display:flex;align-items:center;gap:11px;padding:11px 12px;border-radius:11px;border:1px solid var(--line1);background:color-mix(in oklch,var(--panel) 92%,transparent);cursor:pointer;transition:var(--t);text-align:left;width:100%;color:var(--ink);}
+.sess-row:hover{border-color:var(--line2);transform:translateX(2px);}
+.sess-row.active{border-color:var(--acc2);background:color-mix(in oklch,var(--acc2) 10%,var(--panel));box-shadow:var(--glow-shadow);}
+.sess-row.needs{border-color:color-mix(in oklch,var(--warn) 45%,transparent);}
+.sess-row-main{flex:1;min-width:0;}
+.sess-row-top{display:flex;align-items:center;gap:7px;}
+.pin{color:var(--acc1);font-size:11px;}
+.sess-name{font-family:var(--mono);font-size:13px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.sess-row-sub{font-size:11px;color:var(--sub);margin-top:3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.act-txt b{color:var(--ink);font-family:var(--mono);}
+.needs-txt{color:var(--warn);}
+.done-txt{color:var(--acc3);}
+.lost-txt{color:var(--err);}
+.sess-time{font-family:var(--mono);font-size:10.5px;color:var(--faint);flex:none;align-self:flex-start;}
+/* state dot */
+.state-dot{width:9px;height:9px;border-radius:50%;background:var(--sc);flex:none;position:relative;}
+.state-dot.st-running{box-shadow:0 0 0 0 var(--sc);animation:livePulse 1.8s ease-out infinite;}
+@keyframes livePulse{0%{box-shadow:0 0 0 0 color-mix(in oklch,var(--sc) 70%,transparent);}70%{box-shadow:0 0 0 6px transparent;}100%{box-shadow:0 0 0 0 transparent;}}
+.state-dot.st-idle{background:var(--faint);}
+/* session tool tag */
+.sess-tool{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:10px;font-weight:600;color:var(--tc);background:color-mix(in oklch,var(--tc) 12%,transparent);border:1px solid color-mix(in oklch,var(--tc) 30%,transparent);padding:1px 7px;border-radius:6px;}
+.sess-tool i{width:5px;height:5px;border-radius:50%;background:var(--tc);}
+.sess-tool.small{font-size:9px;padding:0 6px;margin-left:auto;}
+/* detail */
+.sess-detail{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);border-radius:var(--r-lg);padding:18px 20px;min-width:0;}
+.sd-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;flex-wrap:wrap;}
+.sd-title{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+.sd-title h2{font-size:19px;margin:0;font-family:var(--mono);font-weight:700;}
+.sd-state{font-size:11px;font-weight:600;padding:2px 9px;border-radius:7px;font-family:var(--mono);}
+.sd-state.st-running{color:var(--ok);background:color-mix(in oklch,var(--ok) 14%,transparent);}
+.sd-state.st-waiting{color:var(--warn);background:color-mix(in oklch,var(--warn) 14%,transparent);}
+.sd-state.st-idle{color:var(--faint);background:var(--raise);}
+.sd-state.st-completed{color:var(--acc3);background:color-mix(in oklch,var(--acc3) 14%,transparent);}
+.sd-state.st-lost{color:var(--err);background:color-mix(in oklch,var(--err) 14%,transparent);}
+.sd-actions{display:flex;gap:7px;flex-wrap:wrap;}
+.btn-ghost.danger:hover{border-color:var(--err);color:var(--err);background:color-mix(in oklch,var(--err) 8%,transparent);}
+.sd-meta{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin:14px 0 16px;padding:12px 0;border-top:1px solid var(--line1);border-bottom:1px solid var(--line1);font-family:var(--mono);font-size:11.5px;color:var(--sub);}
+.sd-meta span{display:inline-flex;align-items:center;gap:6px;}
+.sd-meta svg{color:var(--faint);}
+.sd-body{display:grid;grid-template-columns:1fr 256px;gap:16px;align-items:start;}
+.sd-sub{font-family:var(--mono);font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:10px;}
+.sd-transcript{background:var(--bg2);border:1px solid var(--line1);border-radius:var(--r);padding:14px 16px;min-height:240px;}
+.tr-line{display:flex;gap:10px;padding:6px 0;font-size:13px;line-height:1.5;}
+.tr-who{font-family:var(--mono);font-size:10px;font-weight:700;flex:none;width:48px;text-align:right;padding-top:2px;}
+.tr-you .tr-who{color:var(--acc3);}
+.tr-agent .tr-who{color:var(--acc1);}
+.tr-tool .tr-who{color:var(--sub);}
+.tr-sys .tr-who{color:var(--err);}
+.tr-text{color:var(--ink);text-wrap:pretty;}
+.tr-tool .tr-text{font-family:var(--mono);font-size:12px;color:var(--sub);}
+.tr-sys .tr-text{color:var(--err);}
+.needs-card{margin-top:14px;background:color-mix(in oklch,var(--warn) 8%,var(--panel));border:1px solid color-mix(in oklch,var(--warn) 35%,transparent);border-radius:var(--r);padding:14px;}
+.needs-q{display:flex;align-items:flex-start;gap:9px;font-size:13.5px;color:var(--ink);margin-bottom:12px;line-height:1.55;}
+.needs-q svg{color:var(--warn);flex:none;margin-top:2px;}
+.needs-reply{display:flex;gap:8px;margin-bottom:10px;}
+.needs-reply input{flex:1;border:1px solid var(--line2);background:var(--bg2);border-radius:9px;padding:9px 12px;color:var(--ink);font-size:13px;outline:none;font-family:var(--sans);}
+.needs-reply input:focus{border-color:var(--acc2);}
+.needs-quick{display:flex;gap:6px;flex-wrap:wrap;}
+.result-card{margin-top:14px;display:flex;align-items:center;gap:10px;background:color-mix(in oklch,var(--acc3) 8%,var(--panel));border:1px solid color-mix(in oklch,var(--acc3) 30%,transparent);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink);}
+.result-card svg{color:var(--acc3);flex:none;}
+.sd-rail{display:flex;flex-direction:column;gap:12px;}
+.sd-skills{display:flex;flex-direction:column;gap:6px;margin-bottom:10px;}
+.sd-skill{display:flex;align-items:center;gap:9px;padding:5px 7px;border-radius:8px;background:var(--raise);font-family:var(--mono);font-size:12px;}
+.sd-skill span{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.sk-x{border:none;background:none;color:var(--faint);cursor:pointer;display:grid;place-items:center;padding:2px;border-radius:5px;}
+.sk-x:hover{color:var(--err);background:color-mix(in oklch,var(--err) 12%,transparent);}
+.sd-empty{font-size:11.5px;color:var(--faint);}
+.sd-mcp{display:flex;flex-wrap:wrap;gap:6px;}
+.mcp-chip{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:11px;color:var(--sub);background:var(--raise);border:1px solid var(--line1);padding:3px 9px;border-radius:7px;}
+.mcp-chip i{width:5px;height:5px;border-radius:50%;background:var(--acc3);}
+.sd-wt{display:block;font-family:var(--mono);font-size:11px;color:var(--acc3);background:var(--bg2);border:1px solid var(--line1);border-radius:7px;padding:7px 9px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.sd-wt-note{display:block;font-size:10.5px;color:var(--faint);margin-top:6px;}
+/* dispatch modal */
+.dispatch-modal{width:min(560px,94vw);background:var(--panel);border:1px solid var(--line2);border-radius:18px;padding:22px 24px;box-shadow:0 30px 80px -20px rgba(0,0,0,.6),var(--glow-shadow);animation:palIn .25s cubic-bezier(.2,.8,.2,1);max-height:92vh;overflow-y:auto;}
+.dm-icon{width:42px;height:42px;border-radius:12px;background:var(--grad);display:grid;place-items:center;color:#fff;box-shadow:var(--glow-shadow);flex:none;}
+.dm-label{display:block;font-family:var(--mono);font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.05em;margin:14px 0 8px;}
+.dm-task{width:100%;min-height:74px;border:1px solid var(--line2);background:var(--bg2);border-radius:10px;padding:11px 13px;color:var(--ink);font-size:14px;font-family:var(--sans);resize:vertical;outline:none;line-height:1.5;}
+.dm-task:focus{border-color:var(--acc2);}
+.dm-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
+.dm-tools{display:flex;flex-direction:column;gap:6px;}
+.dm-tool{display:flex;align-items:center;gap:8px;border:1.5px solid var(--line1);background:var(--panel2);color:var(--ink);font-family:var(--sans);font-size:13px;font-weight:500;padding:9px 12px;border-radius:9px;cursor:pointer;transition:var(--t);}
+.dm-tool i{width:9px;height:9px;border-radius:50%;background:var(--line2);}
+.dm-tool.on{border-color:var(--tc);background:color-mix(in oklch,var(--tc) 12%,var(--panel));}
+.dm-tool.on i{background:var(--tc);box-shadow:0 0 7px var(--tc);}
+.dm-projects{display:flex;flex-direction:column;gap:6px;}
+.dm-toggle{display:flex;align-items:center;gap:9px;margin-top:14px;font-size:12.5px;color:var(--sub);cursor:pointer;}
+.dm-toggle input{accent-color:var(--acc2);}
+.dm-skills{display:flex;flex-wrap:wrap;gap:6px;}
+.sk-chip{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--line2);background:transparent;color:var(--sub);font-family:var(--mono);font-size:11px;padding:4px 10px;border-radius:99px;cursor:pointer;transition:var(--t);}
+.sk-chip:hover{color:var(--ink);border-color:var(--faint);}
+.sk-chip.on{color:var(--ink);border-color:var(--acc2);background:color-mix(in oklch,var(--acc2) 12%,transparent);}
+.dispatch-modal .btn-grad.wide{margin-top:20px;}
+/* status bar live dot */
+.sb-live{width:7px;height:7px;border-radius:50%;background:var(--ok);box-shadow:0 0 6px var(--ok);animation:livePulse 1.8s ease-out infinite;--sc:var(--ok);}
+
+/* responsive overrides for sessions (must follow base rules to win) */
+@media(max-width:1100px){
+  .sd-body{grid-template-columns:1fr;}
+}
+@media(max-width:980px){
+  .sess-layout{grid-template-columns:1fr;}
+  .sess-list-pane{position:static;}
+  .sess-list{max-height:none;}
+}
+
+/* ============ control plane ============ */
+.sb-warn{color:var(--warn)!important;}
+.sb-live.warn{background:var(--warn);box-shadow:0 0 6px var(--warn);--sc:var(--warn);}
+/* registry strip */
+.reg-strip{display:flex;align-items:center;gap:12px;padding:12px 18px;border-radius:var(--r);margin-bottom:16px;flex-wrap:wrap;
+  background:linear-gradient(110deg,color-mix(in oklch,var(--acc2) 13%,var(--panel)),var(--panel) 72%);border:1px solid var(--line1);font-size:12.5px;}
+.rs-git{display:inline-flex;align-items:center;gap:7px;font-weight:600;color:var(--acc3);font-family:var(--mono);white-space:nowrap;}
+.reg-strip code{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--bg2);border:1px solid var(--line1);padding:3px 9px;border-radius:7px;white-space:nowrap;}
+.rs-div{width:1px;height:18px;background:var(--line2);}
+.rs-stat{color:var(--sub);font-family:var(--mono);white-space:nowrap;}
+.rs-stat b{color:var(--ink);}
+.rs-guard{display:inline-flex;align-items:center;gap:6px;color:var(--warn);font-family:var(--mono);white-space:nowrap;}
+.rs-flex{flex:1;}
+.rs-panel{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line2);background:transparent;color:var(--acc3);font-family:var(--mono);font-size:11.5px;padding:5px 11px;border-radius:8px;cursor:pointer;transition:var(--t);}
+.rs-panel:hover{border-color:var(--acc3);background:color-mix(in oklch,var(--acc3) 10%,transparent);}
+/* plane stats — same anatomy as dashboard .stat-card */
+.plane-stats{display:grid;grid-template-columns:repeat(5,1fr);gap:14px;margin-bottom:18px;}
+.pstat{display:flex;flex-direction:column;gap:2px;padding:16px 18px;border-radius:var(--r);border:1px solid var(--line1);
+  background:color-mix(in oklch,var(--panel) 92%,transparent);transition:var(--t);text-align:left;position:relative;overflow:hidden;font-family:inherit;color:var(--ink);}
+button.pstat{cursor:pointer;}
+button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shadow:var(--card-shadow);}
+.pstat-l{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--sub);font-weight:500;}
+.pstat-l::before{content:'';width:7px;height:7px;border-radius:50%;background:var(--acc2);flex:none;}
+.pstat-n{font-family:var(--mono);font-size:28px;font-weight:700;letter-spacing:-.02em;margin-top:4px;}
+.pstat.warn{border-color:color-mix(in oklch,var(--warn) 32%,transparent);}
+.pstat.warn .pstat-n{color:var(--warn);}
+.pstat.warn .pstat-l::before{background:var(--warn);box-shadow:0 0 7px var(--warn);}
+.pstat.warn::after{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--warn);}
+.pstat.acc{border-color:color-mix(in oklch,var(--acc3) 32%,transparent);}
+.pstat.acc .pstat-n{color:var(--acc3);}
+.pstat.acc .pstat-l::before{background:var(--acc3);box-shadow:0 0 7px var(--acc3);}
+.pstat.acc::after{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--acc3);}
+@media(max-width:980px){.plane-stats{grid-template-columns:repeat(2,1fr);}}
+.plane-tabs{display:flex;align-items:center;gap:4px;border-bottom:1px solid var(--line1);margin-bottom:18px;}
+/* projection graph */
+.plane-graph{background:var(--bg2);border:1px solid var(--line1);border-radius:var(--r);padding:8px 14px 14px;}
+.pg-cols{display:flex;justify-content:space-between;font-family:var(--mono);font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;padding:10px 4px 4px;}
+.pg-cols span{white-space:nowrap;}
+.pg-cols span:nth-child(2){flex:0 0 auto;}
+.proj-svg{width:100%;display:block;}
+.proj-edge{fill:none;stroke-width:2.2;transition:opacity var(--t);cursor:pointer;}
+.proj-edge.pending{stroke-dasharray:5 5;animation:dash 14s linear infinite;}
+.proj-edge.drift{stroke-dasharray:2 4;stroke-width:2.6;}
+.pg-node{fill:var(--panel);stroke:var(--line2);stroke-width:1;}
+.pg-skill{stroke:color-mix(in oklch,var(--acc1) 40%,var(--line2));}
+.pg-target{fill:color-mix(in oklch,var(--ac) 8%,var(--panel));stroke:color-mix(in oklch,var(--ac) 40%,transparent);}
+.pg-glyph{font-family:var(--mono);font-weight:700;font-size:10px;fill:var(--acc1);}
+.pg-label{font-family:var(--mono);font-size:11px;fill:var(--ink);}
+.pg-sub{font-family:var(--mono);font-size:8.5px;fill:var(--faint);}
+.pg-legend{display:flex;gap:16px;justify-content:center;margin-top:10px;flex-wrap:wrap;}
+.pg-leg{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10.5px;color:var(--sub);}
+.pg-leg i{width:16px;height:3px;border-radius:2px;display:inline-block;}
+.pg-leg.pg-dash i{background:repeating-linear-gradient(90deg,var(--faint) 0 3px,transparent 3px 6px);}
+/* ownership / method tags */
+.own-badge{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:10.5px;font-weight:600;color:var(--oc);background:color-mix(in oklch,var(--oc) 13%,transparent);border:1px solid color-mix(in oklch,var(--oc) 35%,transparent);padding:2px 8px;border-radius:7px;white-space:nowrap;}
+.own-badge.small{font-size:9.5px;padding:1px 6px;}
+.method-tag{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:7px;white-space:nowrap;border:1px solid var(--line2);}
+.method-tag.m-symlink{color:var(--acc3);border-color:color-mix(in oklch,var(--acc3) 35%,transparent);background:color-mix(in oklch,var(--acc3) 10%,transparent);}
+.method-tag.m-copy{color:var(--acc2);border-color:color-mix(in oklch,var(--acc2) 35%,transparent);background:color-mix(in oklch,var(--acc2) 10%,transparent);}
+.method-tag.m-materialize{color:var(--acc1);border-color:color-mix(in oklch,var(--acc1) 35%,transparent);background:color-mix(in oklch,var(--acc1) 10%,transparent);}
+/* targets grid */
+.targets-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px;}
+.target-card{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);border-radius:var(--r-lg);padding:16px 18px;transition:var(--t);}
+.target-card:hover{border-color:color-mix(in oklch,var(--ac) 45%,var(--line1));box-shadow:var(--card-shadow);}
+.tc-head{display:flex;align-items:flex-start;gap:11px;margin-bottom:13px;}
+.tc-agent{width:34px;height:34px;border-radius:9px;display:grid;place-items:center;font-family:var(--mono);font-weight:700;font-size:11px;color:#fff;flex:none;}
+.tc-title{flex:1;min-width:0;}
+.tc-title h3{font-size:14px;margin:0;font-weight:600;}
+.tc-title code{font-family:var(--mono);font-size:11px;color:var(--sub);}
+.tc-meta{display:flex;align-items:center;gap:14px;font-size:11.5px;color:var(--sub);font-family:var(--mono);margin-bottom:13px;padding:10px 0;border-top:1px solid var(--line1);border-bottom:1px solid var(--line1);flex-wrap:wrap;}
+.tc-meta>span{white-space:nowrap;}
+.tc-meta b{color:var(--ink);}
+.tc-drift{display:inline-flex;align-items:center;gap:5px;color:var(--warn);margin-left:auto;}
+.tc-ok{display:inline-flex;align-items:center;gap:5px;color:var(--ok);margin-left:auto;}
+.tc-actions{display:flex;gap:7px;}
+.btn-ghost.xs[disabled]{opacity:.5;cursor:default;}
+/* bindings table */
+.bindings-table{border:1px solid var(--line1);border-radius:var(--r);overflow-x:auto;background:color-mix(in oklch,var(--panel) 92%,transparent);}
+.bt-head,.bt-row{display:grid;grid-template-columns:1.3fr 1.4fr 1.5fr 1.6fr auto auto;gap:14px;align-items:center;padding:11px 16px;min-width:720px;}
+.bt-head{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--faint);background:color-mix(in oklch,var(--panel) 60%,transparent);border-bottom:1px solid var(--line1);}
+.bt-row{border-bottom:1px solid var(--line1);font-size:12.5px;transition:var(--t);}
+.bt-row:last-child{border-bottom:none;}
+.bt-row:hover{background:var(--raise);}
+.bt-skill{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-weight:600;}
+.bt-agent{display:inline-flex;align-items:center;gap:7px;color:var(--sub);font-family:var(--mono);font-size:11.5px;}
+.bt-agent i{width:8px;height:8px;border-radius:50%;flex:none;}
+.bt-matcher{display:flex;flex-direction:column;gap:2px;font-family:var(--mono);font-size:11px;}
+.bt-matcher b{color:var(--acc3);font-weight:600;}
+.bt-matcher code{color:var(--faint);}
+.bt-target code{font-family:var(--mono);font-size:11px;color:var(--sub);}
+.bt-act .btn-icon:hover{color:var(--acc3);}
+/* profiles */
+.profiles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:14px;}
+.profile-card{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);border-radius:var(--r-lg);padding:16px 18px;}
+.pf-head{display:flex;align-items:center;gap:11px;margin-bottom:14px;}
+.pf-head h3{font-size:14px;margin:0;font-weight:600;flex:1;}
+.pf-count{font-family:var(--mono);font-size:10.5px;color:var(--faint);background:var(--raise);padding:2px 8px;border-radius:99px;white-space:nowrap;}
+.pf-list{display:flex;flex-direction:column;gap:8px;}
+.pf-row{display:flex;align-items:center;gap:12px;padding:10px 12px;border-radius:10px;border:1px solid var(--line1);background:var(--panel2);transition:var(--t);flex-wrap:wrap;}
+.pf-row.on{border-color:color-mix(in oklch,var(--ac) 45%,transparent);background:color-mix(in oklch,var(--ac) 8%,var(--panel));}
+.pf-pick{display:flex;align-items:center;gap:9px;border:none;background:none;cursor:pointer;color:var(--ink);padding:0;}
+.pf-radio{width:14px;height:14px;border-radius:50%;border:2px solid var(--line2);flex:none;transition:var(--t);}
+.pf-radio.on{border-color:var(--ac);background:radial-gradient(circle,var(--ac) 0 40%,transparent 50%);box-shadow:0 0 8px color-mix(in oklch,var(--ac) 60%,transparent);}
+.pf-name{font-family:var(--mono);font-size:13px;font-weight:600;}
+.pf-active{font-family:var(--mono);font-size:9px;color:#fff;background:var(--ac);padding:1px 7px;border-radius:6px;}
+.pf-meta{display:flex;gap:12px;margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--sub);}
+.pf-meta span{white-space:nowrap;}
+.pf-env{flex:1 1 100%;font-family:var(--mono);font-size:10.5px;color:var(--faint);background:var(--bg2);border:1px solid var(--line1);border-radius:7px;padding:5px 9px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.sync-hash{font-family:var(--mono);font-size:10.5px;color:var(--acc1);background:var(--raise);padding:0 5px;border-radius:5px;}
+
+/* ============ nav groups + counts ============ */
+.nav-group{display:flex;flex-direction:column;align-items:stretch;width:100%;}
+.nav-divider{height:1px;background:var(--line2);margin:8px 12px;}
+.nav-grouplabel{font-family:var(--mono);font-size:8.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);padding:2px 0 5px;text-align:center;opacity:.85;}
+.act{position:relative;}
+.act-count{position:absolute;top:5px;right:7px;min-width:15px;height:15px;padding:0 4px;border-radius:99px;background:var(--raise);border:1px solid var(--line2);color:var(--sub);font-family:var(--mono);font-size:9px;font-weight:600;display:flex;align-items:center;justify-content:center;line-height:1;}
+.act.on .act-count{border-color:transparent;background:color-mix(in oklch,var(--acc2) 30%,transparent);color:#fff;}
+.act-count.attn{background:var(--warn);border-color:transparent;color:#1a1208;}
+
+/* ============ doctor ============ */
+.doc-summary{display:flex;align-items:center;justify-content:space-between;gap:18px;background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line2);border-radius:var(--r-lg);padding:18px 22px;margin-bottom:18px;flex-wrap:wrap;}
+.doc-verdict{display:flex;align-items:center;gap:16px;}
+.dv-ring{--p:1;width:62px;height:62px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;
+  background:conic-gradient(var(--ok) calc(var(--p)*360deg),color-mix(in oklch,var(--warn) 55%,transparent) 0);position:relative;}
+.dv-ring::after{content:'';position:absolute;inset:6px;border-radius:50%;background:var(--panel);}
+.dv-ring span{position:relative;z-index:1;font-family:var(--mono);font-size:13px;font-weight:700;}
+.doc-verdict.warn .dv-ring{filter:none;}
+.dv-text{display:flex;flex-direction:column;gap:3px;}
+.dv-text strong{font-size:16px;}
+.dv-text span{color:var(--sub);font-size:12.5px;}
+.doc-leg{display:flex;gap:14px;align-items:center;font-size:11.5px;color:var(--sub);flex-wrap:wrap;}
+.dl{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);white-space:nowrap;}
+.dl i{width:8px;height:8px;border-radius:2px;background:var(--faint);}
+.dl.ok i{background:var(--ok);}.dl.bad i{background:var(--warn);}
+.doc-secs{display:grid;grid-template-columns:1fr 1fr;gap:13px;}
+.doc-sec{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);padding:14px 16px;}
+.doc-sec.warn{border-color:color-mix(in oklch,var(--warn) 32%,transparent);}
+.doc-sec.bad{border-color:color-mix(in oklch,var(--err) 36%,transparent);}
+.ds-head{display:flex;align-items:center;gap:9px;margin-bottom:11px;}
+.ds-head h3{font-size:13.5px;margin:0;font-weight:600;flex:1;}
+.ds-dot{width:8px;height:8px;border-radius:50%;background:var(--ok);flex:none;box-shadow:0 0 8px color-mix(in oklch,var(--ok) 60%,transparent);}
+.ds-dot.warn{background:var(--warn);box-shadow:0 0 8px color-mix(in oklch,var(--warn) 60%,transparent);}
+.ds-dot.bad{background:var(--err);}
+.ds-count{font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+.ds-checks{display:flex;flex-direction:column;gap:8px;}
+.ds-check{display:flex;gap:9px;align-items:flex-start;font-size:12.5px;}
+.ds-check.ok>svg{color:var(--ok);flex:none;margin-top:2px;}
+.ds-check.bad>svg{color:var(--warn);flex:none;margin-top:2px;}
+.dsc-body{display:flex;flex-direction:column;gap:7px;min-width:0;}
+.dsc-text{color:var(--sub);}
+.dsc-fix{display:flex;align-items:center;gap:8px;flex-wrap:wrap;background:var(--bg2);border:1px solid var(--line1);border-radius:9px;padding:7px 10px;}
+.dsc-fix>span{font-size:11.5px;color:var(--sub);flex:1;min-width:120px;}
+.dsc-code{font-family:var(--mono);font-size:10px;color:var(--warn);background:color-mix(in oklch,var(--warn) 12%,transparent);padding:1px 6px;border-radius:5px;white-space:nowrap;}
+.btn-ghost.xs{font-size:11px;padding:4px 9px;border-radius:7px;white-space:nowrap;}
+
+/* ============ settings ============ */
+.view-settings{max-width:760px;}
+.set-card{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r-lg);padding:6px 20px;margin-bottom:14px;}
+.set-cardhead{display:flex;align-items:baseline;justify-content:space-between;gap:10px;padding:14px 0 10px;border-bottom:1px solid var(--line1);}
+.set-cardhead h3{font-size:14px;margin:0;}
+.set-cardhead span{font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+.set-row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:15px 0;border-bottom:1px solid var(--line1);}
+.set-row:last-child{border-bottom:none;}
+.set-k h4{font-size:13.5px;margin:0 0 3px;font-weight:600;}
+.set-k p{font-size:12px;color:var(--sub);margin:0;}
+.set-v{font-family:var(--mono);font-size:12px;color:var(--acc3);background:var(--bg2);border:1px solid var(--line1);padding:5px 10px;border-radius:7px;white-space:nowrap;}
+.set-input{display:flex;gap:8px;align-items:center;}
+.set-input input{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--bg2);border:1px solid var(--line2);border-radius:8px;padding:7px 11px;width:300px;max-width:48vw;}
+.set-input input:focus{outline:none;border-color:var(--acc2);}
+.set-agents{display:flex;flex-wrap:wrap;gap:9px;padding:14px 0 16px;}
+.set-agent{display:inline-flex;align-items:center;gap:7px;font-size:12px;color:var(--sub);background:var(--bg2);border:1px solid var(--line1);border-radius:99px;padding:4px 11px 4px 4px;}
+.set-swatches{display:flex;gap:5px;}
+.set-swatches i{width:18px;height:18px;border-radius:5px;}
+@media(max-width:980px){
+  .doc-secs{grid-template-columns:1fr;}
+  .set-input input{width:200px;}
+}
+
+/* ============ add-skill modal ============ */
+.add-modal{width:min(520px,94vw);}
+.add-h3{display:flex;align-items:center;gap:9px;font-size:15px;margin:0;}
+.add-kind{display:flex;gap:8px;margin-bottom:14px;}
+.add-kind-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;gap:7px;padding:10px;border-radius:10px;border:1px solid var(--line2);background:var(--bg2);color:var(--sub);font-size:13px;font-weight:600;cursor:pointer;transition:var(--t);}
+.add-kind-btn.on{border-color:var(--acc2);color:var(--ink);background:color-mix(in oklch,var(--acc2) 12%,transparent);}
+.add-field{display:flex;flex-direction:column;gap:6px;margin-bottom:13px;}
+.add-field span{font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--faint);}
+.add-field input{font-family:var(--mono);font-size:13px;color:var(--ink);background:var(--bg2);border:1px solid var(--line2);border-radius:9px;padding:10px 12px;}
+.add-field input:focus{outline:none;border-color:var(--acc2);}
+.add-note{display:flex;gap:8px;align-items:flex-start;font-size:11.5px;color:var(--sub);background:var(--bg2);border:1px solid var(--line1);border-radius:9px;padding:9px 11px;margin-bottom:12px;}
+.add-note svg{color:var(--acc3);flex:none;margin-top:1px;}
+.add-cmd{font-family:var(--mono);font-size:11.5px;background:var(--bg);border:1px solid var(--line1);border-radius:9px;padding:10px 12px;margin-bottom:16px;overflow-x:auto;}
+.add-cmd code{color:var(--acc3);white-space:nowrap;}
+.add-foot{display:flex;justify-content:flex-end;gap:9px;}
+
+/* ============ Overview (honest) ============ */
+.ov-hero{display:flex;justify-content:space-between;gap:20px;background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line2);border-radius:var(--r-lg);padding:20px 24px;margin-bottom:14px;flex-wrap:wrap;position:relative;overflow:hidden;}
+.ov-hero::before{content:'';position:absolute;inset:0;background:radial-gradient(120% 140% at 100% 0%,color-mix(in oklch,var(--acc2) 14%,transparent),transparent 60%);pointer-events:none;}
+.ov-hero-main{display:flex;flex-direction:column;gap:10px;position:relative;z-index:1;min-width:0;}
+.ov-verdict{display:inline-flex;align-items:center;gap:8px;font-size:15px;font-weight:700;}
+.ov-vdot{width:9px;height:9px;border-radius:50%;}
+.ov-verdict.ok .ov-vdot{background:var(--ok);box-shadow:0 0 10px var(--ok);}
+.ov-verdict.bad{color:var(--warn);}.ov-verdict.bad .ov-vdot{background:var(--warn);box-shadow:0 0 10px var(--warn);}
+.ov-reg{display:flex;align-items:center;gap:9px;color:var(--sub);}
+.ov-reg code{font-family:var(--mono);font-size:14px;color:var(--acc3);}
+.ov-gitline{display:flex;align-items:center;gap:12px;font-size:12.5px;color:var(--sub);font-family:var(--mono);flex-wrap:wrap;}
+.ov-gitline b{color:var(--ink);font-weight:600;}
+.ov-sep{width:1px;height:12px;background:var(--line2);}
+.ov-hero-side{display:flex;flex-direction:column;gap:8px;position:relative;z-index:1;}
+.ov-chip{display:flex;align-items:center;justify-content:space-between;gap:14px;background:var(--bg2);border:1px solid var(--line1);border-radius:9px;padding:7px 12px;min-width:200px;}
+.ovc-k{font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--faint);}
+.ovc-v{font-family:var(--mono);font-size:12px;font-weight:600;}
+.ovc-v.ok{color:var(--ok);}.ovc-v.warn{color:var(--warn);}.ovc-v.acc3{color:var(--acc3);}.ovc-v.mono{color:var(--sub);}
+.ov-attn{display:flex;align-items:center;gap:11px;background:color-mix(in oklch,var(--warn) 9%,var(--panel));border:1px solid color-mix(in oklch,var(--warn) 32%,transparent);border-radius:var(--r);padding:12px 16px;margin-bottom:14px;flex-wrap:wrap;}
+.ov-attn>svg{color:var(--warn);flex:none;}
+.ov-attn>span{font-size:13px;color:var(--sub);}
+.ov-attn b{color:var(--ink);}.ov-attn em{color:var(--sub);font-style:normal;}
+.ov-attn-acts{display:flex;gap:7px;margin-left:auto;flex-wrap:wrap;}
+.fact-row{display:grid;grid-template-columns:repeat(4,1fr);gap:13px;margin-bottom:14px;}
+.fact-card{text-align:left;background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);padding:15px 17px;transition:var(--t);cursor:default;}
+.fact-card.link{cursor:pointer;}
+.fact-card.link:hover{border-color:var(--acc2);transform:translateY(-2px);box-shadow:0 10px 30px -16px var(--acc2);}
+.fact-card.warn{border-color:color-mix(in oklch,var(--warn) 30%,transparent);}
+.fact-top{display:flex;align-items:center;gap:8px;color:var(--sub);font-size:12px;font-family:var(--mono);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px;}
+.fact-top svg{color:var(--acc2);}
+.fact-val{font-size:34px;font-weight:700;line-height:1;letter-spacing:-.02em;margin-bottom:8px;}
+.fact-sub{font-size:11.5px;color:var(--faint);font-family:var(--mono);}
+.ov-grid{display:grid;grid-template-columns:1fr 1fr;gap:13px;}
+.ov-ops-panel{grid-column:1 / -1;}
+.ov-health{display:flex;flex-direction:column;gap:10px;margin-bottom:14px;}
+.ovh-row{display:flex;align-items:center;gap:12px;}
+.ovh-label{font-family:var(--mono);font-size:12px;width:64px;flex:none;}
+.ovh-track{flex:1;height:8px;border-radius:99px;background:var(--bg2);overflow:hidden;}
+.ovh-track i{display:block;height:100%;border-radius:99px;transition:width .5s cubic-bezier(.2,.8,.2,1);}
+.ovh-row b{font-family:var(--mono);font-size:13px;width:24px;text-align:right;}
+.ov-methods{display:flex;gap:18px;padding-top:13px;border-top:1px solid var(--line1);}
+.ovm{display:flex;align-items:center;gap:8px;}
+.ovm b{font-family:var(--mono);font-size:13px;}
+.ov-own{display:flex;flex-direction:column;gap:9px;margin-bottom:13px;}
+.ovo-row{display:flex;align-items:center;gap:12px;}
+.ovo-badge{font-family:var(--mono);font-size:11px;font-weight:600;color:var(--oc);background:color-mix(in oklch,var(--oc) 14%,transparent);padding:3px 10px;border-radius:7px;width:96px;text-align:center;flex:none;}
+.ovo-hint{font-size:12px;color:var(--sub);flex:1;}
+.ovo-n{font-family:var(--mono);font-size:16px;font-weight:700;}
+.ov-own-note{display:flex;align-items:center;gap:7px;font-size:11px;color:var(--faint);padding-top:12px;border-top:1px solid var(--line1);}
+.ov-own-note svg{color:var(--acc3);flex:none;}
+.ov-ops{display:flex;flex-direction:column;gap:2px;}
+.ovop-row{display:grid;grid-template-columns:auto 90px 1fr auto;gap:12px;align-items:center;padding:8px 4px;border-bottom:1px solid var(--line1);font-size:12.5px;}
+.ovop-row:last-child{border-bottom:none;}
+.ovop-dot{width:8px;height:8px;border-radius:50%;}
+.ovop-verb{font-family:var(--mono);font-size:11.5px;font-weight:700;color:var(--acc2);}
+.ovop-skill{font-family:var(--mono);color:var(--sub);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.ovop-t{font-family:var(--mono);font-size:11px;color:var(--faint);}
+.ov-ops-foot{display:flex;justify-content:space-between;gap:14px;padding-top:12px;margin-top:8px;border-top:1px solid var(--line1);font-family:var(--mono);font-size:11.5px;color:var(--sub);}
+.ov-ops-foot b{color:var(--ink);}.ov-ops-foot b.bad{color:var(--err);}
+.ov-usage-panel{grid-column:1 / -1;}
+.ov-usage{display:grid;grid-template-columns:1.5fr 1fr;gap:22px;align-items:start;}
+.hm-leg{display:inline-flex;align-items:center;gap:4px;font-family:var(--mono);font-size:10px;color:var(--faint);}
+.hm-leg i{width:11px;height:11px;border-radius:3px;display:inline-block;}
+.ov-topskills{display:flex;flex-direction:column;gap:6px;}
+.ovts-head{font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--faint);margin-bottom:6px;}
+.ovts-row{display:grid;grid-template-columns:auto 1fr 70px auto;gap:10px;align-items:center;background:none;border:none;cursor:pointer;padding:5px 6px;border-radius:8px;transition:var(--t);text-align:left;}
+.ovts-row:hover{background:var(--raise);}
+.ovts-rank{font-family:var(--mono);font-size:11px;color:var(--faint);width:14px;}
+.ovts-name{font-family:var(--mono);font-size:12.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.ovts-bar{height:6px;border-radius:99px;background:var(--bg2);overflow:hidden;}
+.ovts-bar i{display:block;height:100%;border-radius:99px;}
+.ovts-n{font-family:var(--mono);font-size:11.5px;color:var(--sub);text-align:right;}
+@media(max-width:980px){
+  .ov-usage{grid-template-columns:1fr;}
+  .ov-topskills{border-left:none;padding-left:0;border-top:1px solid var(--line1);padding-top:16px;}
+}
+@media(max-width:980px){
+  .fact-row{grid-template-columns:repeat(2,1fr);}
+  .ov-grid{grid-template-columns:1fr;}
+  .ov-ops-panel{grid-column:auto;}
+}
+
+/* ============ recycle bin / local management ============ */
+.lib-head-right{display:flex;align-items:center;gap:10px;}
+.trash-toggle{position:relative;display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line2);background:var(--panel);color:var(--sub);padding:9px 12px;border-radius:11px;cursor:pointer;transition:var(--t);}
+.trash-toggle:hover{color:var(--ink);border-color:var(--faint);}
+.trash-toggle.on{color:#fff;background:var(--grad);border-color:transparent;box-shadow:var(--glow-shadow);}
+.tt-n{font-family:var(--mono);font-size:10px;font-weight:700;background:var(--err);color:#fff;border-radius:99px;padding:0 6px;min-width:16px;text-align:center;}
+.trash-toggle.on .tt-n{background:rgba(255,255,255,.25);}
+.card-del{position:absolute;top:14px;right:14px;border:none;background:var(--raise);color:var(--faint);width:28px;height:28px;border-radius:8px;display:grid;place-items:center;cursor:pointer;opacity:0;transition:var(--t);}
+.skill-card{position:relative;}
+.skill-card:hover .card-del{opacity:1;}
+.card-del:hover{background:color-mix(in oklch,var(--err) 15%,transparent);color:var(--err);}
+.trash-bar{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:16px;padding:11px 15px;border-radius:var(--r);background:color-mix(in oklch,var(--err) 6%,var(--panel));border:1px solid color-mix(in oklch,var(--err) 25%,transparent);flex-wrap:wrap;}
+.trash-note{display:inline-flex;align-items:center;gap:8px;font-size:12.5px;color:var(--sub);}
+.trash-note svg{color:var(--err);}
+.trash-card{opacity:.92;}
+.trash-card .sc-desc{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
+.trash-ref{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11px;color:var(--faint);margin-bottom:13px;padding:8px 0;border-top:1px solid var(--line1);border-bottom:1px solid var(--line1);}
+.trash-ref svg{color:var(--acc2);}
+.trash-ref code{color:var(--acc1);background:var(--raise);padding:1px 7px;border-radius:5px;}
+.trash-actions{display:flex;gap:8px;}
+.trash-actions .btn-grad,.trash-actions .btn-ghost{flex:1;justify-content:center;}
+/* lifecycle verbs */
+.lifecycle-verbs{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;}
+.lc-verb{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--line2);background:var(--panel2);color:var(--sub);font-family:var(--mono);font-size:11px;font-weight:600;padding:5px 9px;border-radius:8px;cursor:pointer;transition:var(--t);}
+.lc-verb svg{color:var(--acc2);}
+.lc-verb:hover{color:var(--ink);border-color:var(--acc2);background:color-mix(in oklch,var(--acc2) 10%,transparent);transform:translateY(-1px);}
+.lc-rollback svg{color:var(--warn);}
+.lc-rollback:hover{border-color:var(--warn);background:color-mix(in oklch,var(--warn) 10%,transparent);}
+.lc-release svg{color:var(--acc1);}
+.lc-note{font-family:var(--mono);font-size:10.5px;color:var(--faint);}
+
+/* ============ ops & audit ============ */
+.hl-code{font-family:var(--mono);font-size:12px;color:var(--acc3);background:var(--bg2);border:1px solid var(--line1);padding:1px 7px;border-radius:6px;}
+.ops-head-actions{display:flex;gap:8px;}
+.ops-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:18px;}
+@media(max-width:980px){.ops-stats{grid-template-columns:repeat(2,1fr);}}
+.diag-card{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line2);border-radius:var(--r);padding:14px 16px;margin-bottom:16px;}
+.diag-head{display:flex;align-items:center;gap:9px;font-size:13.5px;font-weight:600;margin-bottom:12px;}
+.diag-head svg{color:var(--acc1);}
+.diag-head code{font-family:var(--mono);font-size:11.5px;color:var(--sub);font-weight:400;}
+.diag-fix{margin-left:auto;white-space:nowrap;}
+.diag-checks{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+.diag-check{display:flex;align-items:center;gap:9px;padding:9px 11px;border-radius:9px;background:var(--bg2);border:1px solid var(--line1);font-size:12.5px;}
+.diag-check.ok svg{color:var(--ok);flex:none;}
+.diag-check.bad{border-color:color-mix(in oklch,var(--warn) 35%,transparent);}
+.diag-check.bad svg{color:var(--warn);flex:none;}
+.dc-label{font-weight:600;flex:none;}
+.dc-note{color:var(--sub);font-size:11.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.ops-table{border:1px solid var(--line1);border-radius:var(--r);overflow:hidden;background:color-mix(in oklch,var(--panel) 92%,transparent);}
+.op-row{display:grid;grid-template-columns:auto 86px auto 1.6fr 1.5fr auto;gap:13px;align-items:center;padding:11px 16px;border-bottom:1px solid var(--line1);font-size:12.5px;transition:var(--t);}
+.op-row:last-child{border-bottom:none;}
+.op-row:hover{background:var(--raise);}
+.op-row-failed{background:color-mix(in oklch,var(--err) 5%,transparent);}
+.op-row-drift{background:color-mix(in oklch,var(--warn) 5%,transparent);}
+.op-pill{display:inline-flex;align-items:center;gap:5px;justify-self:start;font-family:var(--mono);font-size:10px;font-weight:600;color:var(--oc);background:color-mix(in oklch,var(--oc) 14%,transparent);padding:3px 8px;border-radius:7px;white-space:nowrap;}
+.op-time{font-family:var(--mono);font-size:11px;color:var(--faint);white-space:nowrap;}
+.op-verb{font-family:var(--mono);font-size:11.5px;font-weight:700;color:var(--acc2);white-space:nowrap;justify-self:start;}
+.op-detail{display:flex;align-items:center;gap:8px;min-width:0;font-family:var(--mono);font-size:12px;flex-wrap:wrap;}
+.op-detail b{font-weight:600;white-space:nowrap;}
+.op-arrow{color:var(--faint);font-size:11px;white-space:nowrap;}
+.op-rev{color:var(--acc1);font-size:11px;}
+.op-arrow code{color:var(--sub);}
+.op-note{font-size:11px;color:var(--sub);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.op-act{display:flex;justify-content:flex-end;gap:6px;}
+.ops-empty{display:flex;flex-direction:column;align-items:center;gap:12px;padding:48px 0;color:var(--faint);text-align:center;}
+.ops-empty svg{color:var(--ok);}
+@media(max-width:980px){
+  .op-row{display:flex;flex-wrap:wrap;align-items:center;gap:8px 10px;}
+  .op-row .op-note{display:none;}
+  .op-detail{flex:1 1 100%;order:5;}
+  .op-act{margin-left:auto;}
+  .diag-checks{grid-template-columns:1fr;}
+}
+
+@media(max-width:980px){
+  .bt-head{display:none;}
+  .bt-row{grid-template-columns:1fr 1fr;gap:8px;}
+}
+
+/* ============ Loom production adapters ============ */
+.nav-group{display:flex;flex-direction:column;align-items:center;gap:4px;}
+.nav-grouplabel{display:block;margin:4px 0 2px;font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:.14em;color:var(--faint);}
+.searchbox input{min-width:0;flex:1;border:0;outline:0;background:transparent;color:var(--ink);}
+.skill-card.sel{border-color:color-mix(in oklch,var(--acc2) 55%,transparent);box-shadow:var(--glow-shadow);}
+.sc-tags{display:flex;flex-wrap:wrap;gap:6px;margin:12px 0;}
+.sc-foot{display:flex;align-items:center;justify-content:space-between;gap:10px;padding-top:12px;border-top:1px solid var(--line1);font-family:var(--mono);font-size:11px;color:var(--faint);}
+.skill-detail{margin-top:18px;}
+.det-stats{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin-top:18px;}
+.det-stats .stat-card{width:100%;}
+.sec-badge{display:inline-flex;align-items:center;gap:6px;border-radius:99px;padding:7px 10px;font-family:var(--mono);font-size:11px;font-weight:700;border:1px solid var(--line2);color:var(--sub);}
+.sec-badge.good{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 35%,transparent);background:color-mix(in oklch,var(--ok) 10%,transparent);}
+.skillm-table{overflow:auto;}
+.skillm-table table{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:12px;}
+.skillm-table th{text-align:left;color:var(--faint);font-size:10px;text-transform:uppercase;letter-spacing:.1em;padding:10px 12px;border-bottom:1px solid var(--line1);}
+.skillm-table td{padding:11px 12px;border-bottom:1px solid var(--line1);color:var(--sub);vertical-align:top;}
+.skillm-table tr:hover td{background:var(--raise);color:var(--ink);}
+.skillm-mini-graph{min-height:260px;}
+.skillm-graph-grid{display:grid;grid-template-columns:240px 1fr 280px;gap:12px;align-items:start;}
+.pg-node-row{height:29px;display:flex;align-items:center;gap:9px;margin-bottom:6px;padding:4px 8px;border:1px solid var(--line1);border-radius:9px;background:var(--raise);font-family:var(--mono);font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.pg-node-row .sm-glyph{width:24px;height:24px;border-radius:7px;font-size:10px;}
+.pg-node-row.target{height:34px;}
+.proj-svg{width:100%;height:260px;overflow:visible;}
+.proj-edge{fill:none;stroke-width:1.5;opacity:.5;}
+.op-table{border:1px solid var(--line1);border-radius:var(--r);overflow:hidden;background:color-mix(in oklch,var(--panel) 92%,transparent);}
+.op-done,.op-ok{--oc:var(--ok);}
+.op-pending{--oc:var(--warn);}
+.op-failed{--oc:var(--err);}
+.op-err{--oc:var(--err);}
+.view-sync .sync-grid{display:grid;grid-template-columns:1.2fr .8fr;gap:14px;}
+.set-card{display:flex;flex-direction:column;gap:0;}
+.set-row{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:16px 0;border-bottom:1px solid var(--line1);}
+.set-row:last-child{border-bottom:none;}
+.set-k h4{margin:0 0 4px;font-size:14px;}
+.set-k p{margin:0;color:var(--sub);font-size:12px;}
+.set-v{font-family:var(--mono);font-size:12px;color:var(--acc3);}
+.doc-summary{display:grid;grid-template-columns:minmax(0,1fr);gap:14px;}
+.doc-verdict{display:flex;align-items:center;gap:18px;padding:22px;border:1px solid var(--line1);border-radius:var(--r-lg);background:var(--panel);}
+.doc-verdict.ok{border-color:color-mix(in oklch,var(--ok) 35%,transparent);}
+.doc-verdict.warn{border-color:color-mix(in oklch,var(--warn) 35%,transparent);}
+.dv-ring{width:56px;height:56px;border-radius:50%;border:5px solid var(--acc2);box-shadow:var(--glow-shadow);}
+.dv-text{display:flex;flex-direction:column;gap:4px;}
+.dv-text b{font-size:20px;}
+.dv-text span{color:var(--sub);}
+.skillm-grid-bg::before{content:"";position:absolute;inset:0;background-image:linear-gradient(color-mix(in oklch,var(--line2) 35%,transparent) 1px,transparent 1px),linear-gradient(90deg,color-mix(in oklch,var(--line2) 35%,transparent) 1px,transparent 1px);background-size:42px 42px;opacity:.18;}
+.skillm-grid-bg::after{content:"";position:absolute;inset:0;background:radial-gradient(circle at 20% 70%,color-mix(in oklch,var(--acc1) 12%,transparent),transparent 24%),radial-gradient(circle at 78% 20%,color-mix(in oklch,var(--acc3) 10%,transparent),transparent 26%);}
+.cmd-pal{width:min(680px,94vw);max-height:82vh;overflow:hidden;background:var(--panel);border:1px solid var(--line2);border-radius:18px;box-shadow:0 30px 80px -20px rgba(0,0,0,.65),var(--glow-shadow);animation:palIn .22s cubic-bezier(.2,.8,.2,1);}
+.cmd-search{height:56px;display:flex;align-items:center;gap:12px;padding:0 16px;border-bottom:1px solid var(--line1);font-family:var(--mono);color:var(--sub);}
+.cmd-search span{flex:1;}
+.cmd-list{max-height:calc(82vh - 56px);overflow:auto;padding:10px;}
+.cmd-item{width:100%;display:grid;grid-template-columns:22px minmax(0,1fr) auto;gap:11px;align-items:center;padding:11px 12px;border-radius:10px;color:var(--ink);font-size:13px;text-align:left;}
+.cmd-item:hover{background:var(--raise);}
+.cmd-item span{font-family:var(--mono);font-size:10px;color:var(--faint);}
+.skillm-tweaks{
+  position:fixed;right:16px;top:76px;z-index:62;width:320px;max-width:calc(100vw - 28px);
+  max-height:calc(100vh - 118px);overflow:auto;background:color-mix(in oklch,var(--panel) 96%,transparent);
+  border:1px solid var(--line2);border-radius:16px;box-shadow:0 24px 70px -24px rgba(0,0,0,.72),var(--glow-shadow);
+  backdrop-filter:blur(16px);font-family:var(--sans);color:var(--ink);
+}
+.skillm-tweaks .twk-hd{
+  height:42px;display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:0 12px 0 14px;border-bottom:1px solid var(--line1);
+}
+.skillm-tweaks .twk-hd b{font-size:14px;line-height:1;font-weight:700;}
+.skillm-tweaks .twk-x{
+  width:26px;height:26px;display:grid;place-items:center;border-radius:8px;border:1px solid var(--line2);
+  background:var(--raise);color:var(--sub);font-size:17px;line-height:1;cursor:pointer;
+}
+.skillm-tweaks .twk-x:hover{color:var(--ink);border-color:var(--acc2);}
+.skillm-tweaks .twk-body{display:flex;flex-direction:column;gap:12px;padding:12px 14px 14px;}
+.skillm-tweaks .twk-sect{
+  margin:2px 0 -4px;font-family:var(--mono);font-size:10px;font-weight:700;line-height:1.2;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--faint);
+}
+.skillm-tweaks .twk-row{display:flex;flex-direction:column;gap:8px;min-width:0;}
+.skillm-tweaks .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;}
+.skillm-tweaks .twk-lbl{display:flex;align-items:center;justify-content:space-between;gap:8px;min-width:0;}
+.skillm-tweaks .twk-lbl span{font-size:12px;line-height:1.3;font-weight:600;color:var(--sub);}
+.skillm-tweaks .twk-chips{display:flex;gap:8px;flex-wrap:wrap;}
+.skillm-tweaks .twk-chip{
+  display:flex!important;overflow:hidden;width:74px!important;height:38px!important;border-radius:10px!important;
+  border:1px solid var(--line2)!important;padding:0!important;background:var(--raise)!important;cursor:pointer;
+}
+.skillm-tweaks .twk-chip[data-on="1"]{outline:2px solid var(--acc3);outline-offset:2px;box-shadow:var(--glow-shadow);}
+.skillm-tweaks .twk-chip i{display:block;flex:1;min-width:0;}
+.skillm-tweaks .sm-switch{transform:scale(.86);transform-origin:right center;}
+.skillm-tweaks .twk-radio{display:flex;gap:4px;padding:4px;background:var(--raise);border:1px solid var(--line1);border-radius:11px;}
+.skillm-tweaks .twk-radio button{
+  flex:1;padding:7px 9px;border-radius:8px;color:var(--sub);font-size:12px;line-height:1.1;font-weight:700;cursor:pointer;
+}
+.skillm-tweaks .twk-radio button[data-on="1"]{background:var(--panel);color:var(--ink);box-shadow:var(--card-shadow);}
+.sm-toast{display:flex;align-items:center;gap:9px;border:1px solid var(--line2);background:var(--panel);color:var(--ink);border-radius:12px;padding:11px 13px;box-shadow:var(--card-shadow);}
+.sm-toast.ok svg{color:var(--ok);}
+.sm-toast.err svg{color:var(--err);}
+.sm-toast.sync svg{color:var(--acc3);}
+.term-head{height:48px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;border-bottom:1px solid var(--line1);font-family:var(--mono);color:var(--sub);}
+.term-head span{display:flex;align-items:center;gap:8px;}
+.term-body{flex:1;overflow:auto;padding:18px 22px;font-family:var(--mono);font-size:13px;color:var(--sub);}
+.term-body b{color:var(--acc1);}
+.term-input{height:46px;display:flex;align-items:center;gap:10px;padding:0 22px;border-top:1px solid var(--line1);font-family:var(--mono);color:var(--faint);}
+.term-input span:first-child{color:var(--acc1);font-size:24px;font-weight:700;}
+
+@media(max-width:980px){
+  .skillm-graph-grid{grid-template-columns:1fr;}
+  .proj-svg{display:none;}
+  .det-stats,.view-sync .sync-grid{grid-template-columns:1fr;}
+  .skillm-tweaks{top:auto;bottom:42px;right:10px;}
+}

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -1275,6 +1275,17 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .term-body b{color:var(--acc1);}
 .term-input{height:46px;display:flex;align-items:center;gap:10px;padding:0 22px;border-top:1px solid var(--line1);font-family:var(--mono);color:var(--faint);}
 .term-input span:first-child{color:var(--acc1);font-size:24px;font-weight:700;}
+.disabled{opacity:.48;cursor:not-allowed!important;}
+.disabled,.disabled *{pointer-events:none!important;}
+.mk-card.disabled{filter:saturate(.75);}
+.view-forge .forge-foot{margin-top:18px;}
+.view-settings .twk-chips{display:flex;gap:7px;flex-wrap:wrap;}
+.view-settings .twk-chip{display:flex;overflow:hidden;width:70px;height:34px;border:1px solid var(--line2);border-radius:9px;background:var(--raise);padding:0;cursor:pointer;}
+.view-settings .twk-chip[data-on="1"]{outline:2px solid var(--acc3);outline-offset:2px;box-shadow:var(--glow-shadow);}
+.view-settings .twk-chip i{display:block;flex:1;min-width:0;}
+.view-settings .twk-radio{display:flex;gap:4px;padding:4px;background:var(--raise);border:1px solid var(--line1);border-radius:11px;}
+.view-settings .twk-radio button{padding:7px 11px;border-radius:8px;border:0;background:transparent;color:var(--sub);font-weight:700;cursor:pointer;}
+.view-settings .twk-radio button[data-on="1"]{background:var(--panel);color:var(--ink);box-shadow:var(--card-shadow);}
 
 @media(max-width:980px){
   .skillm-graph-grid{grid-template-columns:1fr;}

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -939,6 +939,33 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .act-count.attn{background:var(--warn);border-color:transparent;color:#1a1208;}
 
 /* ============ doctor ============ */
+.view-doctor .page-header{display:flex;align-items:flex-end;justify-content:space-between;gap:20px;margin-bottom:18px;flex-wrap:wrap;}
+.view-doctor .title-block h1{font-size:30px;letter-spacing:-.02em;margin:0;font-weight:700;}
+.view-doctor .subtitle{margin-top:5px;color:var(--sub);font-size:14px;}
+.view-doctor .header-actions{display:flex;gap:8px;}
+.view-doctor .btn{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line2);background:transparent;color:var(--ink);font-family:var(--sans);font-weight:600;font-size:13px;padding:8px 14px;border-radius:9px;cursor:pointer;transition:var(--t);}
+.view-doctor .btn:hover{border-color:var(--acc2);background:var(--raise);}
+.view-doctor .btn:disabled{opacity:.5;cursor:default;}
+.view-doctor .page-body{display:block;}
+.view-doctor .empty{color:var(--faint);font-size:13px;text-align:center;padding:28px 0;border:1px solid var(--line1);border-radius:var(--r);background:var(--panel);}
+.view-doctor .kpi{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);padding:14px 16px;min-width:0;}
+.view-doctor .kpi .label{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.08em;color:var(--faint);margin-bottom:8px;}
+.view-doctor .kpi .value{font-family:var(--mono);font-size:18px;font-weight:700;color:var(--ink);overflow-wrap:anywhere;}
+.view-doctor .card{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);overflow:hidden;}
+.view-doctor .card-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:13px 16px;border-bottom:1px solid var(--line1);}
+.view-doctor .card-head h3{margin:0;font-size:14px;text-transform:capitalize;}
+.view-doctor .card-body{padding:0;}
+.view-doctor .tbl{width:100%;border-collapse:collapse;font-size:12.5px;}
+.view-doctor .tbl td{padding:11px 14px;border-bottom:1px solid var(--line1);vertical-align:top;color:var(--sub);}
+.view-doctor .tbl tr:last-child td{border-bottom:none;}
+.view-doctor .row-flex{display:flex;align-items:flex-start;gap:8px;min-width:0;}
+.view-doctor .doctor-check-label svg{color:var(--acc3);flex:none;margin-top:2px;}
+.view-doctor .doctor-check-name{display:block;color:var(--ink);font-weight:600;}
+.view-doctor .doctor-check-id,.view-doctor .mono.dim{display:block;color:var(--faint);font-size:10.5px;overflow-wrap:anywhere;}
+.view-doctor .mono{font-family:var(--mono);}
+.view-doctor .chip{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line2);background:var(--bg2);color:var(--sub);font-family:var(--mono);font-size:10.5px;padding:4px 8px;border-radius:99px;white-space:nowrap;}
+.view-doctor .chip.ok{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 40%,transparent);}
+.view-doctor .chip.warn,.view-doctor .chip.danger{color:var(--warn);border-color:color-mix(in oklch,var(--warn) 45%,transparent);}
 .doc-summary{display:flex;align-items:center;justify-content:space-between;gap:18px;background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line2);border-radius:var(--r-lg);padding:18px 22px;margin-bottom:18px;flex-wrap:wrap;}
 .doc-verdict{display:flex;align-items:center;gap:16px;}
 .dv-ring{--p:1;width:62px;height:62px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -1078,13 +1078,14 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .hm-leg i{width:11px;height:11px;border-radius:3px;display:inline-block;}
 .ov-topskills{display:flex;flex-direction:column;gap:6px;}
 .ovts-head{font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--faint);margin-bottom:6px;}
-.ovts-row{display:grid;grid-template-columns:auto 1fr 70px auto;gap:10px;align-items:center;background:none;border:none;cursor:pointer;padding:5px 6px;border-radius:8px;transition:var(--t);text-align:left;}
+.ovts-note{font-size:11px;color:var(--faint);line-height:1.4;padding:0 6px 4px;}
+.ovts-row{display:grid;grid-template-columns:auto minmax(0,1fr) minmax(70px,.36fr) auto;gap:10px;align-items:center;background:none;border:none;cursor:pointer;padding:5px 6px;border-radius:8px;transition:var(--t);text-align:left;}
 .ovts-row:hover{background:var(--raise);}
 .ovts-rank{font-family:var(--mono);font-size:11px;color:var(--faint);width:14px;}
 .ovts-name{font-family:var(--mono);font-size:12.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .ovts-bar{height:6px;border-radius:99px;background:var(--bg2);overflow:hidden;}
 .ovts-bar i{display:block;height:100%;border-radius:99px;}
-.ovts-n{font-family:var(--mono);font-size:11.5px;color:var(--sub);text-align:right;}
+.ovts-n{font-family:var(--mono);font-size:11.5px;color:var(--sub);text-align:right;white-space:nowrap;}
 @media(max-width:980px){
   .ov-usage{grid-template-columns:1fr;}
   .ov-topskills{border-left:none;padding-left:0;border-top:1px solid var(--line1);padding-top:16px;}

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -966,6 +966,25 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .view-doctor .chip{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line2);background:var(--bg2);color:var(--sub);font-family:var(--mono);font-size:10.5px;padding:4px 8px;border-radius:99px;white-space:nowrap;}
 .view-doctor .chip.ok{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 40%,transparent);}
 .view-doctor .chip.warn,.view-doctor .chip.danger{color:var(--warn);border-color:color-mix(in oklch,var(--warn) 45%,transparent);}
+
+/* ============ first-run ============ */
+.view-first-run .page-header{display:flex;align-items:flex-end;justify-content:space-between;gap:20px;margin-bottom:18px;flex-wrap:wrap;}
+.view-first-run .title-block h1{font-size:30px;letter-spacing:0;margin:0;font-weight:700;}
+.view-first-run .subtitle{margin-top:5px;color:var(--sub);font-size:14px;}
+.view-first-run .page-body{display:block;}
+.view-first-run .card{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r-lg);overflow:hidden;}
+.view-first-run .card-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line1);}
+.view-first-run .card-head h3{margin:0;font-size:15px;}
+.view-first-run .card-body{padding:18px;}
+.view-first-run .kpi-row{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;}
+.view-first-run .kpi{background:var(--bg2);border:1px solid var(--line1);border-radius:var(--r);padding:13px 14px;min-width:0;}
+.view-first-run .kpi .label{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:0;color:var(--faint);margin-bottom:7px;}
+.view-first-run .kpi .value{font-family:var(--mono);font-size:14px;font-weight:700;color:var(--ink);overflow-wrap:anywhere;}
+.view-first-run label{color:var(--sub);font-size:13px;}
+.view-first-run input[type="checkbox"]{accent-color:var(--acc2);}
+.view-first-run .btn{display:inline-flex;align-items:center;gap:8px;border:none;cursor:pointer;font-family:var(--sans);font-weight:600;font-size:14px;color:#fff;background:var(--grad);padding:10px 18px;border-radius:10px;box-shadow:var(--glow-shadow);transition:var(--t);}
+.view-first-run .btn:hover{transform:translateY(-1px);}
+.view-first-run .btn:disabled{opacity:.6;cursor:default;transform:none;}
 .doc-summary{display:flex;align-items:center;justify-content:space-between;gap:18px;background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line2);border-radius:var(--r-lg);padding:18px 22px;margin-bottom:18px;flex-wrap:wrap;}
 .doc-verdict{display:flex;align-items:center;gap:16px;}
 .dv-ring{--p:1;width:62px;height:62px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;
@@ -1319,5 +1338,6 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
   .skillm-graph-grid{grid-template-columns:1fr;}
   .proj-svg{display:none;}
   .det-stats,.view-sync .sync-grid{grid-template-columns:1fr;}
+  .view-first-run .kpi-row{grid-template-columns:1fr;}
   .skillm-tweaks{top:auto;bottom:42px;right:10px;}
 }

--- a/panel/vite.config.ts
+++ b/panel/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
       "/api": {
         target: "http://127.0.0.1:43117",
         changeOrigin: true,
+        configure(proxy) {
+          proxy.on("proxyReq", (proxyReq) => {
+            proxyReq.setHeader("Origin", "http://127.0.0.1:43117");
+            proxyReq.setHeader("Referer", "http://127.0.0.1:43117/");
+          });
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- Replace the active Panel entrypoint with a SkillM-inspired control room UI based on the provided reference archive.
- Keep production data wired to the existing live `/api/v1/*` Panel APIs rather than shipping the reference `SM_*` mock data.
- Fix Vite dev proxy headers so localhost `5173` can call the secured Panel backend on `43117` without 403 failures.

## Why
The earlier SkillM refactor merged a "SkillM-style" shell, but it did not use the supplied UI as the visual source of truth. This PR makes the visible Panel match that direction more directly while preserving Loom's real-data and fail-visible constraints.

## Validation
- `cd panel && bun run typecheck`
- `cd panel && bun run build`
- `cd panel && bun run test` (18 files, 122 tests)
- Live local smoke: `GET /api/v1/health`, `GET /api/v1/workspace/info`, and `GET /api/v1/skills` through `http://127.0.0.1:5173` all return 200 after proxy header rewrite.
- Headless Chrome screenshot confirmed live data renders: 198 skills, 2 targets, 11 queued writes.

## Notes
- The reference marketplace/forge surfaces remain explicitly unavailable because Loom V1 has no real backend contract for them.
- Current registry has observed inventory but no projection records, so `0 live edges` is a real backend state rather than fabricated UI data.
