### PR TITLE
[codex] Make panel operation rows scannable

### DIFF
--- a/panel/src/lib/api/adapters.test.ts
+++ b/panel/src/lib/api/adapters.test.ts
@@ -21,6 +21,9 @@ describe("adaptRegistryOperation", () => {
 
   it("keeps queued rows pending and failed rows errored", () => {
     expect(adaptRegistryOperation(operation({ status: "pending" })).status).toBe("pending");
+    expect(adaptRegistryOperation(operation({ status: "enqueued" })).status).toBe("pending");
+    expect(adaptRegistryOperation(operation({ status: "in_flight" })).status).toBe("pending");
+    expect(adaptRegistryOperation(operation({ status: "retrying" })).status).toBe("pending");
     expect(
       adaptRegistryOperation(
         operation({ status: "succeeded", last_error: { code: "IO_ERROR", message: "failed" } }),

--- a/panel/src/lib/api/adapters.ts
+++ b/panel/src/lib/api/adapters.ts
@@ -4,6 +4,7 @@ import type { RegistryRule } from "../../generated/RegistryRule";
 import type { RegistryTarget } from "../../generated/RegistryTarget";
 import type { PendingOp } from "../../types";
 import { normalizeAgentSlug } from "../agent_options";
+import { bucketRegistryOperation } from "../operation_labels";
 import type { AgentSlug, Binding, Op, Ownership, ProjectionMethod, Skill, Target } from "../types";
 import type { RegistryOperationRecord, SkillSummaryPayload } from "./client";
 
@@ -230,10 +231,7 @@ export function adaptRegistryOperation(op: RegistryOperationRecord): Op {
 }
 
 function operationStatus(op: RegistryOperationRecord): Op["status"] {
-  const status = op.status.toLowerCase();
-  if (op.last_error || status === "failed" || status === "error") return "err";
-  if (status === "pending" || status === "queued") return "pending";
-  return "ok";
+  return bucketRegistryOperation(op);
 }
 
 export function adaptProjectionOp(p: RegistryProjection, index: AdapterIndex): Op {

--- a/panel/src/lib/api/usePanelData.test.ts
+++ b/panel/src/lib/api/usePanelData.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { dedupePanelOps } from "./usePanelData";
+import type { Op } from "../types";
+
+function op(overrides: Partial<Op>): Op {
+  return {
+    id: "op-1",
+    status: "pending",
+    kind: "sync.push",
+    skill: "",
+    target: "registry",
+    method: "copy",
+    time: "now",
+    ...overrides,
+  };
+}
+
+describe("dedupePanelOps", () => {
+  it("keeps pending queue rows first and removes matching activity rows", () => {
+    const pending = op({ id: "request-1", status: "pending" });
+    const activity = op({ id: "request-1", status: "ok" });
+    const other = op({ id: "request-2", kind: "skill.save" });
+
+    expect(dedupePanelOps([pending], [activity, other])).toEqual([pending, other]);
+  });
+
+  it("dedupes id-less rows by their visible operation identity", () => {
+    const first = op({ id: "", kind: "skill.save", skill: "docs", target: "codex", time: "10:00" });
+    const duplicate = op({ id: "", kind: "skill.save", skill: "docs", target: "codex", time: "10:00" });
+    const changed = op({ id: "", kind: "skill.save", skill: "docs", target: "claude", time: "10:00" });
+
+    expect(dedupePanelOps([first], [duplicate, changed])).toEqual([first, changed]);
+  });
+});

--- a/panel/src/lib/api/usePanelData.ts
+++ b/panel/src/lib/api/usePanelData.ts
@@ -100,6 +100,18 @@ function uniqueWarnings(warnings: string[]): string[] {
   return Array.from(new Set(warnings));
 }
 
+export function dedupePanelOps(pendingOps: Op[], activityOps: Op[]): Op[] {
+  const seen = new Set<string>();
+  const merged: Op[] = [];
+  for (const op of [...pendingOps, ...activityOps]) {
+    const key = op.id || `${op.kind}|${op.skill}|${op.target}|${op.time}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(op);
+  }
+  return merged;
+}
+
 export function usePanelData(): PanelLiveData {
   const [state, setState] = useState<LiveState>(INITIAL_STATE);
 
@@ -202,9 +214,9 @@ export function usePanelData(): PanelLiveData {
       const targets = registryTargets.map((t) => adaptTarget(t, index, observedSkillCounts));
       const bindings = registryBindings.map((b) => adaptBinding(b, rules));
 
-      const pendingOps: Op[] = (pending.data.ops ?? []).map(adaptPendingOp);
+      const pendingOps: Op[] = dedupePanelOps((pending.data.ops ?? []).map(adaptPendingOp), []);
       const activityOps: Op[] = (activity.data.data?.operations ?? []).map(adaptRegistryOperation);
-      const ops = [...pendingOps, ...activityOps].slice(0, 30);
+      const ops = dedupePanelOps(pendingOps, activityOps).slice(0, 30);
       const warnings = uniqueWarnings([
         ...baseWarnings,
         ...skillsPayload.warnings,
@@ -235,7 +247,7 @@ export function usePanelData(): PanelLiveData {
           bindings,
           ops,
           projections,
-          queuedWriteCount: pending.data.count ?? 0,
+          queuedWriteCount: pending.data.count ?? pendingOps.length,
         }),
       );
     } catch (err) {

--- a/panel/src/lib/operation_labels.test.ts
+++ b/panel/src/lib/operation_labels.test.ts
@@ -5,6 +5,8 @@ import {
   operationDetailParts,
   operationStatusLabel,
   operationSubjectLabel,
+  registryOperationDetailParts,
+  registryOperationSubjectLabel,
   describeRegistryOperation,
   registryOperationDisplayId,
 } from "./operation_labels";
@@ -98,8 +100,28 @@ describe("operation labels", () => {
     };
 
     expect(operationActionLabel(op.kind)).toBe("导入观测到的技能");
+    expect(operationActionLabel("import-observed")).toBe("导入观测到的技能");
+    expect(operationActionLabel("monitor-observed")).toBe("扫描观测目录");
     expect(operationStatusLabel(op.status)).toBe("待处理");
     expect(operationSubjectLabel(op)).toBe("4 个 skill");
     expect(operationDetailParts(op)).toContain("target target_codex_home");
+  });
+
+  it("summarizes multi-skill audit history without exposing the raw list", () => {
+    const skillList = "agentsmd-audit, ai-slop-cleaner, aiproxy-workflow-auth-debug, app-sizzle, app-store-screens";
+    const op = registryOperation({
+      intent: "skill.monitor_observed",
+      status: "succeeded",
+      ack: true,
+      skill: skillList,
+      source: "registry",
+    });
+    const label = describeRegistryOperation(op);
+
+    expect(registryOperationSubjectLabel(op)).toBe("5 个 skill");
+    expect(registryOperationDetailParts(op)).toContain("本次批量操作包含 5 个 skill");
+    expect(label.title).toBe("5 skills observed skill monitor done");
+    expect(label.details).toContain("skills 5");
+    expect(label.details.join(" ")).not.toContain(skillList);
   });
 });

--- a/panel/src/lib/operation_labels.test.ts
+++ b/panel/src/lib/operation_labels.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   describeActivityOperation,
+  operationActionLabel,
+  operationDetailParts,
+  operationStatusLabel,
+  operationSubjectLabel,
   describeRegistryOperation,
   registryOperationDisplayId,
 } from "./operation_labels";
@@ -80,5 +84,22 @@ describe("operation labels", () => {
         }),
       ),
     ).toBe("audit_1");
+  });
+
+  it("summarizes multi-skill activity without exposing the raw list", () => {
+    const op: Op = {
+      id: "op_import",
+      status: "pending",
+      kind: "skill.import_observed",
+      skill: "aiproxy-workflow-auth-debug, ask-claude, ask-gemini, code-review",
+      target: "target_codex_home",
+      method: "—",
+      time: "now",
+    };
+
+    expect(operationActionLabel(op.kind)).toBe("导入观测到的技能");
+    expect(operationStatusLabel(op.status)).toBe("待处理");
+    expect(operationSubjectLabel(op)).toBe("4 个 skill");
+    expect(operationDetailParts(op)).toContain("target target_codex_home");
   });
 });

--- a/panel/src/lib/operation_labels.ts
+++ b/panel/src/lib/operation_labels.ts
@@ -1,5 +1,5 @@
 import type { RegistryOperationRecord } from "./api/client";
-import type { Op } from "./types";
+import type { Op, OpStatus } from "./types";
 
 export interface OperationLabel {
   category: string;
@@ -33,6 +33,28 @@ const INTENT_LABELS: Record<string, IntentDescriptor> = {
   "sync-push": { category: "Sync", phrase: "remote sync push" },
   "sync-pull": { category: "Sync", phrase: "remote sync pull" },
   "sync-replay": { category: "Sync", phrase: "pending sync replay" },
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  "target.add": "注册目标目录",
+  "target.remove": "移除目标目录",
+  "workspace.binding.add": "新增绑定规则",
+  "workspace.binding.remove": "移除绑定规则",
+  "skill.project": "投影到目标目录",
+  "skill.capture": "回收目标目录修改",
+  "skill.import_observed": "导入观测到的技能",
+  "skill.monitor_observed": "扫描观测目录",
+  "skill.orphan.clean": "清理孤立技能",
+  "skill.save": "保存技能源",
+  "skill.snapshot": "创建快照",
+  "skill.release": "发布版本标签",
+  "skill.rollback": "回滚技能",
+  "sync.push": "推送远端同步",
+  "sync.pull": "拉取远端同步",
+  "sync.replay": "重放同步队列",
+  "sync-push": "推送远端同步",
+  "sync-pull": "拉取远端同步",
+  "sync-replay": "重放同步队列",
 };
 
 export function describeActivityOperation(op: Op): OperationLabel {
@@ -78,6 +100,41 @@ export function describeRegistryOperation(op: RegistryOperationRecord): Operatio
     details,
     technicalId,
   };
+}
+
+export function operationActionLabel(kind: string): string {
+  const normalized = normalizeIntent(kind);
+  return ACTION_LABELS[normalized] ?? normalized.replace(/[._-]/g, " ");
+}
+
+export function operationStatusLabel(status: OpStatus): string {
+  if (status === "ok") return "已完成";
+  if (status === "err") return "失败";
+  return "待处理";
+}
+
+export function splitOperationSkills(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim().replace(/@\S+$/, ""))
+    .filter((part, index, items) => part.length > 0 && items.indexOf(part) === index);
+}
+
+export function operationSubjectLabel(op: Op): string {
+  const skills = splitOperationSkills(op.skill).filter((name) => name !== op.kind);
+  if (skills.length > 3) return `${skills.length} 个 skill`;
+  if (skills.length > 0) return skills.join(", ");
+  if (meaningfulField(op.target)) return op.target;
+  return operationActionLabel(op.kind);
+}
+
+export function operationDetailParts(op: Op): string[] {
+  return compact([
+    meaningfulField(op.target) ? `target ${op.target}` : null,
+    meaningfulField(op.method) ? `方式 ${op.method}` : null,
+    op.reason ? `${op.status === "err" ? "错误" : "说明"} ${op.reason}` : null,
+    `id ${op.id}`,
+  ]);
 }
 
 export function registryOperationDisplayId(op: RegistryOperationRecord): string {

--- a/panel/src/lib/operation_labels.ts
+++ b/panel/src/lib/operation_labels.ts
@@ -24,6 +24,8 @@ const INTENT_LABELS: Record<string, IntentDescriptor> = {
   "skill.capture": { category: "Capture", phrase: "skill capture" },
   "skill.import_observed": { category: "Import", phrase: "observed skill import" },
   "skill.monitor_observed": { category: "Monitor", phrase: "observed skill monitor" },
+  "import-observed": { category: "Import", phrase: "observed skill import" },
+  "monitor-observed": { category: "Monitor", phrase: "observed skill monitor" },
   "skill.orphan.clean": { category: "Cleanup", phrase: "orphan cleanup" },
   "skill.save": { category: "Skill", phrase: "skill save" },
   "skill.snapshot": { category: "Snapshot", phrase: "skill snapshot" },
@@ -44,6 +46,8 @@ const ACTION_LABELS: Record<string, string> = {
   "skill.capture": "回收目标目录修改",
   "skill.import_observed": "导入观测到的技能",
   "skill.monitor_observed": "扫描观测目录",
+  "import-observed": "导入观测到的技能",
+  "monitor-observed": "扫描观测目录",
   "skill.orphan.clean": "清理孤立技能",
   "skill.save": "保存技能源",
   "skill.snapshot": "创建快照",
@@ -84,9 +88,10 @@ export function describeRegistryOperation(op: RegistryOperationRecord): Operatio
   const status = statusWord(bucketRegistryOperation(op));
   const technicalId = registryOperationDisplayId(op);
   const subject = subjectForRegistryOperation(op, descriptor);
+  const skills = meaningfulString(op.skill) ? splitOperationSkills(op.skill) : [];
   const details = compact([
     `intent ${normalizeIntent(op.intent)}`,
-    meaningfulString(op.skill) ? `skill ${op.skill}` : null,
+    skills.length > 3 ? `skills ${skills.length}` : skills.length > 0 ? `skill ${skills.join(", ")}` : null,
     meaningfulString(op.target) ? `target ${op.target}` : null,
     meaningfulString(op.binding) ? `binding ${op.binding}` : null,
     meaningfulString(op.method) ? `method ${op.method}` : null,
@@ -113,11 +118,28 @@ export function operationStatusLabel(status: OpStatus): string {
   return "待处理";
 }
 
+export function registryOperationStatusLabel(op: RegistryOperationRecord): string {
+  const status = bucketRegistryOperation(op);
+  if (status === "ok") return "已完成";
+  if (status === "err") return "失败";
+  return "待处理";
+}
+
 export function splitOperationSkills(value: string): string[] {
   return value
     .split(",")
     .map((part) => part.trim().replace(/@\S+$/, ""))
     .filter((part, index, items) => part.length > 0 && items.indexOf(part) === index);
+}
+
+export function registryOperationSubjectLabel(op: RegistryOperationRecord): string {
+  const skills = meaningfulString(op.skill) ? splitOperationSkills(op.skill) : [];
+  if (skills.length > 3) return `${skills.length} 个 skill`;
+  if (skills.length > 0) return skills.join(", ");
+  if (meaningfulString(op.target)) return op.target;
+  if (meaningfulString(op.binding)) return op.binding;
+  if (meaningfulString(op.source)) return op.source;
+  return operationActionLabel(op.intent);
 }
 
 export function operationSubjectLabel(op: Op): string {
@@ -126,6 +148,23 @@ export function operationSubjectLabel(op: Op): string {
   if (skills.length > 0) return skills.join(", ");
   if (meaningfulField(op.target)) return op.target;
   return operationActionLabel(op.kind);
+}
+
+export function registryOperationTargetLabel(op: RegistryOperationRecord): string {
+  return op.target ?? op.binding ?? op.source ?? "registry";
+}
+
+export function registryOperationDetailParts(op: RegistryOperationRecord): string[] {
+  const skills = meaningfulString(op.skill) ? splitOperationSkills(op.skill) : [];
+  return compact([
+    skills.length > 3 ? `本次批量操作包含 ${skills.length} 个 skill` : null,
+    meaningfulString(op.target) ? `target ${op.target}` : null,
+    meaningfulString(op.binding) ? `binding ${op.binding}` : null,
+    meaningfulString(op.method) ? `方式 ${op.method}` : null,
+    op.last_error?.message ? `错误 ${op.last_error.message}` : null,
+    op.ack ? "已同步" : "未同步",
+    `id ${registryOperationDisplayId(op)}`,
+  ]);
 }
 
 export function operationDetailParts(op: Op): string[] {
@@ -176,7 +215,10 @@ function subjectForRegistryOperation(op: RegistryOperationRecord, descriptor: In
   const targetSubject = subjectFromTarget(op.target ?? null);
   if (descriptor.category === "Target") return targetSubject ?? "";
   if (descriptor.category === "Binding") return subjectFromBinding(op.binding ?? null) ?? targetSubject ?? "";
-  if (meaningfulString(op.skill)) return op.skill;
+  if (meaningfulString(op.skill)) {
+    const skills = splitOperationSkills(op.skill);
+    return skills.length > 3 ? `${skills.length} skills` : skills.join(", ");
+  }
   return targetSubject ?? "";
 }
 

--- a/panel/src/lib/skillm_prefs.test.ts
+++ b/panel/src/lib/skillm_prefs.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadSkillMPreferences, saveSkillMPreferences } from "./skillm_prefs";
+
+const STORAGE_KEY = "loom.skillm.preferences";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("SkillM preferences", () => {
+  it("round-trips local appearance preferences", () => {
+    saveSkillMPreferences({ dark: false, density: "compact", accent: ["#111111", "#222222", "#333333"] });
+
+    expect(loadSkillMPreferences()).toEqual({
+      dark: false,
+      density: "compact",
+      accent: ["#111111", "#222222", "#333333"],
+    });
+  });
+
+  it("falls back to defaults when stored preferences are corrupt", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not-json");
+
+    expect(loadSkillMPreferences()).toEqual({
+      dark: true,
+      density: "regular",
+      accent: ["#ff0080", "#7928ca", "#00d9ff"],
+    });
+  });
+
+  it("does not throw when localStorage rejects writes", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    expect(() => saveSkillMPreferences({ dark: false, density: "compact", accent: ["#111111", "#222222", "#333333"] })).not.toThrow();
+  });
+});

--- a/panel/src/lib/skillm_prefs.ts
+++ b/panel/src/lib/skillm_prefs.ts
@@ -1,0 +1,42 @@
+export type SkillMDensity = "compact" | "regular" | "comfy";
+
+export interface SkillMPreferences {
+  dark: boolean;
+  density: SkillMDensity;
+  accent: string[];
+}
+
+const STORAGE_KEY = "loom.skillm.preferences";
+const DEFAULT_ACCENT = ["#ff0080", "#7928ca", "#00d9ff"];
+const DEFAULT_PREFS: SkillMPreferences = { dark: true, density: "regular", accent: DEFAULT_ACCENT };
+
+export function loadSkillMPreferences(): SkillMPreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFS;
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "null") as Partial<SkillMPreferences> | null;
+    return {
+      dark: typeof parsed?.dark === "boolean" ? parsed.dark : DEFAULT_PREFS.dark,
+      density: isDensity(parsed?.density) ? parsed.density : DEFAULT_PREFS.density,
+      accent: isAccent(parsed?.accent) ? parsed.accent : DEFAULT_PREFS.accent,
+    };
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+export function saveSkillMPreferences(preferences: SkillMPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch {
+    // Appearance preferences are best-effort; blocked storage must not break the panel.
+  }
+}
+
+function isDensity(value: unknown): value is SkillMDensity {
+  return value === "compact" || value === "regular" || value === "comfy";
+}
+
+function isAccent(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length === 3 && value.every((color) => typeof color === "string" && color.length > 0);
+}

--- a/panel/src/pages/OperationLogRow.tsx
+++ b/panel/src/pages/OperationLogRow.tsx
@@ -1,0 +1,67 @@
+import type { Op } from "../lib/types";
+import {
+  operationActionLabel,
+  operationDetailParts,
+  operationStatusLabel,
+  operationSubjectLabel,
+  splitOperationSkills,
+} from "../lib/operation_labels";
+
+interface OperationLogRowProps {
+  op: Op;
+}
+
+function classForStatus(status: Op["status"]) {
+  if (status === "ok") return "done";
+  if (status === "err") return "failed";
+  return "pending";
+}
+
+function methodLabel(method: Op["method"]) {
+  return method === "—" ? "无方式" : method;
+}
+
+export function OperationLogRow({ op }: OperationLogRowProps) {
+  const rowClass = classForStatus(op.status);
+  const skills = splitOperationSkills(op.skill).filter((name) => name !== op.kind);
+  const details = operationDetailParts(op);
+  const visibleSkills = skills.slice(0, 80);
+  const hiddenSkillCount = Math.max(0, skills.length - visibleSkills.length);
+  const countLabel = skills.length > 1 ? `批量 ${skills.length}` : methodLabel(op.method);
+
+  return (
+    <details className={`op-row op-log-row op-row-${rowClass}`}>
+      <summary className="op-row-main">
+        <span className={`op-pill op-${rowClass}`}>{operationStatusLabel(op.status)}</span>
+        <span className="op-time">{op.time}</span>
+        <span className="op-verb">{operationActionLabel(op.kind)}</span>
+        <span className="op-main-subject">
+          <b>{operationSubjectLabel(op)}</b>
+          {op.target !== "—" ? <code>{op.target}</code> : null}
+        </span>
+        <span className="op-count-chip">{countLabel}</span>
+        <span className="op-more-chip">详情</span>
+      </summary>
+      <div className="op-expanded">
+        <div className="op-kv-grid">
+          <span>intent</span><code>{op.kind}</code>
+          <span>target</span><code>{op.target}</code>
+          <span>method</span><code>{methodLabel(op.method)}</code>
+          <span>id</span><code>{op.id}</code>
+        </div>
+        {details.length > 0 ? <div className="op-detail-line">{details.join(" · ")}</div> : null}
+        {skills.length > 0 ? (
+          <div className="op-skill-block">
+            <span className="op-skill-label">skills</span>
+            <div className="op-skill-chips">
+              {visibleSkills.map((name) => (
+                <span key={name}>{name}</span>
+              ))}
+              {hiddenSkillCount > 0 ? <span>+{hiddenSkillCount} more</span> : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}

--- a/panel/src/pages/OperationLogRow.tsx
+++ b/panel/src/pages/OperationLogRow.tsx
@@ -25,8 +25,6 @@ export function OperationLogRow({ op }: OperationLogRowProps) {
   const rowClass = classForStatus(op.status);
   const skills = splitOperationSkills(op.skill).filter((name) => name !== op.kind);
   const details = operationDetailParts(op);
-  const visibleSkills = skills.slice(0, 80);
-  const hiddenSkillCount = Math.max(0, skills.length - visibleSkills.length);
   const countLabel = skills.length > 1 ? `批量 ${skills.length}` : methodLabel(op.method);
 
   return (
@@ -54,10 +52,9 @@ export function OperationLogRow({ op }: OperationLogRowProps) {
           <div className="op-skill-block">
             <span className="op-skill-label">skills</span>
             <div className="op-skill-chips">
-              {visibleSkills.map((name) => (
+              {skills.map((name) => (
                 <span key={name}>{name}</span>
               ))}
-              {hiddenSkillCount > 0 ? <span>+{hiddenSkillCount} more</span> : null}
             </div>
           </div>
         ) : null}

--- a/panel/src/pages/SkillMAuditHistory.tsx
+++ b/panel/src/pages/SkillMAuditHistory.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from "react";
 import { api, type OpsPayload, type RegistryOperationRecord } from "../lib/api/client";
+import {
+  operationActionLabel,
+  registryOperationDetailParts,
+  registryOperationDisplayId,
+  registryOperationStatusLabel,
+  registryOperationSubjectLabel,
+  registryOperationTargetLabel,
+} from "../lib/operation_labels";
 
 const HISTORY_PAGE_SIZE = 100;
 
@@ -106,25 +114,26 @@ export function SkillMAuditHistory({ live, refreshKey }: SkillMAuditHistoryProps
 }
 
 function AuditHistoryLine({ op }: { op: RegistryOperationRecord }) {
+  const rowClass = historyClass(op);
+  const details = registryOperationDetailParts(op);
+  const target = registryOperationTargetLabel(op);
+
   return (
-    <div className={`op-row op-row-${historyClass(op)}`}>
-      <span className={`op-pill op-${historyClass(op)}`}>{historyStatus(op)}</span>
-      <span className="op-time">{op.updated_at || op.created_at}</span>
-      <span className="op-verb">{op.intent}</span>
+    <div className={`op-row op-row-${rowClass}`}>
+      <span className={`op-pill op-${rowClass}`}>{registryOperationStatusLabel(op)}</span>
+      <span className="op-time" title={op.updated_at || op.created_at}>{historyTime(op)}</span>
+      <span className="op-verb">{operationActionLabel(op.intent)}</span>
       <span className="op-detail">
-        {op.skill ?? historyId(op)}
-        <span className="op-arrow">
-          {" -> "}
-          <code>{op.target ?? op.binding ?? op.source ?? "registry"}</code>
-        </span>
+        <b>{registryOperationSubjectLabel(op)}</b>
+        <code>{target}</code>
       </span>
-      <span className="op-note">{op.last_error?.message ?? op.method ?? op.source ?? historyId(op)}</span>
+      <span className="op-note">{details.join(" · ")}</span>
     </div>
   );
 }
 
 function historyId(op: RegistryOperationRecord): string {
-  return op.op_id ?? op.audit_id ?? op.request_id ?? `${op.intent}-${op.created_at}`;
+  return registryOperationDisplayId(op);
 }
 
 function historyStatus(op: RegistryOperationRecord): "ok" | "pending" | "err" {
@@ -139,4 +148,17 @@ function historyClass(op: RegistryOperationRecord): "done" | "pending" | "failed
   if (status === "err") return "failed";
   if (status === "pending") return "pending";
   return "done";
+}
+
+function historyTime(op: RegistryOperationRecord): string {
+  const iso = op.updated_at || op.created_at;
+  const timestamp = Date.parse(iso);
+  if (!Number.isFinite(timestamp)) return iso;
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
 }

--- a/panel/src/pages/SkillMAuditHistory.tsx
+++ b/panel/src/pages/SkillMAuditHistory.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from "react";
 import { api, type OpsPayload, type RegistryOperationRecord } from "../lib/api/client";
 import {
   operationActionLabel,
+  bucketRegistryOperation,
   registryOperationDetailParts,
   registryOperationDisplayId,
   registryOperationStatusLabel,
   registryOperationSubjectLabel,
   registryOperationTargetLabel,
+  splitOperationSkills,
 } from "../lib/operation_labels";
 
 const HISTORY_PAGE_SIZE = 100;
@@ -116,19 +118,41 @@ export function SkillMAuditHistory({ live, refreshKey }: SkillMAuditHistoryProps
 function AuditHistoryLine({ op }: { op: RegistryOperationRecord }) {
   const rowClass = historyClass(op);
   const details = registryOperationDetailParts(op);
+  const summaryDetails = details.filter((part) => !part.startsWith("id ")).slice(0, 2);
+  const skills = op.skill ? splitOperationSkills(op.skill) : [];
   const target = registryOperationTargetLabel(op);
 
   return (
-    <div className={`op-row op-row-${rowClass}`}>
-      <span className={`op-pill op-${rowClass}`}>{registryOperationStatusLabel(op)}</span>
-      <span className="op-time" title={op.updated_at || op.created_at}>{historyTime(op)}</span>
-      <span className="op-verb">{operationActionLabel(op.intent)}</span>
-      <span className="op-detail">
-        <b>{registryOperationSubjectLabel(op)}</b>
-        <code>{target}</code>
-      </span>
-      <span className="op-note">{details.join(" · ")}</span>
-    </div>
+    <details className={`op-row op-log-row audit-history-row op-row-${rowClass}`}>
+      <summary className="op-row-main">
+        <span className={`op-pill op-${rowClass}`}>{registryOperationStatusLabel(op)}</span>
+        <span className="op-time" title={op.updated_at || op.created_at}>{historyTime(op)}</span>
+        <span className="op-verb">{operationActionLabel(op.intent)}</span>
+        <span className="op-main-subject">
+          <b>{registryOperationSubjectLabel(op)}</b>
+          <code>{target}</code>
+        </span>
+        <span className="op-count-chip">{summaryDetails[0] ?? "详情"}</span>
+        <span className="op-more-chip">展开</span>
+      </summary>
+      <div className="op-expanded">
+        <div className="op-kv-grid">
+          <span>intent</span><code>{op.intent}</code>
+          <span>source</span><code>{op.source ?? "registry"}</code>
+          <span>status</span><code>{op.status}</code>
+          <span>id</span><code>{registryOperationDisplayId(op)}</code>
+        </div>
+        {details.length > 0 ? <div className="op-detail-line">{details.join(" · ")}</div> : null}
+        {skills.length > 0 ? (
+          <div className="op-skill-block">
+            <span className="op-skill-label">skills</span>
+            <div className="op-skill-chips">
+              {skills.map((name) => <span key={name}>{name}</span>)}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </details>
   );
 }
 
@@ -136,15 +160,8 @@ function historyId(op: RegistryOperationRecord): string {
   return registryOperationDisplayId(op);
 }
 
-function historyStatus(op: RegistryOperationRecord): "ok" | "pending" | "err" {
-  const status = op.status.toLowerCase();
-  if (status === "failed" || status === "err" || status === "error") return "err";
-  if (status === "pending" || status === "queued" || status === "running") return "pending";
-  return "ok";
-}
-
 function historyClass(op: RegistryOperationRecord): "done" | "pending" | "failed" {
-  const status = historyStatus(op);
+  const status = bucketRegistryOperation(op);
   if (status === "err") return "failed";
   if (status === "pending") return "pending";
   return "done";

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -136,11 +136,12 @@ describe("SkillMPanel", () => {
   it("switches between queued ops and audit history tabs", async () => {
     panelData.current = panelData.liveOps;
     window.history.replaceState(null, "", "/?view=ops");
+    const auditSkillList = "agentsmd-audit, ai-slop-cleaner, aiproxy-workflow-auth-debug, app-sizzle, app-store-screens";
     const ops = vi.spyOn(api, "ops").mockResolvedValue({
       ok: true,
       data: {
         count: 40,
-        loaded_count: 1,
+        loaded_count: 2,
         offset: 0,
         limit: 100,
         has_more: false,
@@ -160,6 +161,21 @@ describe("SkillMPanel", () => {
             created_at: "2026-06-12T09:00:00Z",
             updated_at: "2026-06-12T09:01:00Z",
           },
+          {
+            op_id: "hist-2",
+            audit_id: "audit-2",
+            request_id: "req-2",
+            source: "registry",
+            intent: "skill.monitor_observed",
+            status: "succeeded",
+            ack: true,
+            skill: auditSkillList,
+            target: null,
+            binding: null,
+            method: null,
+            created_at: "2026-06-12T09:02:00Z",
+            updated_at: "2026-06-12T09:03:00Z",
+          },
         ],
       },
     });
@@ -174,8 +190,11 @@ describe("SkillMPanel", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /审计历史/ }));
 
-    expect(await screen.findByText("skill.release")).toBeTruthy();
+    expect(await screen.findByText("发布版本标签")).toBeTruthy();
     expect(screen.getByText("release-notes")).toBeTruthy();
+    expect(screen.getByText("5 个 skill")).toBeTruthy();
+    expect(screen.getByText(/本次批量操作包含 5 个 skill/)).toBeTruthy();
+    expect(screen.queryByText(auditSkillList)).toBeNull();
     expect(ops.mock.calls[0]?.[0]).toEqual({ limit: 100, offset: 0 });
     expect(new URL(window.location.href).searchParams.get("view")).toBe("history");
   });

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -93,6 +93,15 @@ const panelData = vi.hoisted(() => ({
         time: "2026-06-12 09:05",
         reason: "queued",
       },
+      {
+        id: "op-bulk",
+        kind: "skill.monitor_observed",
+        skill: "aiproxy-workflow-auth-debug, ask-claude, ask-gemini, code-review",
+        target: "target_codex_home",
+        status: "pending" as const,
+        time: "2026-06-12 09:06",
+        method: "—",
+      },
     ],
     projections: [],
     queuedWriteCount: 0,
@@ -157,7 +166,10 @@ describe("SkillMPanel", () => {
 
     render(<SkillMPanel />);
 
-    expect(screen.getByText("sync.push")).toBeTruthy();
+    expect(screen.getByText("推送远端同步")).toBeTruthy();
+    expect(screen.getByText("扫描观测目录")).toBeTruthy();
+    expect(screen.getByText("4 个 skill")).toBeTruthy();
+    expect(screen.queryByText("aiproxy-workflow-auth-debug, ask-claude, ask-gemini, code-review")).toBeNull();
     expect(screen.queryByText("skill.save")).toBeNull();
 
     await userEvent.click(screen.getByRole("button", { name: /审计历史/ }));

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { api } from "../lib/api/client";
+import { OperationLogRow } from "./OperationLogRow";
 import { SkillMPanel } from "./SkillMPanel";
 
 const panelData = vi.hoisted(() => ({
@@ -118,6 +119,7 @@ vi.mock("../lib/api/usePanelData", () => ({
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  window.localStorage.clear();
   panelData.refetch.mockReset();
   panelData.current = null;
   window.history.replaceState(null, "", "/");
@@ -176,11 +178,42 @@ describe("SkillMPanel", () => {
             created_at: "2026-06-12T09:02:00Z",
             updated_at: "2026-06-12T09:03:00Z",
           },
+          {
+            op_id: "hist-3",
+            audit_id: "audit-3",
+            request_id: "req-3",
+            source: "registry",
+            intent: "sync.replay",
+            status: "enqueued",
+            ack: false,
+            skill: null,
+            target: null,
+            binding: null,
+            method: null,
+            created_at: "2026-06-12T09:04:00Z",
+            updated_at: "2026-06-12T09:05:00Z",
+          },
+          {
+            op_id: "hist-4",
+            audit_id: "audit-4",
+            request_id: "req-4",
+            source: "registry",
+            intent: "sync.push",
+            status: "succeeded",
+            ack: true,
+            skill: null,
+            target: null,
+            binding: null,
+            method: null,
+            last_error: { code: "sync_failed", message: "remote rejected push" },
+            created_at: "2026-06-12T09:06:00Z",
+            updated_at: "2026-06-12T09:07:00Z",
+          },
         ],
       },
     });
 
-    render(<SkillMPanel />);
+    const { container } = render(<SkillMPanel />);
 
     expect(screen.getByText("推送远端同步")).toBeTruthy();
     expect(screen.getByText("扫描观测目录")).toBeTruthy();
@@ -191,12 +224,36 @@ describe("SkillMPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: /审计历史/ }));
 
     expect(await screen.findByText("发布版本标签")).toBeTruthy();
-    expect(screen.getByText("release-notes")).toBeTruthy();
+    expect(screen.getAllByText("release-notes").length).toBeGreaterThan(0);
     expect(screen.getByText("5 个 skill")).toBeTruthy();
-    expect(screen.getByText(/本次批量操作包含 5 个 skill/)).toBeTruthy();
+    expect(screen.getAllByText(/本次批量操作包含 5 个 skill/).length).toBeGreaterThan(0);
+    expect([...container.querySelectorAll(".op-row-pending .op-pill")].some((node) => node.textContent === "待处理")).toBe(true);
+    expect([...container.querySelectorAll(".op-row-failed .op-pill")].some((node) => node.textContent === "失败")).toBe(true);
     expect(screen.queryByText(auditSkillList)).toBeNull();
     expect(ops.mock.calls[0]?.[0]).toEqual({ limit: 100, offset: 0 });
     expect(new URL(window.location.href).searchParams.get("view")).toBe("history");
+  });
+
+  it("keeps every skill name available when expanded bulk rows exceed the summary height", () => {
+    const names = Array.from({ length: 90 }, (_, index) => `skill-${index + 1}`);
+
+    render(
+      <OperationLogRow
+        op={{
+          id: "bulk-all",
+          kind: "skill.monitor_observed",
+          skill: names.join(", "),
+          target: "target_codex_home",
+          status: "pending",
+          time: "now",
+          method: "—",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("skill-1")).toBeTruthy();
+    expect(screen.getByText("skill-90")).toBeTruthy();
+    expect(screen.queryByText(/\+10 more/)).toBeNull();
   });
 
   it("keeps skill details visible while browsing many skill cards", async () => {
@@ -266,8 +323,9 @@ describe("SkillMPanel", () => {
 
     render(<SkillMPanel />);
 
-    expect(screen.getByText("扫描观测目录")).toBeTruthy();
-    expect(screen.getByText("4 个 skill")).toBeTruthy();
+    expect(screen.getByText("推送远端同步")).toBeTruthy();
+    expect(screen.queryByText("扫描观测目录")).toBeNull();
+    expect(screen.queryByText("4 个 skill")).toBeNull();
     expect(screen.queryByText("aiproxy-workflow-auth-debug, ask-claude, ask-gemini, code-review")).toBeNull();
     expect(screen.queryByText("skill.monitor_observed")).toBeNull();
   });
@@ -283,5 +341,80 @@ describe("SkillMPanel", () => {
 
     expect(screen.getByRole("heading", { name: "注册表同步" })).toBeTruthy();
     expect(syncReplay).not.toHaveBeenCalled();
+  });
+
+  it("does not underreport queued operations when the API count exceeds visible rows", () => {
+    panelData.current = { ...panelData.liveOps, queuedWriteCount: 5 };
+    window.history.replaceState(null, "", "/?view=ops");
+
+    const { container } = render(<SkillMPanel />);
+    const pendingStat = [...container.querySelectorAll(".pstat")].find((node) => node.textContent?.includes("待处理"));
+
+    expect(pendingStat?.textContent).toContain("5");
+    expect(screen.getByText(/5 queued/)).toBeTruthy();
+  });
+
+  it("makes non-wired controls read as status and gives overlays real controls", async () => {
+    panelData.current = {
+      ...panelData.liveOps,
+      skills: [
+        {
+          id: "alpha",
+          name: "alpha-skill",
+          description: "Alpha description",
+          tag: "workflow",
+          sourceStatus: "present",
+          releaseTags: [],
+          snapshotTags: [],
+          latestRev: "rev-alpha",
+          ruleCount: 0,
+          bindingCount: 1,
+          projectionCount: 2,
+          changed: "1h ago",
+          targets: [],
+        },
+        {
+          id: "beta",
+          name: "beta-skill",
+          description: "Beta description",
+          tag: "debug",
+          sourceStatus: "present",
+          releaseTags: [],
+          snapshotTags: [],
+          latestRev: "rev-beta",
+          ruleCount: 0,
+          bindingCount: 0,
+          projectionCount: 0,
+          changed: "2h ago",
+          targets: [],
+        },
+      ],
+      targets: [{ id: "target_codex", agent: "codex", path: "~/.codex/skills", profile: "default", ownership: "observed", projectedSkills: 2 }],
+      bindings: [{ id: "bind-alpha", skill: "alpha-skill", policy: "codex", matcher: "tag:workflow", target: "target_codex", method: "copy" }],
+    };
+    window.history.replaceState(null, "", "/?view=targets");
+
+    render(<SkillMPanel />);
+
+    expect(screen.queryByRole("button", { name: /target add/i })).toBeNull();
+    expect(screen.getByText("target 新增未接入")).toBeTruthy();
+    expect(screen.getByText("verify 未接入")).toBeTruthy();
+
+    await userEvent.keyboard("{Control>}k{/Control}");
+    const search = await screen.findByRole("textbox", { name: "搜索命令" });
+    await userEvent.type(search, "beta");
+
+    expect(screen.getByText("Open beta-skill")).toBeTruthy();
+    expect(screen.queryByText("Open alpha-skill")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "关闭命令面板" }));
+    await userEvent.click(screen.getByRole("button", { name: /Settings/ }));
+
+    expect(screen.getByRole("switch", { name: "切换深色模式" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "选择配色 1" })).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "tweaks" }));
+
+    expect(screen.getByRole("button", { name: "关闭 Tweaks" })).toBeTruthy();
   });
 });

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { api } from "../lib/api/client";
 import { SkillMPanel } from "./SkillMPanel";
@@ -197,5 +197,91 @@ describe("SkillMPanel", () => {
     expect(screen.queryByText(auditSkillList)).toBeNull();
     expect(ops.mock.calls[0]?.[0]).toEqual({ limit: 100, offset: 0 });
     expect(new URL(window.location.href).searchParams.get("view")).toBe("history");
+  });
+
+  it("keeps skill details visible while browsing many skill cards", async () => {
+    panelData.current = {
+      ...panelData.liveOps,
+      ops: [],
+      skills: [
+        {
+          id: "alpha",
+          name: "alpha-skill",
+          description: "Alpha description",
+          tag: "workflow",
+          sourceStatus: "present",
+          releaseTags: [],
+          snapshotTags: [],
+          latestRev: "rev-alpha",
+          ruleCount: 0,
+          bindingCount: 1,
+          projectionCount: 2,
+          changed: "1h ago",
+          targets: [],
+        },
+        {
+          id: "beta",
+          name: "beta-skill",
+          description: "Beta description",
+          tag: "debug",
+          sourceStatus: "missing",
+          releaseTags: [],
+          snapshotTags: [],
+          latestRev: "rev-beta",
+          ruleCount: 0,
+          bindingCount: 0,
+          projectionCount: 0,
+          changed: "2h ago",
+          targets: [],
+        },
+      ],
+      targets: [],
+    };
+    window.history.replaceState(null, "", "/?view=skills");
+
+    render(<SkillMPanel />);
+
+    expect(screen.getByLabelText("alpha-skill detail")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "查看 beta-skill 详情" }));
+
+    const detail = screen.getByLabelText("beta-skill detail");
+    expect(detail).toBeTruthy();
+    expect(within(detail).getByText("Beta description")).toBeTruthy();
+  });
+
+  it("uses the current panel host instead of a hard-coded dev port", () => {
+    panelData.current = panelData.liveOps;
+    window.history.replaceState(null, "", "/?view=targets");
+
+    render(<SkillMPanel />);
+
+    expect(screen.getByTitle("当前 Panel 地址")).toBeTruthy();
+    expect(screen.queryByText("localhost:5173")).toBeNull();
+  });
+
+  it("summarizes Git sync events without exposing raw bulk skill lists", () => {
+    panelData.current = panelData.liveOps;
+    window.history.replaceState(null, "", "/?view=sync");
+
+    render(<SkillMPanel />);
+
+    expect(screen.getByText("扫描观测目录")).toBeTruthy();
+    expect(screen.getByText("4 个 skill")).toBeTruthy();
+    expect(screen.queryByText("aiproxy-workflow-auth-debug, ask-claude, ask-gemini, code-review")).toBeNull();
+    expect(screen.queryByText("skill.monitor_observed")).toBeNull();
+  });
+
+  it("routes the footer sync control to Git sync instead of replaying immediately", async () => {
+    panelData.current = panelData.liveOps;
+    window.history.replaceState(null, "", "/");
+    const syncReplay = vi.spyOn(api, "syncReplay");
+
+    render(<SkillMPanel />);
+
+    await userEvent.click(screen.getByRole("button", { name: /local/ }));
+
+    expect(screen.getByRole("heading", { name: "注册表同步" })).toBeTruthy();
+    expect(syncReplay).not.toHaveBeenCalled();
   });
 });

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -5,6 +5,7 @@ import { api } from "../lib/api/client";
 import type { Op, PanelPageKey, Skill, Target } from "../lib/types";
 import { FirstRunPage } from "./panel/FirstRunPage";
 import { DoctorPage } from "./panel/DoctorPage";
+import { OperationLogRow } from "./OperationLogRow";
 import { SkillMAuditHistory } from "./SkillMAuditHistory";
 
 type SkillMPage = PanelPageKey | "market" | "forge";
@@ -122,12 +123,6 @@ function methodTone(method: string) {
   if (method === "copy") return "var(--acc2)";
   if (method === "symlink") return "var(--acc3)";
   return "var(--faint)";
-}
-
-function classForOp(op: Op) {
-  if (op.status === "ok") return "done";
-  if (op.status === "err") return "failed";
-  return "pending";
 }
 
 const HEATMAP_WEEKS = 26;
@@ -620,13 +615,9 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
       </header>
       <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
       <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
-      {history ? <SkillMAuditHistory live={live.live} refreshKey={live.lastUpdated} /> : <section className="ops-table">{rows.map((op) => <OpLine key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>队列已清空 · 没有待处理或失败的操作</p></div>}</section>}
+      {history ? <SkillMAuditHistory live={live.live} refreshKey={live.lastUpdated} /> : <section className="ops-table">{rows.map((op) => <OperationLogRow key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>队列已清空 · 没有待处理或失败的操作</p></div>}</section>}
     </div>
   );
-}
-
-function OpLine({ op }: { op: Op }) {
-  return <div className={`op-row op-row-${classForOp(op)}`}><span className={`op-pill op-${classForOp(op)}`}>{op.status}</span><span className="op-time">{op.time}</span><span className="op-verb">{op.kind}</span><span className="op-detail">{op.skill}<span className="op-arrow">{" -> "}<code>{op.target}</code></span></span><span className="op-note">{op.reason ?? op.method}</span></div>;
 }
 
 function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runAction: (label: string, fn: () => Promise<unknown>) => void }) {

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -7,6 +7,12 @@ import { FirstRunPage } from "./panel/FirstRunPage";
 import { DoctorPage } from "./panel/DoctorPage";
 import { OperationLogRow } from "./OperationLogRow";
 import { SkillMAuditHistory } from "./SkillMAuditHistory";
+import {
+  operationActionLabel,
+  operationDetailParts,
+  operationStatusLabel,
+  operationSubjectLabel,
+} from "../lib/operation_labels";
 
 type SkillMPage = PanelPageKey | "market" | "forge";
 type ToastKind = "ok" | "err" | "info" | "sync";
@@ -104,6 +110,11 @@ function agentsForSkill(skill: Skill, targets: Target[]) {
 
 function registryLabel(root: string | null) {
   return root?.replace(/^\/Users\/[^/]+/, "~") ?? "~/.loom-registry";
+}
+
+function panelHostLabel() {
+  if (typeof window === "undefined") return "local panel";
+  return window.location.host || "local panel";
 }
 
 function statusText(ok: boolean, warn: boolean) {
@@ -228,7 +239,8 @@ export function SkillMPanel() {
     window.setTimeout(() => setToasts((items) => items.filter((item) => item.id !== id)), 3200);
   };
 
-  const runAction = async (label: string, fn: () => Promise<unknown>) => {
+  const runAction = async (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => {
+    if (options?.confirm && typeof window !== "undefined" && !window.confirm(options.confirm)) return;
     try {
       await fn();
       toast("ok", `${label} completed`);
@@ -282,7 +294,7 @@ export function SkillMPanel() {
           {termOpen && <Terminal live={live} close={() => setTermOpen(false)} />}
         </main>
       </div>
-      <StatusBar live={live} counts={counts} dark={dark} setDark={setDark} onSync={() => runAction("Replay / sync", api.syncReplay)} onTerm={() => setTermOpen((open) => !open)} onTweaks={() => setTweaksOpen((open) => !open)} />
+      <StatusBar live={live} counts={counts} dark={dark} setDark={setDark} onSync={() => go("sync")} onTerm={() => setTermOpen((open) => !open)} onTweaks={() => setTweaksOpen((open) => !open)} />
       {paletteOpen && <Palette skills={live.skills} go={(page) => { go(page); setPaletteOpen(false); }} openSkill={(name) => { setSelectedSkill(name); go("skills"); setPaletteOpen(false); }} close={() => setPaletteOpen(false)} />}
       {tweaksOpen && <Tweaks dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} close={() => setTweaksOpen(false)} />}
       <Toasts items={toasts} dismiss={(id) => setToasts((items) => items.filter((item) => item.id !== id))} />
@@ -488,43 +500,73 @@ function Skills({ skills, targets, query, setQuery, selected, setSelectedSkill }
         <div className="chip-group">{tags.map((tag) => <button key={tag} className="chip" onClick={() => setQuery(tag)}>#{tag}</button>)}</div>
         <div className="sort-group"><span className="sort-label">排序</span>{[["name", "名称"], ["edges", "投影"], ["bindings", "绑定"]].map(([id, label]) => <button key={id} className={`sort-pill ${sort === id ? "on" : ""}`} onClick={() => setSort(id)}>{label}</button>)}</div>
       </div>
-      <div className="lib-grid">
-        {shown.map((skill) => (
-          <article key={skill.name} className={`skill-card ${selected?.name === skill.name ? "sel" : ""}`} onClick={() => setSelectedSkill(skill.name)}>
-            <div className="sc-head"><Glyph>{skill.name}</Glyph><div className="sc-title"><h3>{skill.name}</h3><span className="sc-meta">{sourceLabel(skill)} · {skill.changed}</span></div><Switch on={(skill.observedTargetIds?.length ?? 0) > 0 || skill.projectionCount > 0} onChange={() => undefined} /></div>
-            <p className="sc-desc">{skill.description || "No description from backend."}</p>
-            <div className="sc-signals"><span className={`sec-badge small ${skill.sourceStatus === "present" ? "verified" : "caution"}`}>{skill.sourceStatus}</span><span className="sc-cat">{skill.bindingCount} bindings</span><span className="sc-cat">{skill.projectionCount} projections</span></div>
-            <div className="sc-tools">{agentsForSkill(skill, targets).slice(0, 3).map((agent) => <span key={agent} className="tool-pill on" style={{ "--tc": agentMeta[agent]?.color ?? "var(--acc2)" } as CSSProperties}><i />{agentMeta[agent]?.short ?? agent.slice(0, 2).toUpperCase()}</span>)}<span className="sc-scope">{agentsForSkill(skill, targets).length > 0 ? "real target rows" : "no target rows"}</span></div>
-            <div className="sc-foot"><span className="sc-tags"><span className="sm-tag">#{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span></span><span className="sc-calls">{skill.projectionCount} edges</span></div>
-          </article>
-        ))}
-        {shown.length === 0 && <div className="lib-empty"><Icon d="lib" size={28} /><p>没有匹配当前筛选的 skill</p></div>}
+      <div className="lib-layout">
+        <div className="lib-grid" role="list" aria-label="Skill list">
+          {shown.map((skill) => {
+            const targetAgents = agentsForSkill(skill, targets);
+            const active = (skill.observedTargetIds?.length ?? 0) > 0 || skill.projectionCount > 0;
+            const isSelected = selected?.name === skill.name;
+            return (
+              <article
+                key={skill.name}
+                className={`skill-card ${isSelected ? "sel" : ""}`}
+                role="button"
+                tabIndex={0}
+                aria-pressed={isSelected}
+                aria-label={`查看 ${skill.name} 详情`}
+                onClick={() => setSelectedSkill(skill.name)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    setSelectedSkill(skill.name);
+                  }
+                }}
+              >
+                <div className="sc-head"><Glyph>{skill.name}</Glyph><div className="sc-title"><h3>{skill.name}</h3><span className="sc-meta">{sourceLabel(skill)} · {skill.changed}</span></div><span className={`sc-state ${active ? "on" : ""}`}>{active ? "已连接" : "未连接"}</span></div>
+                <p className="sc-desc">{skill.description || "No description from backend."}</p>
+                <div className="sc-signals"><span className={`sec-badge small ${skill.sourceStatus === "present" ? "verified" : "caution"}`}>{skill.sourceStatus}</span><span className="sc-cat">{skill.bindingCount} bindings</span><span className="sc-cat">{skill.projectionCount} projections</span></div>
+                <div className="sc-tools">{targetAgents.slice(0, 3).map((agent) => <span key={agent} className="tool-pill on" style={{ "--tc": agentMeta[agent]?.color ?? "var(--acc2)" } as CSSProperties}><i />{agentMeta[agent]?.short ?? agent.slice(0, 2).toUpperCase()}</span>)}<span className="sc-scope">{targetAgents.length > 0 ? "real target rows" : "no target rows"}</span></div>
+                <div className="sc-foot"><span className="sc-tags"><span className="sm-tag">#{skill.tag}</span><span className="sm-tag">{skill.latestRev}</span></span><span className="sc-calls">查看详情</span></div>
+              </article>
+            );
+          })}
+          {shown.length === 0 && <div className="lib-empty"><Icon d="lib" size={28} /><p>没有匹配当前筛选的 skill</p></div>}
+        </div>
+        <SkillDetail skill={selected} />
       </div>
-      {selected && (
-        <section className="skill-detail panel">
-          <div className="det-head">
-            <div className="det-title"><Glyph>{selected.name}</Glyph><div><h2>{selected.name}</h2><p>{selected.description || "No backend description."}</p></div></div>
-            <span className="sec-badge good"><Icon d="shield" />{selected.sourceStatus}</span>
-          </div>
-          <div className="det-stats">
-            <Stat label="Bindings" value={selected.bindingCount} sub="routing rules" icon="branch" />
-            <Stat label="Projections" value={selected.projectionCount} sub="materialized edges" icon="graph" />
-            <Stat label="Latest rev" value={selected.latestRev} sub="backend reported" icon="clock" />
-            <Stat label="Targets" value={selected.targets.length + (selected.observedTargetIds?.length ?? 0)} sub="observed + projected" icon="target" />
-          </div>
-        </section>
-      )}
     </div>
+  );
+}
+
+function SkillDetail({ skill }: { skill: Skill | null }) {
+  if (!skill) {
+    return <aside className="skill-detail panel"><div className="panel-empty">选择一个 skill 查看来源、目标和投影统计。</div></aside>;
+  }
+  const targetCount = skill.targets.length + (skill.observedTargetIds?.length ?? 0);
+  return (
+    <aside className="skill-detail panel" aria-label={`${skill.name} detail`}>
+      <div className="det-head">
+        <div className="det-title"><Glyph>{skill.name}</Glyph><div><h2>{skill.name}</h2><p>{skill.description || "No backend description."}</p></div></div>
+        <span className="sec-badge good"><Icon d="shield" />{skill.sourceStatus}</span>
+      </div>
+      <div className="det-metrics">
+        <div><span>Bindings</span><b>{skill.bindingCount}</b><em>routing rules</em></div>
+        <div><span>Projections</span><b>{skill.projectionCount}</b><em>materialized edges</em></div>
+        <div><span>Latest rev</span><b>{skill.latestRev}</b><em>backend reported</em></div>
+        <div><span>Targets</span><b>{targetCount}</b><em>observed + projected</em></div>
+      </div>
+    </aside>
   );
 }
 
 function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: "targets" | "bindings" | "projections"; go: (page: SkillMPage) => void }) {
   const drifts = live.projections.filter((p) => p.observed_drift || p.health === "drift").length;
   const pending = live.queuedWriteCount + live.ops.filter((op) => op.status === "pending").length;
+  const panelHost = panelHostLabel();
   return (
     <div className="view view-plane">
       <header className="view-head"><div><h1>控制平面</h1><p>把注册表里的 skill 通过 binding 投影到各 agent 目录 · symlink / copy / materialize</p></div><button className="btn-grad sm disabled"><Icon d="branch" size={14} />应用全部投影</button></header>
-      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />Git 注册表</span><code>{registryLabel(live.registryRoot)}</code><span className="rs-div" /><span className="rs-stat"><b>{live.skills.length}</b> skills · <b>{live.targets.length}</b> targets</span><span className="rs-div" /><span className="rs-guard"><Icon d="bolt" size={12} />硬写保护 已开</span><span className="rs-flex" /><button className="rs-panel"><Icon d="eye" size={13} />localhost:5173</button></div>
+      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />Git 注册表</span><code>{registryLabel(live.registryRoot)}</code><span className="rs-div" /><span className="rs-stat"><b>{live.skills.length}</b> skills · <b>{live.targets.length}</b> targets</span><span className="rs-div" /><span className="rs-guard"><Icon d="bolt" size={12} />硬写保护 已开</span><span className="rs-flex" /><span className="rs-panel" title="当前 Panel 地址"><Icon d="eye" size={13} />{panelHost}</span></div>
       <div className="plane-stats">
         <button className="pstat" onClick={() => go("targets")}><span className="pstat-l">Targets</span><span className="pstat-n">{live.targets.length}</span></button>
         <button className="pstat" onClick={() => go("bindings")}><span className="pstat-l">Bindings</span><span className="pstat-n">{live.bindings.length}</span></button>
@@ -602,7 +644,7 @@ function EmptyPanel({ text }: { text: string }) {
   return <div className="panel"><div className="panel-empty">{text}</div></div>;
 }
 
-function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; go: (page: SkillMPage) => void; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
+function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; go: (page: SkillMPage) => void; runAction: (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => void }) {
   const failed = live.ops.filter((op) => op.status === "err").length;
   const pending = live.ops.filter((op) => op.status === "pending").length + live.queuedWriteCount;
   const queue = live.ops.filter((op) => op.status !== "ok");
@@ -611,7 +653,7 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
     <div className="view view-ops">
       <header className="view-head">
         <div><h1>Ops &amp; 审计</h1><p>每条命令都来自 live API · 可重放、可诊断、可清理</p></div>
-        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge)}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry)}><Icon d="sync" />replay 队列</button></div>
+        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge, { confirm: "确定要清理当前操作队列吗？这个动作会修改本地操作状态。" })}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry, { confirm: "确定要重放当前待处理队列吗？" })}><Icon d="sync" />replay 队列</button></div>
       </header>
       <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
       <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
@@ -620,16 +662,20 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
   );
 }
 
-function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runAction: (label: string, fn: () => Promise<unknown>) => void }) {
+function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runAction: (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => void }) {
   const remote = live.remote;
   const remoteConfigured = Boolean(remote?.configured || remote?.url || remote?.remote);
+  const confirmReplay = { confirm: "确定要重放同步队列吗？这会修改本地注册表同步状态。" };
   return (
     <div className="view view-sync">
-      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><button className="btn-ghost sm disabled"><Icon d="dl" size={14} />sync pull</button><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" />replay</button></div></header>
-      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || remote?.remote || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-div" /><span className="rs-stat">pending <b>{remote?.pending_ops ?? live.queuedWriteCount}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay)}><Icon d="sync" size={13} />replay</button></div>
+      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><button className="btn-ghost sm disabled"><Icon d="dl" size={14} />sync pull</button><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" />replay</button></div></header>
+      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || remote?.remote || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-div" /><span className="rs-stat">pending <b>{remote?.pending_ops ?? live.queuedWriteCount}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" size={13} />replay</button></div>
       <div className="sync-grid">
         <section className="panel sync-topo-panel"><div className="panel-head"><h3><Icon d="sync" />注册表拓扑</h3><span className="panel-hint">{remoteConfigured ? "local -> origin" : "local only"}</span></div><svg viewBox="0 0 640 300" className="sync-topo"><path className={`beam ${remoteConfigured ? "on" : ""}`} stroke="var(--acc3)" d="M150 220 C150 112 320 132 320 86" /><circle className="topo-cloud" cx="320" cy="78" r="34" /><text x="320" y="82" textAnchor="middle" className="topo-name">origin</text><text x="320" y="104" textAnchor="middle" className="topo-sub">{remoteConfigured ? "configured" : "not configured"}</text><circle className="topo-node self" cx="150" cy="220" r="38" /><text x="150" y="218" textAnchor="middle" className="topo-name">local</text><text x="150" y="235" textAnchor="middle" className="topo-sub">{remote?.pending_ops ?? live.queuedWriteCount} pending</text></svg></section>
-        <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{live.ops.length} events</span></div><div className="ev-stream">{live.ops.slice(0, 6).map((op) => <div key={op.id} className={`ev-row ev-${operationTone(op.status)}`}><span className="ev-ic"><Icon d={op.status === "ok" ? "check" : op.status === "err" ? "bolt" : "sync"} size={13} /></span><span className="ev-time">{op.time}</span><span className="ev-text">{op.kind} <b>{op.skill}</b></span><span className="ev-dev">{op.target}</span></div>)}{live.ops.length === 0 && <div className="panel-empty">No sync activity yet.</div>}</div></section>
+        <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{live.ops.length} events</span></div><div className="ev-stream">{live.ops.slice(0, 6).map((op) => {
+          const details = operationDetailParts(op).filter((part) => !part.startsWith("id ")).slice(0, 2);
+          return <div key={op.id} className={`ev-row ev-${operationTone(op.status)}`}><span className="ev-ic"><Icon d={op.status === "ok" ? "check" : op.status === "err" ? "bolt" : "sync"} size={13} /></span><span className="ev-time">{op.time}</span><span className="ev-text"><b>{operationActionLabel(op.kind)}</b><span>{operationSubjectLabel(op)}</span></span><span className="ev-dev">{details.join(" · ") || operationStatusLabel(op.status)}</span></div>;
+        })}{live.ops.length === 0 && <div className="panel-empty">No sync activity yet.</div>}</div></section>
       </div>
     </div>
   );
@@ -644,7 +690,7 @@ function Settings({ live, dark, setDark, density, setDensity, accent, setAccent 
   return (
     <div className="view view-settings">
       <header className="view-head"><div><h1>Settings</h1><p>注册表根、远端、写保护与外观 · 与 loom workspace 配置一致</p></div></header>
-      <section className="set-card"><div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Git 支撑的注册表所在目录</p></div><code className="set-v">{registryLabel(live.registryRoot)}</code></div><div className="set-row"><div className="set-k"><h4>Remote origin</h4><p>团队注册表推送地址</p></div><code className="set-v">{live.remote?.url ?? live.remote?.remote ?? "not configured"}</code></div><div className="set-row"><div className="set-k"><h4>写保护</h4><p>当前 API 未暴露该配置状态</p></div><code className="set-v">backend field missing</code></div></section>
+      <section className="set-card"><div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Git 支撑的注册表所在目录</p></div><code className="set-v">{registryLabel(live.registryRoot)}</code></div><div className="set-row"><div className="set-k"><h4>Remote origin</h4><p>团队注册表推送地址</p></div><code className="set-v">{live.remote?.url ?? live.remote?.remote ?? "not configured"}</code></div><div className="set-row"><div className="set-k"><h4>写保护</h4><p>当前 API 未暴露该配置状态</p></div><code className="set-v">未暴露</code></div></section>
       <section className="set-card"><div className="set-cardhead"><h3>Agent directories ({live.agentDirs.length})</h3><span>来自 workspace/info.agent_dirs</span></div><div className="set-agents">{live.agentDirs.map((dir) => <span key={`${dir.agent}-${dir.path}`} className="set-agent" title={dir.path}><span className="tc-agent" style={{ background: agentMeta[dir.agent]?.color }}>{agentMeta[dir.agent]?.short ?? dir.agent.slice(0, 2).toUpperCase()}</span>{dir.agent}<code>{dir.env_var ?? "no env"}</code></span>)}</div>{live.agentDirs.length === 0 && <div className="panel-empty">workspace/info 没有返回 agent_dirs。</div>}</section>
       <section className="set-card"><div className="set-cardhead"><h3>外观</h3><span>本机偏好</span></div>
         <div className="set-row"><div className="set-k"><h4>Theme</h4><p>深色模式</p></div><Switch on={dark} onChange={setDark} /></div>
@@ -660,11 +706,11 @@ function Switch({ on, onChange }: { on: boolean; onChange: (value: boolean) => v
 }
 
 function Market({ live }: { live: ReturnType<typeof usePanelData> }) {
-  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>Loom V1 没有 marketplace/catalog backend contract</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>local registry skills</span></div><span className="reg-div" /><div className="reg-stat"><b>missing</b><span>catalog contract</span></div><span className="reg-flex" /><span className="reg-src">来源：live registry only</span></div><EmptyPanel text="未接入真实 catalog API，所以不展示市场分类或安装流。" /></div>;
+  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>当前只连接本地注册表，尚未接入市场目录服务</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>本地 skills</span></div><span className="reg-div" /><div className="reg-stat"><b>未接入</b><span>市场目录</span></div><span className="reg-flex" /><span className="reg-src">来源：本地注册表</span></div><EmptyPanel text="未接入真实市场目录 API，所以不展示市场分类或安装流。" /></div>;
 }
 
 function Forge({ live }: { live: ReturnType<typeof usePanelData> }) {
-  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>Loom V1 没有 create-wizard/docs-ingestion/transcript backend contract</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>local skills available for reference</span></div><span className="reg-div" /><div className="reg-stat"><b>missing</b><span>write contract</span></div><span className="reg-flex" /><span className="reg-src">未创建任何本地草稿</span></div><EmptyPanel text="未接入真实创建向导 API，所以不展示模板、AI 生成、文档导入或发布步骤。" /></div>;
+  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>当前只读展示本地 skill，尚未接入创建向导</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>可参考 skills</span></div><span className="reg-div" /><div className="reg-stat"><b>未接入</b><span>写入流程</span></div><span className="reg-flex" /><span className="reg-src">未创建任何本地草稿</span></div><EmptyPanel text="未接入真实创建向导 API，所以不展示模板、AI 生成、文档导入或发布步骤。" /></div>;
 }
 
 function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; close: () => void }) {

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -7,6 +7,7 @@ import { FirstRunPage } from "./panel/FirstRunPage";
 import { DoctorPage } from "./panel/DoctorPage";
 import { OperationLogRow } from "./OperationLogRow";
 import { SkillMAuditHistory } from "./SkillMAuditHistory";
+import { loadSkillMPreferences, saveSkillMPreferences } from "../lib/skillm_prefs";
 import {
   operationActionLabel,
   operationDetailParts,
@@ -26,11 +27,11 @@ interface Toast {
 const iconPath: Record<string, string> = {
   dash: "M3 3h7v9H3zM14 3h7v5h-7zM14 12h7v9h-7zM3 16h7v5H3z",
   lib: "M4 4h4v16H4zM10 4h4v16h-4zM16.5 4.5l4 1-3.5 15-4-1z",
-  target: "M12 3a9 9 0 109 9 9 9 9 0 00-9-9zm0 4a5 5 0 105 5 5 5 0 00-5-5zm0 3a2 2 0 102 2 2 2 0 00-2-2z",
+  target: "M12 2v4M12 18v4M2 12h4M18 12h4M8 12a4 4 0 1 0 8 0 4 4 0 0 0-8 0",
   branch: "M6 3v12M6 15a3 3 0 103 3M18 9a3 3 0 10-3-3M18 9a9 9 0 01-9 9",
   graph: "M5 5a2 2 0 104 0 2 2 0 10-4 0M15 12a2 2 0 104 0 2 2 0 10-4 0M7 19a2 2 0 104 0 2 2 0 10-4 0M7.5 6.5l8 4.5M9.5 17.5l6-4.5",
   ops: "M4 6h10M4 12h7M4 18h10M17 7l2.5 2.5L17 12M19 16l-2.5 2.5L14 16",
-  clock: "M12 3a9 9 0 109 9 9 9 9 0 00-9-9zm0 4v5l3.5 2",
+  clock: "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18M12 7v5l3.5 2",
   sync: "M21 12a9 9 0 01-15.5 6.2M3 12a9 9 0 0115.5-6.2M3 12l3-3M3 12l3 3M21 12l-3-3M21 12l-3 3",
   shield: "M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6zM9 12l2 2 4-4",
   gear: "M12 8a4 4 0 100 8 4 4 0 000-8zM19 12a7 7 0 00-.1-1.2l2.1-1.6-2-3.4-2.4 1a7 7 0 00-2.1-1.2L14 3h-4l-.5 2.6a7 7 0 00-2.1 1.2l-2.4-1-2 3.4 2.1 1.6A7 7 0 005 12a7 7 0 00.1 1.2L3 14.8l2 3.4 2.4-1a7 7 0 002.1 1.2L10 21h4l.5-2.6a7 7 0 002.1-1.2l2.4 1 2-3.4-2.1-1.6A7 7 0 0019 12z",
@@ -129,6 +130,10 @@ function operationTone(status: Op["status"]) {
   return "pending";
 }
 
+function pendingQueueCount(live: ReturnType<typeof usePanelData>) {
+  return Math.max(live.queuedWriteCount, live.ops.filter((op) => op.status === "pending").length);
+}
+
 function methodTone(method: string) {
   if (method === "materialize") return "var(--acc1)";
   if (method === "copy") return "var(--acc2)";
@@ -192,23 +197,24 @@ function buildSkillMetrics(skills: Skill[], ops: Op[]): SkillMetric[] {
 
 export function SkillMPanel() {
   const live = usePanelData();
+  const initialPrefs = useMemo(loadSkillMPreferences, []);
   const [view, setView] = useState<SkillMPage>(initialView);
   const [query, setQuery] = useState("");
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [termOpen, setTermOpen] = useState(false);
   const [tweaksOpen, setTweaksOpen] = useState(false);
-  const [dark, setDark] = useState(true);
-  const [density, setDensity] = useState<"compact" | "regular" | "comfy">("regular");
-  const [accent, setAccent] = useState(["#ff0080", "#7928ca", "#00d9ff"]);
+  const [dark, setDark] = useState(initialPrefs.dark);
+  const [density, setDensity] = useState(initialPrefs.density);
+  const [accent, setAccent] = useState(initialPrefs.accent);
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const counts = useMemo(() => {
     const failedOps = live.ops.filter((op) => op.status === "err").length;
     const drifted = live.projections.filter((p) => p.observed_drift || p.health === "drift").length;
-    const pending = live.queuedWriteCount + live.ops.filter((op) => op.status === "pending").length;
+    const pending = pendingQueueCount(live);
     return { failedOps, drifted, pending, attention: failedOps + drifted + pending };
-  }, [live.ops, live.projections, live.queuedWriteCount]);
+  }, [live]);
 
   const filteredSkills = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -266,6 +272,10 @@ export function SkillMPanel() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
+
+  useEffect(() => {
+    saveSkillMPreferences({ dark, density, accent });
+  }, [accent, dark, density]);
 
   return (
     <div
@@ -493,7 +503,7 @@ function Skills({ skills, targets, query, setQuery, selected, setSelectedSkill }
     <div className="view view-lib">
       <header className="view-head">
         <div><h1>技能库</h1><p>{skills.length} 个 skill · live registry inventory · 真实后端数据</p></div>
-        <div className="lib-head-right"><div className="searchbox"><Icon d="search" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索 skill…（名称 / 描述 / 标签）" /><kbd>⌘K</kbd></div><button className="btn-grad sm disabled"><Icon d="plus" size={14} />skill add</button></div>
+        <div className="lib-head-right"><div className="searchbox"><Icon d="search" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索 skill…（名称 / 描述 / 标签）" /><kbd>⌘K</kbd></div><span className="soon-pill"><Icon d="plus" size={14} />新增入口未接入</span></div>
       </header>
       <div className="filter-bar">
         <div className="chip-group">{["all", "observed", "present", "missing", "non-compliant"].map((item) => <button key={item} className={`chip ${source === item ? "on" : ""}`} onClick={() => setSource(item)}>{item === "all" ? "全部来源" : item}</button>)}</div>
@@ -561,11 +571,11 @@ function SkillDetail({ skill }: { skill: Skill | null }) {
 
 function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: "targets" | "bindings" | "projections"; go: (page: SkillMPage) => void }) {
   const drifts = live.projections.filter((p) => p.observed_drift || p.health === "drift").length;
-  const pending = live.queuedWriteCount + live.ops.filter((op) => op.status === "pending").length;
+  const pending = pendingQueueCount(live);
   const panelHost = panelHostLabel();
   return (
     <div className="view view-plane">
-      <header className="view-head"><div><h1>控制平面</h1><p>把注册表里的 skill 通过 binding 投影到各 agent 目录 · symlink / copy / materialize</p></div><button className="btn-grad sm disabled"><Icon d="branch" size={14} />应用全部投影</button></header>
+      <header className="view-head"><div><h1>控制平面</h1><p>把注册表里的 skill 通过 binding 投影到各 agent 目录 · symlink / copy / materialize</p></div><span className="soon-pill"><Icon d="branch" size={14} />批量投影未接入</span></header>
       <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />Git 注册表</span><code>{registryLabel(live.registryRoot)}</code><span className="rs-div" /><span className="rs-stat"><b>{live.skills.length}</b> skills · <b>{live.targets.length}</b> targets</span><span className="rs-div" /><span className="rs-guard"><Icon d="bolt" size={12} />硬写保护 已开</span><span className="rs-flex" /><span className="rs-panel" title="当前 Panel 地址"><Icon d="eye" size={13} />{panelHost}</span></div>
       <div className="plane-stats">
         <button className="pstat" onClick={() => go("targets")}><span className="pstat-l">Targets</span><span className="pstat-n">{live.targets.length}</span></button>
@@ -577,8 +587,8 @@ function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: 
       <nav className="plane-tabs">
         {([["projections", "投影关系图", "graph"], ["targets", "Targets", "target"], ["bindings", "Bindings", "branch"]] as const).map(([id, label, icon]) => <button key={id} className={`det-tab ${tab === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={icon} size={14} />{label}</button>)}
         <span className="tab-flex" />
-        {tab === "targets" ? <button className="btn-ghost sm disabled"><Icon d="plus" size={13} />target add</button> : null}
-        {tab === "bindings" ? <button className="btn-ghost sm disabled"><Icon d="plus" size={13} />binding add</button> : null}
+        {tab === "targets" ? <span className="soon-pill"><Icon d="plus" size={13} />target 新增未接入</span> : null}
+        {tab === "bindings" ? <span className="soon-pill"><Icon d="plus" size={13} />binding 新增未接入</span> : null}
       </nav>
       {tab === "targets" && <div className="targets-grid">{live.targets.map((t) => <TargetCard key={t.id} target={t} />)}{live.targets.length === 0 && <EmptyPanel text="No target rows from backend." />}</div>}
       {tab === "bindings" && <BindingsTable bindings={live.bindings} />}
@@ -595,7 +605,7 @@ function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: 
 
 function TargetCard({ target }: { target: Target }) {
   const meta = agentMeta[target.agent] ?? { name: target.agent, short: target.agent.slice(0, 2).toUpperCase(), color: "var(--acc2)" };
-  return <article className="target-card" style={{ "--ac": meta.color } as CSSProperties}><div className="tc-head"><span className="tc-agent" style={{ background: meta.color }}>{meta.short}</span><div className="tc-title"><h3>{meta.name}</h3><code>{target.path}</code></div><OwnBadge ownership={target.ownership} /></div><div className="tc-meta"><span>profile <b>{target.profile}</b></span><span>{target.projectedSkills ?? 0} 个投影</span><span className="tc-ok"><Icon d="check" size={11} />同步</span></div><div className="tc-actions"><button className="btn-ghost xs disabled">verify</button><button className="btn-ghost xs disabled">{target.ownership === "observed" ? "转 managed" : "capture"}</button></div></article>;
+  return <article className="target-card" style={{ "--ac": meta.color } as CSSProperties}><div className="tc-head"><span className="tc-agent" style={{ background: meta.color }}>{meta.short}</span><div className="tc-title"><h3>{meta.name}</h3><code>{target.path}</code></div><OwnBadge ownership={target.ownership} /></div><div className="tc-meta"><span>profile <b>{target.profile}</b></span><span>{target.projectedSkills ?? 0} 个投影</span><span className="tc-ok"><Icon d="check" size={11} />同步</span></div><div className="tc-actions"><span className="mini-state">verify 未接入</span><span className="mini-state">{target.ownership === "observed" ? "managed 转换未接入" : "capture 未接入"}</span></div></article>;
 }
 
 function OwnBadge({ ownership }: { ownership: string }) {
@@ -604,7 +614,7 @@ function OwnBadge({ ownership }: { ownership: string }) {
 }
 
 function BindingsTable({ bindings }: { bindings: ReturnType<typeof usePanelData>["bindings"] }) {
-  return <div className="bindings-table"><div className="bt-head"><span>Skill</span><span>Policy</span><span>Matcher</span><span>Target</span><span>方式</span><span /></div>{bindings.map((b) => <div className="bt-row" key={b.id}><span className="bt-skill"><Glyph>{b.skill}</Glyph>{b.skill}</span><span className="bt-agent"><i />{b.policy}</span><span className="bt-matcher"><b>{b.matcher.split(":")[0]}</b><code>{b.matcher.split(":").slice(1).join(":") || "—"}</code></span><span className="bt-target"><code>{shortName(b.target)}</code></span><span><MethodTag method={b.method} /></span><span className="bt-act"><button className="btn-icon disabled"><Icon d="branch" size={14} /></button></span></div>)}{bindings.length === 0 && <div className="panel-empty">No bindings yet. Create a real binding before Loom can materialize projections.</div>}</div>;
+  return <div className="bindings-table"><div className="bt-head"><span>Skill</span><span>Policy</span><span>Matcher</span><span>Target</span><span>方式</span><span /></div>{bindings.map((b) => <div className="bt-row" key={b.id}><span className="bt-skill"><Glyph>{b.skill}</Glyph>{b.skill}</span><span className="bt-agent"><i />{b.policy}</span><span className="bt-matcher"><b>{b.matcher.split(":")[0]}</b><code>{b.matcher.split(":").slice(1).join(":") || "—"}</code></span><span className="bt-target"><code>{shortName(b.target)}</code></span><span><MethodTag method={b.method} /></span><span className="bt-act"><span className="mini-state">只读</span></span></div>)}{bindings.length === 0 && <div className="panel-empty">No bindings yet. Create a real binding before Loom can materialize projections.</div>}</div>;
 }
 
 function DataGrid({ columns, rows }: { columns: string[]; rows: Array<Array<string | number>> }) {
@@ -646,8 +656,9 @@ function EmptyPanel({ text }: { text: string }) {
 
 function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; go: (page: SkillMPage) => void; runAction: (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => void }) {
   const failed = live.ops.filter((op) => op.status === "err").length;
-  const pending = live.ops.filter((op) => op.status === "pending").length + live.queuedWriteCount;
+  const pending = pendingQueueCount(live);
   const queue = live.ops.filter((op) => op.status !== "ok");
+  const queueCount = Math.max(queue.length, live.queuedWriteCount);
   const rows = history ? live.ops : queue;
   return (
     <div className="view view-ops">
@@ -656,7 +667,7 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
         <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge, { confirm: "确定要清理当前操作队列吗？这个动作会修改本地操作状态。" })}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry, { confirm: "确定要重放当前待处理队列吗？" })}><Icon d="sync" />replay 队列</button></div>
       </header>
       <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
-      <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queue.length ? <span className="tab-count">{queue.length}</span> : null}</button>)}<span className="tab-flex" /></nav>
+      <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queueCount ? <span className="tab-count">{queueCount}</span> : null}</button>)}<span className="tab-flex" /></nav>
       {history ? <SkillMAuditHistory live={live.live} refreshKey={live.lastUpdated} /> : <section className="ops-table">{rows.map((op) => <OperationLogRow key={op.id} op={op} />)}{rows.length === 0 && <div className="ops-empty"><Icon d="check" size={26} /><p>队列已清空 · 没有待处理或失败的操作</p></div>}</section>}
     </div>
   );
@@ -666,16 +677,17 @@ function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runA
   const remote = live.remote;
   const remoteConfigured = Boolean(remote?.configured || remote?.url || remote?.remote);
   const confirmReplay = { confirm: "确定要重放同步队列吗？这会修改本地注册表同步状态。" };
+  const syncOps = live.ops.filter((op) => op.kind.startsWith("sync."));
   return (
     <div className="view view-sync">
-      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><button className="btn-ghost sm disabled"><Icon d="dl" size={14} />sync pull</button><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" />replay</button></div></header>
+      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><span className="soon-pill"><Icon d="dl" size={14} />pull 未接入</span><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" />replay</button></div></header>
       <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || remote?.remote || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-div" /><span className="rs-stat">pending <b>{remote?.pending_ops ?? live.queuedWriteCount}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" size={13} />replay</button></div>
       <div className="sync-grid">
         <section className="panel sync-topo-panel"><div className="panel-head"><h3><Icon d="sync" />注册表拓扑</h3><span className="panel-hint">{remoteConfigured ? "local -> origin" : "local only"}</span></div><svg viewBox="0 0 640 300" className="sync-topo"><path className={`beam ${remoteConfigured ? "on" : ""}`} stroke="var(--acc3)" d="M150 220 C150 112 320 132 320 86" /><circle className="topo-cloud" cx="320" cy="78" r="34" /><text x="320" y="82" textAnchor="middle" className="topo-name">origin</text><text x="320" y="104" textAnchor="middle" className="topo-sub">{remoteConfigured ? "configured" : "not configured"}</text><circle className="topo-node self" cx="150" cy="220" r="38" /><text x="150" y="218" textAnchor="middle" className="topo-name">local</text><text x="150" y="235" textAnchor="middle" className="topo-sub">{remote?.pending_ops ?? live.queuedWriteCount} pending</text></svg></section>
-        <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{live.ops.length} events</span></div><div className="ev-stream">{live.ops.slice(0, 6).map((op) => {
+        <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{syncOps.length} sync events</span></div><div className="ev-stream">{syncOps.slice(0, 6).map((op) => {
           const details = operationDetailParts(op).filter((part) => !part.startsWith("id ")).slice(0, 2);
           return <div key={op.id} className={`ev-row ev-${operationTone(op.status)}`}><span className="ev-ic"><Icon d={op.status === "ok" ? "check" : op.status === "err" ? "bolt" : "sync"} size={13} /></span><span className="ev-time">{op.time}</span><span className="ev-text"><b>{operationActionLabel(op.kind)}</b><span>{operationSubjectLabel(op)}</span></span><span className="ev-dev">{details.join(" · ") || operationStatusLabel(op.status)}</span></div>;
-        })}{live.ops.length === 0 && <div className="panel-empty">No sync activity yet.</div>}</div></section>
+        })}{syncOps.length === 0 && <div className="panel-empty">No sync activity yet.</div>}</div></section>
       </div>
     </div>
   );
@@ -693,16 +705,16 @@ function Settings({ live, dark, setDark, density, setDensity, accent, setAccent 
       <section className="set-card"><div className="set-row"><div className="set-k"><h4>Registry root</h4><p>Git 支撑的注册表所在目录</p></div><code className="set-v">{registryLabel(live.registryRoot)}</code></div><div className="set-row"><div className="set-k"><h4>Remote origin</h4><p>团队注册表推送地址</p></div><code className="set-v">{live.remote?.url ?? live.remote?.remote ?? "not configured"}</code></div><div className="set-row"><div className="set-k"><h4>写保护</h4><p>当前 API 未暴露该配置状态</p></div><code className="set-v">未暴露</code></div></section>
       <section className="set-card"><div className="set-cardhead"><h3>Agent directories ({live.agentDirs.length})</h3><span>来自 workspace/info.agent_dirs</span></div><div className="set-agents">{live.agentDirs.map((dir) => <span key={`${dir.agent}-${dir.path}`} className="set-agent" title={dir.path}><span className="tc-agent" style={{ background: agentMeta[dir.agent]?.color }}>{agentMeta[dir.agent]?.short ?? dir.agent.slice(0, 2).toUpperCase()}</span>{dir.agent}<code>{dir.env_var ?? "no env"}</code></span>)}</div>{live.agentDirs.length === 0 && <div className="panel-empty">workspace/info 没有返回 agent_dirs。</div>}</section>
       <section className="set-card"><div className="set-cardhead"><h3>外观</h3><span>本机偏好</span></div>
-        <div className="set-row"><div className="set-k"><h4>Theme</h4><p>深色模式</p></div><Switch on={dark} onChange={setDark} /></div>
-        <div className="set-row"><div className="set-k"><h4>Accent</h4><p>Neon / Aurora / Sunset</p></div><div className="twk-chips">{themes.map((theme) => <button key={theme.join("")} className="twk-chip" data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
+        <div className="set-row"><div className="set-k"><h4>Theme</h4><p>深色模式</p></div><Switch label="切换深色模式" on={dark} onChange={setDark} /></div>
+        <div className="set-row"><div className="set-k"><h4>Accent</h4><p>Neon / Aurora / Sunset</p></div><div className="twk-chips">{themes.map((theme, index) => <button key={theme.join("")} className="twk-chip" aria-label={`选择配色 ${index + 1}`} data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
         <div className="set-row"><div className="set-k"><h4>Density</h4><p>Layout spacing</p></div><div className="twk-radio">{(["compact", "regular", "comfy"] as const).map((value) => <button key={value} data-on={density === value ? "1" : "0"} onClick={() => setDensity(value)}>{value}</button>)}</div></div>
       </section>
     </div>
   );
 }
 
-function Switch({ on, onChange }: { on: boolean; onChange: (value: boolean) => void }) {
-  return <button className={`sm-switch ${on ? "on" : ""}`} role="switch" aria-checked={on} onClick={() => onChange(!on)}><span className="knob" /></button>;
+function Switch({ on, onChange, label = "切换开关" }: { on: boolean; onChange: (value: boolean) => void; label?: string }) {
+  return <button className={`sm-switch ${on ? "on" : ""}`} role="switch" aria-label={label} aria-checked={on} onClick={() => onChange(!on)}><span className="knob" /></button>;
 }
 
 function Market({ live }: { live: ReturnType<typeof usePanelData> }) {
@@ -716,21 +728,26 @@ function Forge({ live }: { live: ReturnType<typeof usePanelData> }) {
 function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; close: () => void }) {
   return (
     <div className="sm-terminal">
-      <div className="term-head"><span><Icon d="term" /> TERMINAL - skillm shell</span><button className="btn-icon" onClick={close}><Icon d="x" /></button></div>
+      <div className="term-head"><span><Icon d="term" /> TERMINAL - read-only preview</span><button className="btn-icon" aria-label="关闭终端预览" onClick={close}><Icon d="x" /></button></div>
       <div className="term-body"><p>SkillM Terminal - read-only preview</p><p><b>$</b> loom workspace status</p><p>{live.live ? "registry live" : live.error ?? "offline"} · {live.skills.length} skills · {live.targets.length} targets · {live.queuedWriteCount} queued</p></div>
-      <div className="term-input"><span>&gt;</span><span>help · ls · doctor · sync</span></div>
+      <div className="term-note"><span>只读命令预览</span><code>help · ls · doctor · sync</code></div>
     </div>
   );
 }
 
 function Palette({ skills, go, openSkill, close }: { skills: Skill[]; go: (page: SkillMPage) => void; openSkill: (name: string) => void; close: () => void }) {
+  const [filter, setFilter] = useState("");
+  const q = filter.trim().toLowerCase();
+  const filteredPages = pages.filter((page) => !q || `${page.label} ${page.group}`.toLowerCase().includes(q));
+  const filteredSkills = skills.filter((skill) => !q || `${skill.name} ${skill.tag} ${skill.description ?? ""}`.toLowerCase().includes(q)).slice(0, 8);
   return (
     <div className="sm-veil" onMouseDown={close}>
       <div className="cmd-pal" onMouseDown={(event) => event.stopPropagation()}>
-        <div className="cmd-search"><Icon d="search" /><span>Command palette</span><button className="btn-icon" onClick={close}><Icon d="x" /></button></div>
+        <div className="cmd-search"><Icon d="search" /><input autoFocus value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="搜索页面或 skill" aria-label="搜索命令" /><button className="btn-icon" aria-label="关闭命令面板" onClick={close}><Icon d="x" /></button></div>
         <div className="cmd-list">
-          {pages.map((page) => <button key={page.id} className="cmd-item" onClick={() => go(page.id)}><Icon d={page.icon} />Go to {page.label}<span>{page.group}</span></button>)}
-          {skills.slice(0, 8).map((skill) => <button key={skill.name} className="cmd-item" onClick={() => openSkill(skill.name)}><Icon d="eye" />Open {skill.name}<span>{sourceLabel(skill)}</span></button>)}
+          {filteredPages.map((page) => <button key={page.id} className="cmd-item" onClick={() => go(page.id)}><Icon d={page.icon} />Go to {page.label}<span>{page.group}</span></button>)}
+          {filteredSkills.map((skill) => <button key={skill.name} className="cmd-item" onClick={() => openSkill(skill.name)}><Icon d="eye" />Open {skill.name}<span>{sourceLabel(skill)}</span></button>)}
+          {filteredPages.length + filteredSkills.length === 0 ? <div className="panel-empty">没有匹配的命令。</div> : null}
         </div>
       </div>
     </div>
@@ -741,11 +758,11 @@ function Tweaks({ dark, setDark, density, setDensity, accent, setAccent, close }
   const themes = [["#ff0080", "#7928ca", "#00d9ff"], ["#34d399", "#0ea5e9", "#a3e635"], ["#ff6b35", "#f43f5e", "#fbbf24"]];
   return (
     <aside className="twk-panel skillm-tweaks">
-      <div className="twk-hd"><b>Tweaks</b><button className="twk-x" onClick={close}>×</button></div>
+      <div className="twk-hd"><b>Tweaks</b><button className="twk-x" aria-label="关闭 Tweaks" onClick={close}>×</button></div>
       <div className="twk-body">
         <div className="twk-sect">视觉方向</div>
-        <div className="twk-row"><div className="twk-lbl"><span>配色（Neon / Aurora / Sunset）</span></div><div className="twk-chips">{themes.map((theme) => <button key={theme.join("")} className="twk-chip" data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
-        <div className="twk-row twk-row-h"><div className="twk-lbl"><span>深色模式</span></div><Switch on={dark} onChange={setDark} /></div>
+        <div className="twk-row"><div className="twk-lbl"><span>配色（Neon / Aurora / Sunset）</span></div><div className="twk-chips">{themes.map((theme, index) => <button key={theme.join("")} className="twk-chip" aria-label={`选择配色 ${index + 1}`} data-on={theme.join("") === accent.join("") ? "1" : "0"} onClick={() => setAccent(theme)}>{theme.map((color) => <i key={color} style={{ background: color }} />)}</button>)}</div></div>
+        <div className="twk-row twk-row-h"><div className="twk-lbl"><span>深色模式</span></div><Switch label="切换深色模式" on={dark} onChange={setDark} /></div>
         <div className="twk-sect">布局</div>
         <div className="twk-radio">{(["compact", "regular", "comfy"] as const).map((value) => <button key={value} data-on={density === value ? "1" : "0"} onClick={() => setDensity(value)}>{value}</button>)}</div>
       </div>

--- a/panel/src/pages/panel/DoctorPage.tsx
+++ b/panel/src/pages/panel/DoctorPage.tsx
@@ -74,7 +74,7 @@ export function DoctorPage({ apiReachable, mode, refreshKey, onNavigate }: Docto
             {state.message}
           </div>
         )}
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 18 }}>
+        <div className="kpi-row">
           <Kpi
             label="Health"
             value={state.kind === "ready" ? (state.payload.healthy ? "healthy" : "attention") : state.kind}

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -1206,10 +1206,34 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .op-arrow code{color:var(--sub);}
 .op-note{font-size:11px;color:var(--sub);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .op-act{display:flex;justify-content:flex-end;gap:6px;}
+.op-log-row{display:block;padding:0;}
+.op-log-row>summary{list-style:none;}
+.op-log-row>summary::-webkit-details-marker{display:none;}
+.op-row-main{display:grid;grid-template-columns:auto 78px minmax(118px,.42fr) minmax(0,1fr) auto auto;gap:12px;align-items:center;min-height:48px;padding:10px 14px;cursor:pointer;}
+.op-log-row[open] .op-row-main{border-bottom:1px solid var(--line1);background:color-mix(in oklch,var(--raise) 58%,transparent);}
+.op-main-subject{display:flex;align-items:center;gap:8px;min-width:0;font-family:var(--mono);font-size:12px;}
+.op-main-subject b{display:block;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700;color:var(--ink);}
+.op-main-subject code{display:block;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--faint);font-size:10.5px;background:var(--bg2);border:1px solid var(--line1);border-radius:6px;padding:2px 7px;}
+.op-count-chip,.op-more-chip{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--line1);border-radius:7px;background:var(--bg2);color:var(--sub);font-family:var(--mono);font-size:10.5px;font-weight:700;padding:4px 8px;white-space:nowrap;}
+.op-more-chip{color:var(--acc3);}
+.op-expanded{display:grid;grid-template-columns:minmax(220px,.7fr) minmax(0,1fr);gap:12px;padding:12px 14px 14px;background:color-mix(in oklch,var(--bg2) 42%,transparent);}
+.op-kv-grid{display:grid;grid-template-columns:58px minmax(0,1fr);gap:7px 10px;align-content:start;font-size:11px;}
+.op-kv-grid span,.op-skill-label{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--faint);}
+.op-kv-grid code{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--sub);font-family:var(--mono);font-size:11px;}
+.op-detail-line{grid-column:1/-1;color:var(--sub);font-size:11.5px;line-height:1.45;}
+.op-skill-block{grid-column:1/-1;display:grid;grid-template-columns:58px minmax(0,1fr);gap:8px 10px;align-items:start;}
+.op-skill-chips{display:flex;flex-wrap:wrap;gap:5px;max-height:118px;overflow:auto;padding-right:4px;}
+.op-skill-chips span{font-family:var(--mono);font-size:10.5px;color:var(--sub);border:1px solid var(--line1);background:var(--panel);border-radius:7px;padding:3px 7px;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .ops-empty{display:flex;flex-direction:column;align-items:center;gap:12px;padding:48px 0;color:var(--faint);text-align:center;}
 .ops-empty svg{color:var(--ok);}
 @media(max-width:980px){
   .op-row{display:flex;flex-wrap:wrap;align-items:center;gap:8px 10px;}
+  .op-log-row{display:block;}
+  .op-row-main{display:grid;grid-template-columns:auto auto minmax(0,1fr) auto;gap:8px 10px;}
+  .op-row-main .op-verb{grid-column:3;}
+  .op-main-subject{grid-column:1/-1;order:5;}
+  .op-count-chip{grid-column:3;justify-self:start;}
+  .op-expanded{grid-template-columns:1fr;}
   .op-row .op-note{display:none;}
   .op-detail{flex:1 1 100%;order:5;}
   .op-act{margin-left:auto;}

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -236,7 +236,9 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .chip-check{cursor:pointer;}
 .chip-check input{accent-color:var(--acc2);margin-right:2px;}
 
+.lib-layout{display:grid;grid-template-columns:minmax(0,1fr) minmax(300px,360px);gap:16px;align-items:start;}
 .lib-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px;}
+.lib-layout .lib-grid{grid-template-columns:repeat(auto-fill,minmax(280px,1fr));}
 .den-compact .lib-grid{grid-template-columns:repeat(auto-fill,minmax(290px,1fr));gap:11px;}
 .skill-card{background:color-mix(in oklch,var(--panel) 94%,transparent);border:1px solid var(--line1);border-radius:var(--r-lg);
   padding:17px 18px;cursor:pointer;transition:transform var(--t),box-shadow var(--t),border-color var(--t);
@@ -265,6 +267,8 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .tool-pill.on{color:var(--ink);border-color:var(--tc);background:color-mix(in oklch,var(--tc) 14%,transparent);}
 .tool-pill.on i{background:var(--tc);box-shadow:0 0 7px var(--tc);}
 .sc-scope{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--faint);}
+.sc-state{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--line1);background:var(--bg2);color:var(--faint);font-family:var(--mono);font-size:10px;font-weight:700;padding:3px 8px;border-radius:7px;white-space:nowrap;}
+.sc-state.on{color:var(--acc3);border-color:color-mix(in oklch,var(--acc3) 34%,transparent);background:color-mix(in oklch,var(--acc3) 10%,transparent);}
 .sc-foot{display:flex;align-items:center;gap:8px;}
 .sc-tags{display:flex;gap:4px;flex:1;flex-wrap:wrap;}
 .sc-calls{font-family:var(--mono);font-size:11px;color:var(--sub);white-space:nowrap;}
@@ -412,6 +416,10 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .ev-stream{display:flex;flex-direction:column;gap:2px;margin-bottom:14px;}
 .ev-row{display:grid;grid-template-columns:auto auto 1fr auto;gap:10px;align-items:center;padding:8px 10px;border-radius:8px;font-size:12px;transition:var(--t);}
 .ev-row:hover{background:var(--raise);}
+.ev-text{display:flex;flex-direction:column;gap:2px;min-width:0;}
+.ev-text b{font-family:var(--mono);font-size:11.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.ev-text span{font-family:var(--mono);font-size:11px;color:var(--sub);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.ev-dev{max-width:230px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .ev-ic{width:22px;height:22px;border-radius:7px;display:grid;place-items:center;flex:none;background:var(--raise);color:var(--sub);}
 .ev-push .ev-ic{color:var(--acc3);}.ev-pull .ev-ic{color:var(--acc2);}
 .ev-drift .ev-ic{color:var(--warn);background:color-mix(in oklch,var(--warn) 15%,transparent);}
@@ -1253,9 +1261,19 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .skill-card.sel{border-color:color-mix(in oklch,var(--acc2) 55%,transparent);box-shadow:var(--glow-shadow);}
 .sc-tags{display:flex;flex-wrap:wrap;gap:6px;margin:12px 0;}
 .sc-foot{display:flex;align-items:center;justify-content:space-between;gap:10px;padding-top:12px;border-top:1px solid var(--line1);font-family:var(--mono);font-size:11px;color:var(--faint);}
+.lib-layout .skill-detail{position:sticky;top:10px;max-height:calc(100vh - 138px);overflow:auto;margin-top:0;}
 .skill-detail{margin-top:18px;}
 .det-stats{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin-top:18px;}
 .det-stats .stat-card{width:100%;}
+.skill-detail .det-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px;}
+.skill-detail .det-title{display:flex;align-items:flex-start;gap:10px;min-width:0;}
+.skill-detail .det-title h2{margin:0;font-family:var(--mono);font-size:17px;line-height:1.25;overflow-wrap:anywhere;}
+.skill-detail .det-title p{margin:5px 0 0;color:var(--sub);font-size:12.5px;line-height:1.45;}
+.det-metrics{display:grid;grid-template-columns:1fr 1fr;gap:9px;}
+.det-metrics div{min-width:0;border:1px solid var(--line1);background:var(--bg2);border-radius:10px;padding:10px 11px;}
+.det-metrics span{display:block;font-family:var(--mono);font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;}
+.det-metrics b{display:block;margin-top:6px;font-family:var(--mono);font-size:18px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.det-metrics em{display:block;margin-top:2px;font-style:normal;font-size:11px;color:var(--sub);line-height:1.3;}
 .sec-badge{display:inline-flex;align-items:center;gap:6px;border-radius:99px;padding:7px 10px;font-family:var(--mono);font-size:11px;font-weight:700;border:1px solid var(--line2);color:var(--sub);}
 .sec-badge.good{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 35%,transparent);background:color-mix(in oklch,var(--ok) 10%,transparent);}
 .skillm-table{overflow:auto;}
@@ -1360,9 +1378,23 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .view-settings .twk-radio button[data-on="1"]{background:var(--panel);color:var(--ink);box-shadow:var(--card-shadow);}
 
 @media(max-width:980px){
+  .lib-layout{grid-template-columns:1fr;}
+  .lib-layout .skill-detail{position:static;max-height:none;order:-1;}
+  .lib-head-right{width:100%;align-items:stretch;flex-direction:column;}
+  .searchbox{min-width:0;width:100%;box-sizing:border-box;}
+  .searchbox kbd{display:none;}
+  .lib-head-right .btn-grad.sm.disabled{display:none;}
   .skillm-graph-grid{grid-template-columns:1fr;}
   .proj-svg{display:none;}
   .det-stats,.view-sync .sync-grid{grid-template-columns:1fr;}
   .view-first-run .kpi-row{grid-template-columns:1fr;}
   .skillm-tweaks{top:auto;bottom:42px;right:10px;}
+}
+
+@media(max-width:640px){
+  .sm-statusbar .sb-ver,
+  .sm-statusbar button.sb-item:not(.sb-sync),
+  .sm-statusbar .sb-flex{display:none;}
+  .sm-statusbar{gap:6px;overflow:hidden;}
+  .sm-statusbar .sb-item{min-width:0;}
 }

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -91,7 +91,7 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .view-head h1{font-size:30px;letter-spacing:-.02em;margin:0;font-weight:700;}
 .den-compact .view-head h1{font-size:25px;}
 .view-head p{margin:5px 0 0;color:var(--sub);font-size:14px;}
-.panel{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);
+.panel{min-width:0;background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line1);
   border-radius:var(--r-lg);padding:20px 22px;backdrop-filter:blur(8px);}
 .panel-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;}
 .panel-head h3{display:flex;align-items:center;gap:9px;font-size:15px;margin:0;font-weight:600;}
@@ -118,6 +118,8 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .btn-ghost.installed{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 40%,transparent);}
 .btn-icon{border:none;background:transparent;color:var(--sub);cursor:pointer;padding:6px;border-radius:8px;display:grid;place-items:center;transition:var(--t);}
 .btn-icon:hover{background:var(--raise);color:var(--ink);}
+.soon-pill,.mini-state{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line1);background:var(--raise);color:var(--sub);font-family:var(--mono);font-size:11px;font-weight:700;border-radius:9px;padding:7px 10px;white-space:nowrap;}
+.mini-state{font-size:10.5px;padding:4px 8px;border-radius:7px;}
 
 /* ---- shared atoms ---- */
 .sm-glyph{display:grid;place-items:center;border-radius:11px;font-family:var(--mono);font-weight:700;flex:none;
@@ -544,7 +546,7 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .im-step.ok .im-step-ic{background:var(--ok);border-color:transparent;color:#fff;}
 
 /* ============ terminal ============ */
-.sm-terminal{position:absolute;left:0;right:0;bottom:0;height:300px;z-index:30;display:flex;flex-direction:column;
+.sm-terminal{position:fixed;left:68px;right:0;bottom:30px;height:min(300px,calc(100vh - 86px));z-index:30;display:flex;flex-direction:column;
   background:color-mix(in oklch,var(--bg2) 97%,transparent);backdrop-filter:blur(16px);border-top:2px solid var(--acc2);
   box-shadow:0 -20px 60px -20px rgba(0,0,0,.6);animation:termIn .25s cubic-bezier(.2,.8,.2,1);}
 @keyframes termIn{from{transform:translateY(100%);}}
@@ -831,7 +833,7 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .sb-warn{color:var(--warn)!important;}
 .sb-live.warn{background:var(--warn);box-shadow:0 0 6px var(--warn);--sc:var(--warn);}
 /* registry strip */
-.reg-strip{display:flex;align-items:center;gap:12px;padding:12px 18px;border-radius:var(--r);margin-bottom:16px;flex-wrap:wrap;
+.reg-strip{display:flex;align-items:center;gap:12px;min-width:0;max-width:100%;padding:12px 18px;border-radius:var(--r);margin-bottom:16px;flex-wrap:wrap;
   background:linear-gradient(110deg,color-mix(in oklch,var(--acc2) 13%,var(--panel)),var(--panel) 72%);border:1px solid var(--line1);font-size:12.5px;}
 .rs-git{display:inline-flex;align-items:center;gap:7px;font-weight:600;color:var(--acc3);font-family:var(--mono);white-space:nowrap;}
 .reg-strip code{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--bg2);border:1px solid var(--line1);padding:3px 9px;border-radius:7px;white-space:nowrap;}
@@ -1183,7 +1185,7 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 
 /* ============ ops & audit ============ */
 .hl-code{font-family:var(--mono);font-size:12px;color:var(--acc3);background:var(--bg2);border:1px solid var(--line1);padding:1px 7px;border-radius:6px;}
-.ops-head-actions{display:flex;gap:8px;}
+.ops-head-actions{display:flex;gap:8px;min-width:0;}
 .ops-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:18px;}
 @media(max-width:980px){.ops-stats{grid-template-columns:repeat(2,1fr);}}
 .diag-card{background:color-mix(in oklch,var(--panel) 92%,transparent);border:1px solid var(--line2);border-radius:var(--r);padding:14px 16px;margin-bottom:16px;}
@@ -1294,6 +1296,8 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .op-failed{--oc:var(--err);}
 .op-err{--oc:var(--err);}
 .view-sync .sync-grid{display:grid;grid-template-columns:1.2fr .8fr;gap:14px;}
+.view-doctor .kpi-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:18px;}
+.view-doctor .kpi .value{overflow-wrap:normal;word-break:normal;}
 .set-card{display:flex;flex-direction:column;gap:0;}
 .set-row{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:16px 0;border-bottom:1px solid var(--line1);}
 .set-row:last-child{border-bottom:none;}
@@ -1312,10 +1316,11 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .skillm-grid-bg::after{content:"";position:absolute;inset:0;background:radial-gradient(circle at 20% 70%,color-mix(in oklch,var(--acc1) 12%,transparent),transparent 24%),radial-gradient(circle at 78% 20%,color-mix(in oklch,var(--acc3) 10%,transparent),transparent 26%);}
 .cmd-pal{width:min(680px,94vw);max-height:82vh;overflow:hidden;background:var(--panel);border:1px solid var(--line2);border-radius:18px;box-shadow:0 30px 80px -20px rgba(0,0,0,.65),var(--glow-shadow);animation:palIn .22s cubic-bezier(.2,.8,.2,1);}
 .cmd-search{height:56px;display:flex;align-items:center;gap:12px;padding:0 16px;border-bottom:1px solid var(--line1);font-family:var(--mono);color:var(--sub);}
-.cmd-search span{flex:1;}
+.cmd-search input{flex:1;min-width:0;border:0;outline:0;background:transparent;color:var(--ink);font-family:var(--sans);font-size:14px;}
 .cmd-list{max-height:calc(82vh - 56px);overflow:auto;padding:10px;}
-.cmd-item{width:100%;display:grid;grid-template-columns:22px minmax(0,1fr) auto;gap:11px;align-items:center;padding:11px 12px;border-radius:10px;color:var(--ink);font-size:13px;text-align:left;}
+.cmd-item{width:100%;display:grid;grid-template-columns:22px minmax(0,1fr) auto;gap:11px;align-items:center;padding:11px 12px;border:0;background:transparent;border-radius:10px;color:var(--ink);font-family:var(--sans);font-size:13px;text-align:left;cursor:pointer;transition:var(--t);}
 .cmd-item:hover{background:var(--raise);}
+.cmd-item:focus-visible{outline:2px solid var(--acc3);outline-offset:2px;}
 .cmd-item span{font-family:var(--mono);font-size:10px;color:var(--faint);}
 .skillm-tweaks{
   position:fixed;right:16px;top:76px;z-index:62;width:320px;max-width:calc(100vw - 28px);
@@ -1363,8 +1368,8 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .term-head span{display:flex;align-items:center;gap:8px;}
 .term-body{flex:1;overflow:auto;padding:18px 22px;font-family:var(--mono);font-size:13px;color:var(--sub);}
 .term-body b{color:var(--acc1);}
-.term-input{height:46px;display:flex;align-items:center;gap:10px;padding:0 22px;border-top:1px solid var(--line1);font-family:var(--mono);color:var(--faint);}
-.term-input span:first-child{color:var(--acc1);font-size:24px;font-weight:700;}
+.term-note{height:46px;display:flex;align-items:center;gap:10px;padding:0 22px;border-top:1px solid var(--line1);font-family:var(--mono);color:var(--faint);}
+.term-note code{color:var(--sub);font-size:12px;}
 .disabled{opacity:.48;cursor:not-allowed!important;}
 .disabled,.disabled *{pointer-events:none!important;}
 .mk-card.disabled{filter:saturate(.75);}
@@ -1392,9 +1397,37 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 }
 
 @media(max-width:640px){
+  .view{max-width:none;padding:22px 14px 56px;}
+  .den-compact .view,.den-comfy .view{max-width:none;padding:22px 14px 56px;}
+  .view-head{align-items:flex-start;gap:14px;}
+  .view-head>div:first-child{min-width:0;}
+  .view-head p{overflow-wrap:anywhere;}
+  .panel-head{align-items:flex-start;gap:10px;flex-wrap:wrap;}
+  .panel-head h3{min-width:0;}
+  .panel-hint{overflow-wrap:anywhere;}
+  .ops-head-actions{width:100%;flex-wrap:wrap;}
+  .ops-head-actions .btn-grad,
+  .ops-head-actions .btn-ghost,
+  .ops-head-actions .soon-pill{flex:1 1 130px;justify-content:center;}
+  .reg-strip{align-items:flex-start;padding:11px 12px;gap:8px;}
+  .rs-git,.rs-stat,.rs-guard{white-space:normal;}
+  .reg-strip code{flex:1 1 130px;min-width:0;max-width:100%;white-space:normal;overflow-wrap:anywhere;}
+  .rs-div,.rs-flex{display:none;}
+  .rs-panel{flex:1 1 100%;justify-content:center;}
+  .sync-topo{min-width:0;}
+  .ev-row{grid-template-columns:auto minmax(0,1fr);gap:7px 9px;}
+  .ev-text,.ev-dev{grid-column:2;max-width:none;min-width:0;}
+  .ev-dev{white-space:normal;overflow-wrap:anywhere;}
+  .targets-grid,.profiles-grid{grid-template-columns:minmax(0,1fr);}
+  .target-card{min-width:0;}
+  .tc-title code,.reg-strip code{white-space:normal;overflow-wrap:anywhere;}
+  .soon-pill{white-space:normal;}
+  .plane-tabs{flex-wrap:wrap;gap:6px;}
+  .view-doctor .kpi-row{grid-template-columns:1fr;}
   .sm-statusbar .sb-ver,
-  .sm-statusbar button.sb-item:not(.sb-sync),
   .sm-statusbar .sb-flex{display:none;}
-  .sm-statusbar{gap:6px;overflow:hidden;}
-  .sm-statusbar .sb-item{min-width:0;}
+  .sm-statusbar{gap:6px;overflow-x:auto;overflow-y:hidden;scrollbar-width:none;}
+  .sm-statusbar::-webkit-scrollbar{display:none;}
+  .sm-statusbar .sb-item{flex:0 0 auto;min-width:0;white-space:nowrap;}
+  .sm-terminal{left:68px;bottom:30px;height:min(300px,calc(100vh - 78px));}
 }

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -1201,6 +1201,7 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .op-verb{font-family:var(--mono);font-size:11.5px;font-weight:700;color:var(--acc2);white-space:nowrap;justify-self:start;}
 .op-detail{display:flex;align-items:center;gap:8px;min-width:0;font-family:var(--mono);font-size:12px;flex-wrap:wrap;}
 .op-detail b{font-weight:600;white-space:nowrap;}
+.op-detail code{display:block;max-width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--faint);font-size:10.5px;background:var(--bg2);border:1px solid var(--line1);border-radius:6px;padding:2px 7px;}
 .op-arrow{color:var(--faint);font-size:11px;white-space:nowrap;}
 .op-rev{color:var(--acc1);font-size:11px;}
 .op-arrow code{color:var(--sub);}


### PR DESCRIPTION
## Summary

Fixes #319.
Fixes #325.
Fixes #326.
Fixes #327.
Fixes #328.
Fixes #329.
Fixes #330.
Fixes #332.
Fixes #333.
Refs #321.
Refs #322.
Refs #331.
Refs #334.

This PR turns the SkillM panel from raw operational dumps into scannable, bounded interaction surfaces across Ops, Audit History, Sync, Doctor, command palette, terminal preview, and settings.

## What changed

- Reworked Ops and Audit History rows into compact summaries with expandable technical details.
- Preserved every skill name in expanded bulk operation rows instead of truncating after 80.
- Shared operation status bucketing so `enqueued`, `in_flight`, `retrying`, and `last_error` rows style consistently.
- Deduped pending/activity operation feeds and fixed pending counters without double-counting or underreporting API queue counts.
- Filtered Sync event stream to real `sync.*` operations only.
- Made command palette searchable and terminal overlay a clear read-only preview.
- Replaced non-wired disabled buttons with explicit status pills.
- Persisted SkillM appearance preferences with guarded localStorage writes.
- Fixed invalid custom SVG paths and Doctor mobile KPI wrapping.
- Tightened mobile layout so control-plane and Sync content no longer clips at 390px.

## Follow-ups left open

- #321: Audit History still needs filters for long logs.
- #322: confirmations are guarded now, but should become product-grade in-app confirmation sheets.
- #331: Projection graph still needs a scalable large-registry design.
- #334: Market and Forge are still placeholder routes.

## Validation

- `cd panel && bun run typecheck`
- `cd panel && bun run test -- src/pages/SkillMPanel.test.tsx src/lib/operation_labels.test.ts src/lib/api/usePanelData.test.ts src/lib/skillm_prefs.test.ts`
- `cd panel && bun run test`
- `cd panel && bun run build`
- `git diff --check`
- `cargo check`
- `cargo test`
- Playwright mobile proof for `http://127.0.0.1:5174/?view=sync` at 390x844: `documentElement.scrollWidth === 390`, `body.scrollWidth === 390`, `.sm-main.scrollWidth === 322`, no SVG/path console errors.
- Computer Use smoke checked Ops queue summaries, Sync empty event stream, command palette filtering, and terminal preview.
