### PR TITLE
Fix remaining SkillM panel UX issues

### DIFF
--- a/panel/src/pages/SkillMAuditHistory.test.tsx
+++ b/panel/src/pages/SkillMAuditHistory.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { SkillMAuditHistory } from "./SkillMAuditHistory";
+import { api, type RegistryOperationRecord } from "../lib/api/client";
+
+function registryOperation(overrides: Partial<RegistryOperationRecord> = {}): RegistryOperationRecord {
+  return {
+    op_id: "op_123",
+    audit_id: "audit_123",
+    request_id: "req_123",
+    source: "registry",
+    intent: "target.add",
+    status: "succeeded",
+    ack: true,
+    created_at: "2026-04-09T10:05:00Z",
+    updated_at: "2026-04-09T10:06:00Z",
+    ...overrides,
+  };
+}
+
+function opsResponse(operations: RegistryOperationRecord[], hasMore = false, offset = 0) {
+  return {
+    ok: true,
+    data: {
+      count: operations.length,
+      loaded_count: operations.length,
+      offset,
+      limit: 100,
+      has_more: hasMore,
+      operations,
+    },
+  };
+}
+
+describe("SkillMAuditHistory", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps raw audit fields out of collapsed rows until the row is expanded", async () => {
+    const rawOperation = registryOperation({
+      op_id: "op_raw_123",
+      audit_id: "audit_raw_123",
+      request_id: "req_raw_123",
+      source: "daemon-source",
+      intent: "target.add",
+      status: "succeeded",
+      target: "target_claude_proj_a",
+      created_at: "2026-04-09T10:05:00Z",
+      updated_at: "2026-04-09T10:06:00Z",
+    });
+    vi.spyOn(api, "ops").mockResolvedValue(opsResponse([rawOperation]));
+
+    render(<SkillMAuditHistory live refreshKey={null} />);
+
+    const title = await screen.findByText("Claude target registration done");
+    const row = title.closest("details");
+    expect(row).not.toBeNull();
+
+    expect(within(row!).queryByText("target.add")).toBeNull();
+    expect(within(row!).queryByText("succeeded")).toBeNull();
+    expect(within(row!).queryByText("daemon-source")).toBeNull();
+    expect(within(row!).queryByText("op_raw_123")).toBeNull();
+    expect(within(row!).queryByText(/target_claude_proj_a/)).toBeNull();
+    expect(within(row!).queryByText("2026-04-09T10:06:00Z")).toBeNull();
+
+    fireEvent.click(within(row!).getByText("详情"));
+
+    expect(await within(row!).findByText("target.add")).toBeTruthy();
+    expect(within(row!).getByText("succeeded")).toBeTruthy();
+    expect(within(row!).getByText("daemon-source")).toBeTruthy();
+    expect(within(row!).getByText("op_raw_123")).toBeTruthy();
+    expect(within(row!).getByText(/target_claude_proj_a/)).toBeTruthy();
+    expect(within(row!).getByText("2026-04-09T10:06:00Z")).toBeTruthy();
+  });
+
+  it("filters loaded audit rows by text, status bucket, and operation category while preserving pagination", async () => {
+    const targetOp = registryOperation({
+      op_id: "op_target",
+      intent: "target.add",
+      target: "target_claude_proj_a",
+    });
+    const importOp = registryOperation({
+      op_id: "op_import",
+      intent: "skill.import_observed",
+      skill: "writer",
+    });
+    const failedSyncOp = registryOperation({
+      op_id: "op_sync",
+      intent: "sync.push",
+      status: "failed",
+      ack: false,
+      last_error: { code: "push_failed", message: "remote rejected update" },
+    });
+    const opsSpy = vi
+      .spyOn(api, "ops")
+      .mockResolvedValueOnce(opsResponse([targetOp, importOp, failedSyncOp], true))
+      .mockResolvedValueOnce(opsResponse([], false, 100));
+
+    render(<SkillMAuditHistory live refreshKey={null} />);
+
+    expect(await screen.findByText("3 loaded audit changes.")).toBeTruthy();
+    expect(screen.getByText("Claude target registration done")).toBeTruthy();
+    expect(screen.getByText("writer observed skill import done")).toBeTruthy();
+    expect(screen.getByText("Remote sync push failed")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Audit text filter"), { target: { value: "writer" } });
+    expect(screen.getByText("writer observed skill import done")).toBeTruthy();
+    expect(screen.queryByText("Claude target registration done")).toBeNull();
+    expect(screen.queryByText("Remote sync push failed")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Audit text filter"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Audit status filter"), { target: { value: "err" } });
+    expect(screen.getByText("Remote sync push failed")).toBeTruthy();
+    expect(screen.queryByText("writer observed skill import done")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Audit status filter"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Audit operation type filter"), { target: { value: "Target" } });
+    expect(screen.getByText("Claude target registration done")).toBeTruthy();
+    expect(screen.queryByText("writer observed skill import done")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "older" }));
+
+    await waitFor(() => expect(opsSpy).toHaveBeenCalledTimes(2));
+    expect(opsSpy.mock.calls[1][0]).toEqual({ limit: 100, offset: 100 });
+  });
+
+  it("can transition from offline to live without changing hook order", async () => {
+    const opsSpy = vi
+      .spyOn(api, "ops")
+      .mockResolvedValue(opsResponse([registryOperation({ target: "target_claude_proj_a" })]));
+
+    const { rerender } = render(<SkillMAuditHistory live={false} refreshKey={null} />);
+
+    expect(screen.getByText("Audit history needs the live panel API.")).toBeTruthy();
+
+    rerender(<SkillMAuditHistory live refreshKey="ready" />);
+
+    expect(await screen.findByText("Claude target registration done")).toBeTruthy();
+    expect(opsSpy).toHaveBeenCalledWith({ limit: 100, offset: 0 }, expect.any(AbortSignal));
+  });
+});

--- a/panel/src/pages/SkillMAuditHistory.tsx
+++ b/panel/src/pages/SkillMAuditHistory.tsx
@@ -1,19 +1,32 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api, type OpsPayload, type RegistryOperationRecord } from "../lib/api/client";
 import {
-  operationActionLabel,
   bucketRegistryOperation,
+  describeRegistryOperation,
   registryOperationDetailParts,
   registryOperationDisplayId,
   registryOperationStatusLabel,
-  registryOperationSubjectLabel,
-  registryOperationTargetLabel,
   splitOperationSkills,
 } from "../lib/operation_labels";
 
 const HISTORY_PAGE_SIZE = 100;
+const STATUS_FILTERS = [
+  ["all", "All statuses"],
+  ["ok", "Done"],
+  ["pending", "Pending"],
+  ["err", "Failed"],
+] as const;
 
 type HistoryData = NonNullable<OpsPayload["data"]>;
+type AuditStatusFilter = (typeof STATUS_FILTERS)[number][0];
+type AuditRowLabel = ReturnType<typeof describeRegistryOperation>;
+
+interface AuditHistoryRow {
+  op: RegistryOperationRecord;
+  label: AuditRowLabel;
+  status: "ok" | "pending" | "err";
+  searchText: string;
+}
 
 interface SkillMAuditHistoryProps {
   live: boolean;
@@ -34,6 +47,9 @@ const INITIAL_HISTORY_STATE: HistoryState = {
 
 export function SkillMAuditHistory({ live, refreshKey }: SkillMAuditHistoryProps) {
   const [offset, setOffset] = useState(0);
+  const [textFilter, setTextFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState<AuditStatusFilter>("all");
+  const [categoryFilter, setCategoryFilter] = useState("all");
   const [state, setState] = useState<HistoryState>(INITIAL_HISTORY_STATE);
 
   useEffect(() => {
@@ -70,17 +86,47 @@ export function SkillMAuditHistory({ live, refreshKey }: SkillMAuditHistoryProps
     return () => controller.abort();
   }, [live, offset, refreshKey]);
 
-  if (!live) {
-    return <div className="ops-empty">Audit history needs the live panel API.</div>;
-  }
-
   const data = state.data;
   const operations = data?.operations ?? [];
+  const rows = useMemo<AuditHistoryRow[]>(
+    () =>
+      operations.map((op) => {
+        const label = describeRegistryOperation(op);
+        return {
+          op,
+          label,
+          status: bucketRegistryOperation(op),
+          searchText: auditSearchText(op, label),
+        };
+      }),
+    [operations],
+  );
+  const categoryOptions = useMemo(() => {
+    const categories = Array.from(new Set(rows.map((row) => row.label.category)));
+    categories.sort((left, right) => left.localeCompare(right));
+    return categoryFilter !== "all" && !categories.includes(categoryFilter)
+      ? [categoryFilter, ...categories]
+      : categories;
+  }, [categoryFilter, rows]);
+  const normalizedTextFilter = textFilter.trim().toLowerCase();
+  const filteredRows = rows.filter((row) => {
+    if (statusFilter !== "all" && row.status !== statusFilter) return false;
+    if (categoryFilter !== "all" && row.label.category !== categoryFilter) return false;
+    return normalizedTextFilter.length === 0 || row.searchText.includes(normalizedTextFilter);
+  });
+  const filtersActive =
+    normalizedTextFilter.length > 0 || statusFilter !== "all" || categoryFilter !== "all";
   const summary = data
-    ? data.count > data.loaded_count
+    ? filtersActive
+      ? `${filteredRows.length} of ${operations.length} loaded audit changes match filters.`
+      : data.count > data.loaded_count
       ? `Showing ${data.loaded_count} of ${data.count} audit changes.`
       : `${data.loaded_count} loaded audit change${data.loaded_count === 1 ? "" : "s"}.`
     : null;
+
+  if (!live) {
+    return <div className="ops-empty">Audit history needs the live panel API.</div>;
+  }
 
   return (
     <section className="ops-table">
@@ -106,54 +152,137 @@ export function SkillMAuditHistory({ live, refreshKey }: SkillMAuditHistoryProps
           older
         </button>
       </div>
+      <div className="op-row audit-history-filters" aria-label="Audit history filters">
+        <input
+          aria-label="Audit text filter"
+          value={textFilter}
+          onChange={(event) => setTextFilter(event.target.value)}
+          placeholder="Filter audit history"
+          className="field-input"
+          style={{ minHeight: 30, minWidth: 180 }}
+          disabled={!data}
+        />
+        <select
+          aria-label="Audit status filter"
+          value={statusFilter}
+          onChange={(event) => setStatusFilter(event.target.value as AuditStatusFilter)}
+          className="field-input"
+          style={{ minHeight: 30 }}
+          disabled={!data}
+        >
+          {STATUS_FILTERS.map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
+        </select>
+        <select
+          aria-label="Audit operation type filter"
+          value={categoryFilter}
+          onChange={(event) => setCategoryFilter(event.target.value)}
+          className="field-input"
+          style={{ minHeight: 30 }}
+          disabled={!data}
+        >
+          <option value="all">All operation types</option>
+          {categoryOptions.map((category) => (
+            <option key={category} value={category}>{category}</option>
+          ))}
+        </select>
+        <span className="op-note">
+          {filtersActive ? `${filteredRows.length} matches on this page` : "Filtering applies to the loaded page"}
+        </span>
+      </div>
       {state.error && <div className="ops-empty">{state.error}</div>}
       {!state.error && operations.length === 0 && !state.loading && (
         <div className="ops-empty">No audit history returned by API.</div>
       )}
-      {operations.map((op) => <AuditHistoryLine key={historyId(op)} op={op} />)}
+      {!state.error && operations.length > 0 && filteredRows.length === 0 && (
+        <div className="ops-empty">No audit history matches the current filters.</div>
+      )}
+      {filteredRows.map((row) => <AuditHistoryLine key={historyId(row.op)} op={row.op} label={row.label} />)}
     </section>
   );
 }
 
-function AuditHistoryLine({ op }: { op: RegistryOperationRecord }) {
+function AuditHistoryLine({ op, label }: { op: RegistryOperationRecord; label: AuditRowLabel }) {
+  const [expanded, setExpanded] = useState(false);
   const rowClass = historyClass(op);
   const details = registryOperationDetailParts(op);
-  const summaryDetails = details.filter((part) => !part.startsWith("id ")).slice(0, 2);
   const skills = op.skill ? splitOperationSkills(op.skill) : [];
-  const target = registryOperationTargetLabel(op);
+  const summaryChip = auditSummaryChip(op, skills);
 
   return (
-    <details className={`op-row op-log-row audit-history-row op-row-${rowClass}`}>
-      <summary className="op-row-main">
+    <details open={expanded} className={`op-row op-log-row audit-history-row op-row-${rowClass}`}>
+      <summary
+        className="op-row-main"
+        onClick={(event) => {
+          event.preventDefault();
+          setExpanded((value) => !value);
+        }}
+      >
         <span className={`op-pill op-${rowClass}`}>{registryOperationStatusLabel(op)}</span>
-        <span className="op-time" title={op.updated_at || op.created_at}>{historyTime(op)}</span>
-        <span className="op-verb">{operationActionLabel(op.intent)}</span>
+        <span className="op-time">{historyTime(op)}</span>
+        <span className="op-verb">{label.category}</span>
         <span className="op-main-subject">
-          <b>{registryOperationSubjectLabel(op)}</b>
-          <code>{target}</code>
+          <b>{label.title}</b>
         </span>
-        <span className="op-count-chip">{summaryDetails[0] ?? "详情"}</span>
-        <span className="op-more-chip">展开</span>
+        <span className="op-count-chip">{summaryChip}</span>
+        <span className="op-more-chip">{expanded ? "收起" : "详情"}</span>
       </summary>
-      <div className="op-expanded">
-        <div className="op-kv-grid">
-          <span>intent</span><code>{op.intent}</code>
-          <span>source</span><code>{op.source ?? "registry"}</code>
-          <span>status</span><code>{op.status}</code>
-          <span>id</span><code>{registryOperationDisplayId(op)}</code>
-        </div>
-        {details.length > 0 ? <div className="op-detail-line">{details.join(" · ")}</div> : null}
-        {skills.length > 0 ? (
-          <div className="op-skill-block">
-            <span className="op-skill-label">skills</span>
-            <div className="op-skill-chips">
-              {skills.map((name) => <span key={name}>{name}</span>)}
-            </div>
+      {expanded ? (
+        <div className="op-expanded">
+          <div className="op-kv-grid">
+            <span>intent</span><code>{op.intent}</code>
+            <span>source</span><code>{op.source ?? "registry"}</code>
+            <span>status</span><code>{op.status}</code>
+            <span>operation id</span><code>{op.op_id ?? "—"}</code>
+            <span>audit id</span><code>{op.audit_id ?? "—"}</code>
+            <span>request id</span><code>{op.request_id ?? "—"}</code>
+            <span>created</span><code>{op.created_at}</code>
+            <span>updated</span><code>{op.updated_at}</code>
           </div>
-        ) : null}
-      </div>
+          {details.length > 0 ? <div className="op-detail-line">{details.join(" · ")}</div> : null}
+          {skills.length > 0 ? (
+            <div className="op-skill-block">
+              <span className="op-skill-label">skills</span>
+              <div className="op-skill-chips">
+                {skills.map((name) => <span key={name}>{name}</span>)}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </details>
   );
+}
+
+function auditSearchText(op: RegistryOperationRecord, label: AuditRowLabel): string {
+  return [
+    label.category,
+    label.title,
+    ...label.details,
+    registryOperationStatusLabel(op),
+    op.intent,
+    op.status,
+    op.source,
+    op.skill,
+    op.target,
+    op.binding,
+    op.method,
+    op.last_error?.code,
+    op.last_error?.message,
+    op.op_id,
+    op.audit_id,
+    op.request_id,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+}
+
+function auditSummaryChip(op: RegistryOperationRecord, skills: string[]): string {
+  if (op.last_error) return "错误详情";
+  if (skills.length > 1) return `批量 ${skills.length}`;
+  return op.ack ? "已同步" : "待同步";
 }
 
 function historyId(op: RegistryOperationRecord): string {

--- a/panel/src/pages/SkillMPanel.test.tsx
+++ b/panel/src/pages/SkillMPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { api } from "../lib/api/client";
 import { OperationLogRow } from "./OperationLogRow";
@@ -223,10 +223,9 @@ describe("SkillMPanel", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /审计历史/ }));
 
-    expect(await screen.findByText("发布版本标签")).toBeTruthy();
-    expect(screen.getAllByText("release-notes").length).toBeGreaterThan(0);
-    expect(screen.getByText("5 个 skill")).toBeTruthy();
-    expect(screen.getAllByText(/本次批量操作包含 5 个 skill/).length).toBeGreaterThan(0);
+    expect(await screen.findByText("release-notes skill release done")).toBeTruthy();
+    expect(screen.getByText("5 skills observed skill monitor done")).toBeTruthy();
+    expect(screen.getByText("批量 5")).toBeTruthy();
     expect([...container.querySelectorAll(".op-row-pending .op-pill")].some((node) => node.textContent === "待处理")).toBe(true);
     expect([...container.querySelectorAll(".op-row-failed .op-pill")].some((node) => node.textContent === "失败")).toBe(true);
     expect(screen.queryByText(auditSkillList)).toBeNull();
@@ -315,6 +314,66 @@ describe("SkillMPanel", () => {
 
     expect(screen.getByTitle("当前 Panel 地址")).toBeTruthy();
     expect(screen.queryByText("localhost:5173")).toBeNull();
+  });
+
+  it("discloses projection graph truncation and scopes the table to the same page", async () => {
+    const projections = Array.from({ length: 14 }, (_, index) => ({
+      instance_id: `projection-${index + 1}`,
+      skill_id: `skill-${index + 1}`,
+      binding_id: `binding-${index + 1}`,
+      target_id: `target_${index + 1}`,
+      materialized_path: `/tmp/target-${index + 1}/skill-${index + 1}`,
+      method: "copy",
+      last_applied_rev: `rev-${index + 1}`.padEnd(8, "x"),
+      health: "ok",
+      observed_drift: false,
+    }));
+    panelData.current = {
+      ...panelData.liveOps,
+      ops: [],
+      skills: projections.map((projection) => ({
+        id: projection.skill_id,
+        name: projection.skill_id,
+        description: "Projection fixture",
+        tag: "workflow",
+        sourceStatus: "present",
+        releaseTags: [],
+        snapshotTags: [],
+        latestRev: projection.last_applied_rev,
+        ruleCount: 0,
+        bindingCount: 1,
+        projectionCount: 1,
+        changed: "now",
+        targets: [projection.target_id],
+      })),
+      targets: projections.map((projection, index) => ({
+        id: projection.target_id,
+        agent: "codex",
+        path: `/tmp/target-${index + 1}`,
+        profile: "default",
+        ownership: "managed",
+        skills: 1,
+        projectedSkills: 1,
+        lastSync: "now",
+      })),
+      projections,
+    };
+    window.history.replaceState(null, "", "/?view=projections");
+
+    render(<SkillMPanel />);
+
+    const table = screen.getByRole("table");
+    expect(screen.getByText("displaying 12 of 14 skills")).toBeTruthy();
+    expect(screen.getByText("displaying 12 of 14 targets")).toBeTruthy();
+    expect(screen.getByText("displaying 12 of 14 projections")).toBeTruthy();
+    expect(within(table).queryByText("skill-14")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next projection page" }));
+
+    expect(screen.getByText("displaying 2 of 14 skills")).toBeTruthy();
+    expect(screen.getByText("displaying 2 of 14 targets")).toBeTruthy();
+    expect(screen.getByText("displaying 2 of 14 projections")).toBeTruthy();
+    expect(within(table).getByText("skill-14")).toBeTruthy();
   });
 
   it("summarizes Git sync events without exposing raw bulk skill lists", () => {
@@ -416,5 +475,83 @@ describe("SkillMPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: "tweaks" }));
 
     expect(screen.getByRole("button", { name: "关闭 Tweaks" })).toBeTruthy();
+  });
+
+  it("opens an explicit Ops purge confirmation before dispatching", async () => {
+    panelData.current = panelData.liveOps;
+    window.history.replaceState(null, "", "/?view=ops");
+    const purge = vi.spyOn(api, "opsPurge").mockResolvedValue({ ok: true, cmd: "ops.purge", request_id: "req-purge" });
+    const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<SkillMPanel />);
+
+    await userEvent.click(screen.getByRole("button", { name: /purge/ }));
+
+    expect(nativeConfirm).not.toHaveBeenCalled();
+    expect(purge).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog", { name: "清理 Ops 队列？" });
+    expect(within(dialog).getByText("Affected scope")).toBeTruthy();
+    expect(within(dialog).getByText(/不可自动撤销/)).toBeTruthy();
+    expect(within(dialog).getByText(/Ops purge API/)).toBeTruthy();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "确认清理" }));
+
+    await waitFor(() => expect(purge).toHaveBeenCalledTimes(1));
+    expect(panelData.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows queued count and defers Ops replay until the sheet confirm action", async () => {
+    panelData.current = { ...panelData.liveOps, queuedWriteCount: 5 };
+    window.history.replaceState(null, "", "/?view=ops");
+    const retry = vi.spyOn(api, "opsRetry").mockResolvedValue({ ok: true, cmd: "ops.retry", request_id: "req-retry" });
+
+    render(<SkillMPanel />);
+
+    await userEvent.click(screen.getByRole("button", { name: /replay 队列/ }));
+
+    expect(retry).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog", { name: "重放 Ops 队列？" });
+    expect(within(dialog).getByText("Queued count")).toBeTruthy();
+    expect(within(dialog).getByText("5")).toBeTruthy();
+    expect(within(dialog).getByText(/重试 pending\/failed 操作/)).toBeTruthy();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "确认重放" }));
+
+    await waitFor(() => expect(retry).toHaveBeenCalledTimes(1));
+  });
+
+  it("marks Market and Forge as preview before navigation", async () => {
+    panelData.current = panelData.liveOps;
+    render(<SkillMPanel />);
+
+    expect(screen.getByRole("button", { name: /Market Preview/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Forge Preview/ })).toBeTruthy();
+
+    await userEvent.keyboard("{Control>}k{/Control}");
+
+    expect(await screen.findByRole("button", { name: /Go to Market Preview not connected/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Go to Forge Preview not connected/ })).toBeTruthy();
+  });
+
+  it("explains Market and Forge placeholders without fake install or create controls", async () => {
+    panelData.current = panelData.liveOps;
+    render(<SkillMPanel />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Market Preview/ }));
+
+    expect(screen.getByRole("heading", { name: "市场" })).toBeTruthy();
+    expect(screen.getByText("Preview · not connected")).toBeTruthy();
+    expect(screen.getByText(/只读查看本地 registry/)).toBeTruthy();
+    expect(screen.getByText(/不展示安装按钮/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /install|安装/i })).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /Forge Preview/ }));
+
+    expect(screen.getByRole("heading", { name: "Forge" })).toBeTruthy();
+    expect(screen.getByText(/只读参考本地 registry/)).toBeTruthy();
+    expect(screen.getByText(/不展示创建按钮/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /create|创建/i })).toBeNull();
   });
 });

--- a/panel/src/pages/SkillMPanel.tsx
+++ b/panel/src/pages/SkillMPanel.tsx
@@ -17,6 +17,7 @@ import {
 
 type SkillMPage = PanelPageKey | "market" | "forge";
 type ToastKind = "ok" | "err" | "info" | "sync";
+type Confirm = { label: string; action: string; title: string; scope: string; undo: string; impact: string; count?: number; fn: () => Promise<unknown>; tone?: "danger" | "sync" };
 
 interface Toast {
   id: string;
@@ -47,7 +48,7 @@ const iconPath: Record<string, string> = {
   forge: "M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z",
 };
 
-const pages: Array<{ id: SkillMPage; icon: string; label: string; group: "build" | "ops" }> = [
+const pages: Array<{ id: SkillMPage; icon: string; label: string; group: "build" | "ops"; preview?: true }> = [
   { id: "overview", icon: "dash", label: "Overview", group: "build" },
   { id: "skills", icon: "lib", label: "Skills", group: "build" },
   { id: "targets", icon: "target", label: "Targets", group: "build" },
@@ -58,8 +59,8 @@ const pages: Array<{ id: SkillMPage; icon: string; label: string; group: "build"
   { id: "sync", icon: "sync", label: "Git sync", group: "ops" },
   { id: "doctor", icon: "shield", label: "Doctor", group: "ops" },
   { id: "settings", icon: "gear", label: "Settings", group: "ops" },
-  { id: "market", icon: "market", label: "Market", group: "ops" },
-  { id: "forge", icon: "forge", label: "Forge", group: "ops" },
+  { id: "market", icon: "market", label: "Market", group: "ops", preview: true },
+  { id: "forge", icon: "forge", label: "Forge", group: "ops", preview: true },
 ];
 
 const agentMeta: Record<string, { name: string; short: string; color: string }> = {
@@ -141,6 +142,7 @@ function methodTone(method: string) {
   return "var(--faint)";
 }
 
+const PROJECTION_PAGE_SIZE = 12;
 const HEATMAP_WEEKS = 26;
 const HEATMAP_DAYS = HEATMAP_WEEKS * 7;
 const DAY_MS = 86_400_000;
@@ -208,6 +210,7 @@ export function SkillMPanel() {
   const [density, setDensity] = useState(initialPrefs.density);
   const [accent, setAccent] = useState(initialPrefs.accent);
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const [confirm, setConfirm] = useState<Confirm | null>(null);
 
   const counts = useMemo(() => {
     const failedOps = live.ops.filter((op) => op.status === "err").length;
@@ -240,13 +243,12 @@ export function SkillMPanel() {
   };
 
   const toast = (kind: ToastKind, text: string) => {
-    const id = crypto.randomUUID();
+    const id = typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
     setToasts((items) => [...items, { id, kind, text }]);
     window.setTimeout(() => setToasts((items) => items.filter((item) => item.id !== id)), 3200);
   };
 
-  const runAction = async (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => {
-    if (options?.confirm && typeof window !== "undefined" && !window.confirm(options.confirm)) return;
+  const runAction = async (label: string, fn: () => Promise<unknown>) => {
     try {
       await fn();
       toast("ok", `${label} completed`);
@@ -255,6 +257,7 @@ export function SkillMPanel() {
       toast("err", error instanceof Error ? error.message : String(error));
     }
   };
+  const commitAction = async () => { const action = confirm; if (!action) return; setConfirm(null); await runAction(action.label, action.fn); };
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -293,8 +296,8 @@ export function SkillMPanel() {
               {view === "overview" && <Overview live={live} counts={counts} go={go} />}
               {view === "skills" && <Skills skills={live.skills} targets={live.targets} query={query} setQuery={setQuery} selected={selected} setSelectedSkill={setSelectedSkill} />}
               {(view === "targets" || view === "bindings" || view === "projections") && <Plane live={live} tab={view} go={go} />}
-              {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} go={go} runAction={runAction} />}
-              {view === "sync" && <Sync live={live} runAction={runAction} />}
+              {(view === "ops" || view === "history") && <Ops live={live} history={view === "history"} go={go} confirm={setConfirm} />}
+              {view === "sync" && <Sync live={live} confirm={setConfirm} />}
               {view === "doctor" && <Doctor live={live} go={go} />}
               {view === "settings" && <Settings live={live} dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} />}
               {view === "market" && <Market live={live} />}
@@ -307,6 +310,7 @@ export function SkillMPanel() {
       <StatusBar live={live} counts={counts} dark={dark} setDark={setDark} onSync={() => go("sync")} onTerm={() => setTermOpen((open) => !open)} onTweaks={() => setTweaksOpen((open) => !open)} />
       {paletteOpen && <Palette skills={live.skills} go={(page) => { go(page); setPaletteOpen(false); }} openSkill={(name) => { setSelectedSkill(name); go("skills"); setPaletteOpen(false); }} close={() => setPaletteOpen(false)} />}
       {tweaksOpen && <Tweaks dark={dark} setDark={setDark} density={density} setDensity={setDensity} accent={accent} setAccent={setAccent} close={() => setTweaksOpen(false)} />}
+      {confirm && <div className="sm-veil" onMouseDown={() => setConfirm(null)}><section className={`action-confirm ${confirm.tone === "danger" ? "danger" : ""}`} role="dialog" aria-modal="true" aria-label={confirm.title} onMouseDown={(event) => event.stopPropagation()}><div className="ac-head"><span className="ac-icon"><Icon d={confirm.tone === "danger" ? "x" : "sync"} /></span><div><h2>{confirm.title}</h2><p>{confirm.label}</p></div><button className="btn-icon" aria-label="关闭确认" onClick={() => setConfirm(null)}><Icon d="x" /></button></div><dl className="ac-facts"><div><dt>Affected scope</dt><dd>{confirm.scope}</dd></div>{typeof confirm.count === "number" && <div><dt>Queued count</dt><dd><b>{confirm.count}</b> queued</dd></div>}<div><dt>Reversibility</dt><dd>{confirm.undo}</dd></div><div><dt>Impact</dt><dd>{confirm.impact}</dd></div></dl><div className="ac-actions"><button className="btn-ghost sm" onClick={() => setConfirm(null)}>取消</button><button className={confirm.tone === "danger" ? "btn-ghost sm danger" : "btn-grad sm"} onClick={commitAction}>{confirm.action}</button></div></section></div>}
       <Toasts items={toasts} dismiss={(id) => setToasts((items) => items.filter((item) => item.id !== id))} />
     </div>
   );
@@ -323,9 +327,9 @@ function ActivityRail({ view, counts, onGo, onTerm }: { view: SkillMPage; counts
             {pages.filter((page) => page.group === group).map((page) => {
               const count = page.id === "skills" ? counts.skills : page.id === "targets" ? counts.targets : page.id === "bindings" ? counts.bindings : page.id === "projections" ? counts.projections : page.id === "ops" ? counts.attention : 0;
               return (
-                <button key={page.id} className={`act ${view === page.id ? "on" : ""}`} title={page.label} onClick={() => onGo(page.id)}>
+                <button key={page.id} className={`act ${view === page.id ? "on" : ""} ${page.preview ? "preview" : ""}`} title={page.preview ? `${page.label} · Preview · not connected` : page.label} aria-label={page.preview ? `${page.label} Preview not connected` : page.label} onClick={() => onGo(page.id)}>
                   <Icon d={page.icon} size={20} />
-                  <span className="act-label">{page.label}</span>
+                  <span className="act-label">{page.label}</span>{page.preview && <span className="act-preview">Preview</span>}
                   {count > 0 && <span className={`act-count ${page.id === "ops" ? "attn" : ""}`}>{count}</span>}
                 </button>
               );
@@ -573,6 +577,11 @@ function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: 
   const drifts = live.projections.filter((p) => p.observed_drift || p.health === "drift").length;
   const pending = pendingQueueCount(live);
   const panelHost = panelHostLabel();
+  const [projectionPage, setProjectionPage] = useState(0);
+  const projectionPageCount = Math.max(1, Math.ceil(live.projections.length / PROJECTION_PAGE_SIZE)), activeProjectionPage = Math.min(projectionPage, projectionPageCount - 1), scopedProjections = live.projections.slice(activeProjectionPage * PROJECTION_PAGE_SIZE, activeProjectionPage * PROJECTION_PAGE_SIZE + PROJECTION_PAGE_SIZE);
+  const allProjectionSkills = new Set(live.projections.map((p) => p.skill_id)), allProjectionTargets = new Set(live.projections.map((p) => p.target_id)), scopedProjectionSkills = new Set(scopedProjections.map((p) => p.skill_id)), scopedProjectionTargets = new Set(scopedProjections.map((p) => p.target_id));
+  const graphSkills = live.projections.length ? live.skills.filter((skill) => scopedProjectionSkills.has(skill.name)) : live.skills, graphTargets = live.projections.length ? live.targets.filter((target) => scopedProjectionTargets.has(target.id)) : live.targets;
+  const projectionScopeStats = [{ key: "skills", shown: graphSkills.length, total: live.projections.length ? live.skills.filter((skill) => allProjectionSkills.has(skill.name)).length : live.skills.length }, { key: "targets", shown: graphTargets.length, total: live.projections.length ? live.targets.filter((target) => allProjectionTargets.has(target.id)).length : live.targets.length }, { key: "projections", shown: scopedProjections.length, total: live.projections.length }].filter((item) => item.shown < item.total);
   return (
     <div className="view view-plane">
       <header className="view-head"><div><h1>控制平面</h1><p>把注册表里的 skill 通过 binding 投影到各 agent 目录 · symlink / copy / materialize</p></div><span className="soon-pill"><Icon d="branch" size={14} />批量投影未接入</span></header>
@@ -594,9 +603,10 @@ function Plane({ live, tab, go }: { live: ReturnType<typeof usePanelData>; tab: 
       {tab === "bindings" && <BindingsTable bindings={live.bindings} />}
       {tab === "projections" && (
         <section className="panel">
-          <div className="panel-head"><h3><Icon d="graph" />Projection graph</h3><span className="panel-hint">{live.projections.length} edges</span></div>
-          <ProjectionGraph skills={live.skills} targets={live.targets} projections={live.projections} />
-          <DataGrid columns={["skill", "target", "method", "health", "rev"]} rows={live.projections.map((p) => [p.skill_id, shortName(p.target_id), p.method, p.health, p.last_applied_rev?.slice(0, 8) || "—"])} />
+          <div className="panel-head projection-head"><h3><Icon d="graph" />Projection graph</h3><div className="projection-scope-controls"><span className="panel-hint">{scopedProjections.length} of {live.projections.length} edges</span>{projectionPageCount > 1 && <div className="scope-pager" aria-label="Projection scope pages"><button type="button" aria-label="Previous projection page" disabled={activeProjectionPage === 0} onClick={() => setProjectionPage(Math.max(0, activeProjectionPage - 1))}>Prev</button><span>Page {activeProjectionPage + 1} of {projectionPageCount}</span><button type="button" aria-label="Next projection page" disabled={activeProjectionPage >= projectionPageCount - 1} onClick={() => setProjectionPage(Math.min(projectionPageCount - 1, activeProjectionPage + 1))}>Next</button></div>}</div></div>
+          {projectionScopeStats.length > 0 && <div className="scope-disclosure" aria-label="Projection scope disclosure">{projectionScopeStats.map((item) => <span key={item.key}>displaying {item.shown} of {item.total} {item.key}</span>)}</div>}
+          <ProjectionGraph skills={graphSkills} targets={graphTargets} projections={scopedProjections} />
+          <DataGrid columns={["skill", "target", "method", "health", "rev"]} rows={scopedProjections.map((p) => [p.skill_id, shortName(p.target_id), p.method, p.health, p.last_applied_rev?.slice(0, 8) || "—"])} />
         </section>
       )}
     </div>
@@ -618,32 +628,25 @@ function BindingsTable({ bindings }: { bindings: ReturnType<typeof usePanelData>
 }
 
 function DataGrid({ columns, rows }: { columns: string[]; rows: Array<Array<string | number>> }) {
-  return (
-    <div className="skillm-table panel">
-      <table><thead><tr>{columns.map((column) => <th key={column}>{column}</th>)}</tr></thead><tbody>{rows.map((row, index) => <tr key={index}>{row.map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)}</tr>)}</tbody></table>
-      {rows.length === 0 && <div className="panel-empty">No live rows.</div>}
-    </div>
-  );
+  return <div className="skillm-table panel"><table><thead><tr>{columns.map((column) => <th key={column}>{column}</th>)}</tr></thead><tbody>{rows.map((row, index) => <tr key={index}>{row.map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)}</tr>)}</tbody></table>{rows.length === 0 && <div className="panel-empty">No live rows.</div>}</div>;
 }
 
 function ProjectionGraph({ skills, targets, projections = [] }: { skills: Skill[]; targets: Target[]; projections?: ReturnType<typeof usePanelData>["projections"] }) {
-  const shownSkills = projections.length > 0 ? skills.filter((skill) => projections.some((p) => p.skill_id === skill.name)).slice(0, 8) : skills.slice(0, 8);
-  const shownTargets = projections.length > 0 ? targets.filter((target) => projections.some((p) => p.target_id === target.id)).slice(0, 7) : targets.slice(0, 7);
+  const graphHeight = Math.max(260, skills.length * 35 + 20, targets.length * 40 + 20);
   return (
     <div className="plane-graph skillm-mini-graph">
       <div className="pg-cols"><span>注册表 Skill 源</span><span>投影方式</span><span>Target 目录</span></div>
       <div className="skillm-graph-grid">
-        <div>{shownSkills.map((skill) => <div className="pg-node-row" key={skill.name}><Glyph>{skill.name}</Glyph><span>{skill.name}</span></div>)}</div>
-        <svg viewBox="0 0 500 260" className="proj-svg" aria-hidden="true">
-          {projections.slice(0, 12).map((projection) => {
-            const skillIndex = Math.max(0, shownSkills.findIndex((skill) => skill.name === projection.skill_id));
-            const targetIndex = Math.max(0, shownTargets.findIndex((target) => target.id === projection.target_id));
-            const y = 24 + skillIndex * 29;
-            const ty = 24 + Math.max(targetIndex, 0) * 34;
+        <div>{skills.map((skill) => <div className="pg-node-row" key={skill.name}><Glyph>{skill.name}</Glyph><span>{skill.name}</span></div>)}</div>
+        <svg viewBox={`0 0 500 ${graphHeight}`} className="proj-svg" style={{ height: graphHeight }} aria-hidden="true">
+          {projections.map((projection) => {
+            const skillIndex = Math.max(0, skills.findIndex((skill) => skill.name === projection.skill_id));
+            const targetIndex = Math.max(0, targets.findIndex((target) => target.id === projection.target_id));
+            const y = 24 + skillIndex * 35, ty = 24 + Math.max(targetIndex, 0) * 40;
             return <path key={projection.instance_id} d={`M20 ${y} C180 ${y}, 300 ${ty}, 480 ${ty}`} className="proj-edge" stroke={methodTone(projection.method)} />;
           })}
         </svg>
-        <div>{shownTargets.map((target) => <div className="pg-node-row target" key={target.id}><span className="tc-agent">{target.agent.slice(0, 2).toUpperCase()}</span><span>{target.path}</span></div>)}</div>
+        <div>{targets.map((target) => <div className="pg-node-row target" key={target.id}><span className="tc-agent">{target.agent.slice(0, 2).toUpperCase()}</span><span>{target.path}</span></div>)}</div>
       </div>
       {projections.length === 0 && <div className="panel-empty">No live projection edges yet. The graph is showing inventory columns only.</div>}
     </div>
@@ -654,7 +657,7 @@ function EmptyPanel({ text }: { text: string }) {
   return <div className="panel"><div className="panel-empty">{text}</div></div>;
 }
 
-function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePanelData>; history: boolean; go: (page: SkillMPage) => void; runAction: (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => void }) {
+function Ops({ live, history, go, confirm }: { live: ReturnType<typeof usePanelData>; history: boolean; go: (page: SkillMPage) => void; confirm: (action: Confirm) => void }) {
   const failed = live.ops.filter((op) => op.status === "err").length;
   const pending = pendingQueueCount(live);
   const queue = live.ops.filter((op) => op.status !== "ok");
@@ -664,7 +667,7 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
     <div className="view view-ops">
       <header className="view-head">
         <div><h1>Ops &amp; 审计</h1><p>每条命令都来自 live API · 可重放、可诊断、可清理</p></div>
-        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => runAction("Purge ops", api.opsPurge, { confirm: "确定要清理当前操作队列吗？这个动作会修改本地操作状态。" })}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => runAction("Replay queued ops", api.opsRetry, { confirm: "确定要重放当前待处理队列吗？" })}><Icon d="sync" />replay 队列</button></div>
+        <div className="ops-head-actions"><button className="btn-ghost sm" onClick={() => confirm({ label: "Purge ops", action: "确认清理", title: "清理 Ops 队列？", scope: `当前本地 Ops 队列 · ${queueCount} 条待处理/失败，${live.ops.length} 条可见记录`, undo: "不可自动撤销；清理后只能依赖底层审计归档或重新执行命令恢复上下文。", impact: "将调用 Ops purge API，移除当前队列上下文并刷新面板数据。", tone: "danger", fn: api.opsPurge })}><Icon d="x" />purge</button><button className="btn-grad sm" onClick={() => confirm({ label: "Replay queued ops", action: "确认重放", title: "重放 Ops 队列？", scope: "当前本地 Ops 待处理/失败队列", count: queueCount, undo: "重放调度本身不能撤销；每条结果会继续进入操作记录。", impact: "将调用 Ops retry API，重试 pending/failed 操作，可能触发后续投影、同步或写入效果。", tone: "sync", fn: api.opsRetry })}><Icon d="sync" />replay 队列</button></div>
       </header>
       <div className="ops-stats"><div className={`pstat ${pending ? "acc" : ""}`}><span className="pstat-l">待处理</span><span className="pstat-n">{pending}</span></div><div className={`pstat ${failed ? "warn" : ""}`}><span className="pstat-l">失败 / 漂移</span><span className="pstat-n">{failed}</span></div><div className="pstat"><span className="pstat-l">已完成</span><span className="pstat-n">{live.ops.filter((op) => op.status === "ok").length}</span></div><div className="pstat"><span className="pstat-l">审计事件</span><span className="pstat-n">{live.ops.length}</span></div></div>
       <nav className="plane-tabs">{([["ops", "待处理队列"], ["history", "审计历史"]] as const).map(([id, label]) => <button key={id} className={`det-tab ${(history ? "history" : "ops") === id ? "on" : ""}`} onClick={() => go(id)}><Icon d={id === "history" ? "clock" : "ops"} size={14} />{label}{id === "ops" && queueCount ? <span className="tab-count">{queueCount}</span> : null}</button>)}<span className="tab-flex" /></nav>
@@ -673,15 +676,14 @@ function Ops({ live, history, go, runAction }: { live: ReturnType<typeof usePane
   );
 }
 
-function Sync({ live, runAction }: { live: ReturnType<typeof usePanelData>; runAction: (label: string, fn: () => Promise<unknown>, options?: { confirm?: string }) => void }) {
+function Sync({ live, confirm }: { live: ReturnType<typeof usePanelData>; confirm: (action: Confirm) => void }) {
   const remote = live.remote;
   const remoteConfigured = Boolean(remote?.configured || remote?.url || remote?.remote);
-  const confirmReplay = { confirm: "确定要重放同步队列吗？这会修改本地注册表同步状态。" };
   const syncOps = live.ops.filter((op) => op.kind.startsWith("sync."));
   return (
     <div className="view view-sync">
-      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><span className="soon-pill"><Icon d="dl" size={14} />pull 未接入</span><button className="btn-grad sm" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" />replay</button></div></header>
-      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || remote?.remote || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-div" /><span className="rs-stat">pending <b>{remote?.pending_ops ?? live.queuedWriteCount}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => runAction("Sync replay", api.syncReplay, confirmReplay)}><Icon d="sync" size={13} />replay</button></div>
+      <header className="view-head"><div><h1>注册表同步</h1><p>Git 支撑 · push / pull / replay · remote 为空时保持 local-only</p></div><div className="ops-head-actions"><span className="soon-pill"><Icon d="dl" size={14} />pull 未接入</span><button className="btn-grad sm" onClick={() => confirm({ label: "Sync replay", action: "确认重放", title: "重放同步队列？", scope: `Git sync 队列 · ${remote?.url || remote?.remote || "local-only registry"}`, count: remote?.pending_ops ?? live.queuedWriteCount, undo: "重放调度本身不能撤销；同步结果会继续写入审计事件。", impact: "将调用 Sync replay API，重试同步队列并可能更新本地注册表同步状态。", tone: "sync", fn: api.syncReplay })}><Icon d="sync" />replay</button></div></header>
+      <div className="reg-strip"><span className="rs-git"><Icon d="branch" size={14} />remote origin</span><code>{remote?.url || remote?.remote || "not configured"}</code><span className="rs-div" /><span className="rs-stat">state <b>{remote?.sync_state ?? "local_only"}</b></span><span className="rs-div" /><span className="rs-stat">pending <b>{remote?.pending_ops ?? live.queuedWriteCount}</b></span><span className="rs-flex" /><button className="rs-panel" onClick={() => confirm({ label: "Sync replay", action: "确认重放", title: "重放同步队列？", scope: `Git sync 队列 · ${remote?.url || remote?.remote || "local-only registry"}`, count: remote?.pending_ops ?? live.queuedWriteCount, undo: "重放调度本身不能撤销；同步结果会继续写入审计事件。", impact: "将调用 Sync replay API，重试同步队列并可能更新本地注册表同步状态。", tone: "sync", fn: api.syncReplay })}><Icon d="sync" size={13} />replay</button></div>
       <div className="sync-grid">
         <section className="panel sync-topo-panel"><div className="panel-head"><h3><Icon d="sync" />注册表拓扑</h3><span className="panel-hint">{remoteConfigured ? "local -> origin" : "local only"}</span></div><svg viewBox="0 0 640 300" className="sync-topo"><path className={`beam ${remoteConfigured ? "on" : ""}`} stroke="var(--acc3)" d="M150 220 C150 112 320 132 320 86" /><circle className="topo-cloud" cx="320" cy="78" r="34" /><text x="320" y="82" textAnchor="middle" className="topo-name">origin</text><text x="320" y="104" textAnchor="middle" className="topo-sub">{remoteConfigured ? "configured" : "not configured"}</text><circle className="topo-node self" cx="150" cy="220" r="38" /><text x="150" y="218" textAnchor="middle" className="topo-name">local</text><text x="150" y="235" textAnchor="middle" className="topo-sub">{remote?.pending_ops ?? live.queuedWriteCount} pending</text></svg></section>
         <section className="panel"><div className="panel-head"><h3><Icon d="clock" />事件流</h3><span className="panel-hint">{syncOps.length} sync events</span></div><div className="ev-stream">{syncOps.slice(0, 6).map((op) => {
@@ -718,11 +720,11 @@ function Switch({ on, onChange, label = "切换开关" }: { on: boolean; onChang
 }
 
 function Market({ live }: { live: ReturnType<typeof usePanelData> }) {
-  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>当前只连接本地注册表，尚未接入市场目录服务</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>本地 skills</span></div><span className="reg-div" /><div className="reg-stat"><b>未接入</b><span>市场目录</span></div><span className="reg-flex" /><span className="reg-src">来源：本地注册表</span></div><EmptyPanel text="未接入真实市场目录 API，所以不展示市场分类或安装流。" /></div>;
+  return <div className="view view-market"><header className="view-head"><div><h1>市场</h1><p>Preview only · 当前只连接本地注册表，尚未接入市场目录服务</p></div><span className="preview-pill"><Icon d="market" size={14} />Preview · not connected</span></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>本地 skills</span></div><span className="reg-div" /><div className="reg-stat"><b>未接入</b><span>市场目录</span></div><span className="reg-flex" /><span className="reg-src">来源：本地注册表</span></div><section className="preview-panel"><div><h2>现在可用</h2><p>只读查看本地 registry 中已经存在的 skills 和数量。</p></div><div><h2>尚未接入</h2><p>市场目录、搜索、分类、评分和安装 API 还没有后端连接，因此这里不展示安装按钮或模拟安装流程。</p></div></section></div>;
 }
 
 function Forge({ live }: { live: ReturnType<typeof usePanelData> }) {
-  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>当前只读展示本地 skill，尚未接入创建向导</p></div></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>可参考 skills</span></div><span className="reg-div" /><div className="reg-stat"><b>未接入</b><span>写入流程</span></div><span className="reg-flex" /><span className="reg-src">未创建任何本地草稿</span></div><EmptyPanel text="未接入真实创建向导 API，所以不展示模板、AI 生成、文档导入或发布步骤。" /></div>;
+  return <div className="view view-forge"><header className="view-head"><div><h1>Forge</h1><p>Preview only · 当前只读展示本地 skill，尚未接入创建向导</p></div><span className="preview-pill"><Icon d="forge" size={14} />Preview · not connected</span></header><div className="reg-banner"><div className="reg-stat"><b>{live.skills.length}</b><span>可参考 skills</span></div><span className="reg-div" /><div className="reg-stat"><b>未接入</b><span>写入流程</span></div><span className="reg-flex" /><span className="reg-src">未创建任何本地草稿</span></div><section className="preview-panel"><div><h2>现在可用</h2><p>只读参考本地 registry 中的 skill inventory，帮助确认已有命名和标签。</p></div><div><h2>尚未接入</h2><p>创建向导、模板选择、AI 生成、文档导入、发布和写入 API 还没有后端连接，因此这里不展示创建按钮或模拟草稿流程。</p></div></section></div>;
 }
 
 function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; close: () => void }) {
@@ -738,14 +740,14 @@ function Terminal({ live, close }: { live: ReturnType<typeof usePanelData>; clos
 function Palette({ skills, go, openSkill, close }: { skills: Skill[]; go: (page: SkillMPage) => void; openSkill: (name: string) => void; close: () => void }) {
   const [filter, setFilter] = useState("");
   const q = filter.trim().toLowerCase();
-  const filteredPages = pages.filter((page) => !q || `${page.label} ${page.group}`.toLowerCase().includes(q));
+  const filteredPages = pages.filter((page) => !q || `${page.label} ${page.group} ${page.preview ? "preview not connected" : ""}`.toLowerCase().includes(q));
   const filteredSkills = skills.filter((skill) => !q || `${skill.name} ${skill.tag} ${skill.description ?? ""}`.toLowerCase().includes(q)).slice(0, 8);
   return (
     <div className="sm-veil" onMouseDown={close}>
       <div className="cmd-pal" onMouseDown={(event) => event.stopPropagation()}>
         <div className="cmd-search"><Icon d="search" /><input autoFocus value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="搜索页面或 skill" aria-label="搜索命令" /><button className="btn-icon" aria-label="关闭命令面板" onClick={close}><Icon d="x" /></button></div>
         <div className="cmd-list">
-          {filteredPages.map((page) => <button key={page.id} className="cmd-item" onClick={() => go(page.id)}><Icon d={page.icon} />Go to {page.label}<span>{page.group}</span></button>)}
+          {filteredPages.map((page) => <button key={page.id} className={`cmd-item ${page.preview ? "preview" : ""}`} aria-label={page.preview ? `Go to ${page.label} Preview not connected` : `Go to ${page.label}`} onClick={() => go(page.id)}><Icon d={page.icon} />Go to {page.label}<span>{page.preview ? "Preview · not connected" : page.group}</span></button>)}
           {filteredSkills.map((skill) => <button key={skill.name} className="cmd-item" onClick={() => openSkill(skill.name)}><Icon d="eye" />Open {skill.name}<span>{sourceLabel(skill)}</span></button>)}
           {filteredPages.length + filteredSkills.length === 0 ? <div className="panel-empty">没有匹配的命令。</div> : null}
         </div>

--- a/panel/src/styles/panel/skillm.css
+++ b/panel/src/styles/panel/skillm.css
@@ -118,8 +118,9 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .btn-ghost.installed{color:var(--ok);border-color:color-mix(in oklch,var(--ok) 40%,transparent);}
 .btn-icon{border:none;background:transparent;color:var(--sub);cursor:pointer;padding:6px;border-radius:8px;display:grid;place-items:center;transition:var(--t);}
 .btn-icon:hover{background:var(--raise);color:var(--ink);}
-.soon-pill,.mini-state{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line1);background:var(--raise);color:var(--sub);font-family:var(--mono);font-size:11px;font-weight:700;border-radius:9px;padding:7px 10px;white-space:nowrap;}
+.soon-pill,.mini-state,.preview-pill{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line1);background:var(--raise);color:var(--sub);font-family:var(--mono);font-size:11px;font-weight:700;border-radius:9px;padding:7px 10px;white-space:nowrap;}
 .mini-state{font-size:10.5px;padding:4px 8px;border-radius:7px;}
+.act-preview{position:absolute;right:1px;bottom:1px;max-width:42px;overflow:hidden;text-overflow:clip;border-radius:5px;padding:2px 3px;background:var(--warn);color:#1a1208;font-family:var(--mono);font-size:6.5px;font-weight:700;line-height:1;text-transform:uppercase;}
 
 /* ---- shared atoms ---- */
 .sm-glyph{display:grid;place-items:center;border-radius:11px;font-family:var(--mono);font-weight:700;flex:none;
@@ -520,6 +521,9 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 /* ============ install modal ============ */
 .sm-veil{position:fixed;inset:0;z-index:55;background:color-mix(in oklch,var(--bg) 60%,transparent);backdrop-filter:blur(8px);
   display:grid;place-items:center;padding:24px;animation:veilIn .15s;}
+.action-confirm{width:min(460px,94vw);background:var(--panel);border:1px solid var(--line2);border-radius:16px;padding:20px 22px;box-shadow:0 30px 80px -20px rgba(0,0,0,.6),var(--glow-shadow);animation:palIn .2s cubic-bezier(.2,.8,.2,1);}
+.ac-head{display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;}.ac-head h2{margin:0;font-size:18px;}.ac-head p{margin:3px 0 0;color:var(--faint);font-family:var(--mono);font-size:11px;}.ac-head .btn-icon{margin-left:auto;}.ac-icon{width:36px;height:36px;border-radius:10px;display:grid;place-items:center;background:color-mix(in oklch,var(--acc3) 14%,var(--panel));color:var(--acc3);}.action-confirm.danger .ac-icon{background:color-mix(in oklch,var(--err) 14%,var(--panel));color:var(--err);}
+.ac-facts{display:flex;flex-direction:column;gap:10px;margin:0;}.ac-facts div{padding:10px 12px;border:1px solid var(--line1);border-radius:10px;background:var(--bg2);}.ac-facts dt{font-family:var(--mono);font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px;}.ac-facts dd{margin:0;color:var(--sub);font-size:12.5px;line-height:1.55;}.ac-facts b{color:var(--ink);}.ac-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:16px;}
 .install-modal{width:min(480px,94vw);background:var(--panel);border:1px solid var(--line2);border-radius:18px;
   padding:22px 24px;box-shadow:0 30px 80px -20px rgba(0,0,0,.6),var(--glow-shadow);animation:palIn .25s cubic-bezier(.2,.8,.2,1);}
 .im-head{display:flex;align-items:center;gap:13px;margin-bottom:14px;}
@@ -673,6 +677,7 @@ body{font-family:var(--sans);background:var(--bg);overflow:hidden;}
 .reg-div{width:1px;height:26px;background:var(--line2);}
 .reg-flex{flex:1;}
 .reg-src{font-family:var(--mono);font-size:11px;color:var(--faint);}
+.preview-pill{color:var(--warn);border-color:color-mix(in oklch,var(--warn) 35%,transparent);background:color-mix(in oklch,var(--warn) 10%,var(--panel));}.preview-panel{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:14px;}.preview-panel>div{background:var(--panel);border:1px solid var(--line1);border-radius:var(--r);padding:16px 18px;}.preview-panel h2{margin:0 0 8px;font-size:14px;}.preview-panel p{margin:0;color:var(--sub);font-size:13px;line-height:1.6;}
 .mk-cats{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;}
 .mk-cat{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line1);background:var(--panel2);color:var(--sub);font-family:var(--sans);font-size:12.5px;font-weight:500;padding:7px 13px;border-radius:10px;cursor:pointer;transition:var(--t);white-space:nowrap;}
 .mk-cat svg{color:var(--acc2);}
@@ -1283,6 +1288,7 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .skillm-table th{text-align:left;color:var(--faint);font-size:10px;text-transform:uppercase;letter-spacing:.1em;padding:10px 12px;border-bottom:1px solid var(--line1);}
 .skillm-table td{padding:11px 12px;border-bottom:1px solid var(--line1);color:var(--sub);vertical-align:top;}
 .skillm-table tr:hover td{background:var(--raise);color:var(--ink);}
+.projection-head{align-items:flex-start;gap:12px;}.projection-scope-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;justify-content:flex-end;}.scope-pager,.scope-disclosure{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-family:var(--mono);font-size:10.5px;color:var(--sub);}.scope-pager{border:1px solid var(--line1);background:var(--raise);border-radius:9px;padding:4px;}.scope-pager button{border:0;background:transparent;color:var(--sub);font-family:var(--mono);font-size:10.5px;font-weight:700;padding:4px 7px;border-radius:6px;cursor:pointer;}.scope-pager button:hover:not(:disabled){background:var(--panel);color:var(--ink);}.scope-pager button:disabled{opacity:.4;cursor:not-allowed;}.scope-disclosure{margin:-5px 0 12px;}.scope-disclosure span{border:1px solid var(--line1);background:var(--bg2);border-radius:8px;padding:5px 8px;color:var(--faint);}
 .skillm-mini-graph{min-height:260px;}
 .skillm-graph-grid{display:grid;grid-template-columns:240px 1fr 280px;gap:12px;align-items:start;}
 .pg-node-row{height:29px;display:flex;align-items:center;gap:9px;margin-bottom:6px;padding:4px 8px;border:1px solid var(--line1);border-radius:9px;background:var(--raise);font-family:var(--mono);font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
@@ -1322,6 +1328,7 @@ button.pstat:hover{transform:translateY(-2px);border-color:var(--line2);box-shad
 .cmd-item:hover{background:var(--raise);}
 .cmd-item:focus-visible{outline:2px solid var(--acc3);outline-offset:2px;}
 .cmd-item span{font-family:var(--mono);font-size:10px;color:var(--faint);}
+.cmd-item.preview span{color:var(--warn);}
 .skillm-tweaks{
   position:fixed;right:16px;top:76px;z-index:62;width:320px;max-width:calc(100vw - 28px);
   max-height:calc(100vh - 118px);overflow:auto;background:color-mix(in oklch,var(--panel) 96%,transparent);


### PR DESCRIPTION
## Summary
- Add human-readable audit history rows with text/status/type filters and expandable raw details.
- Add explicit confirmation sheets for Ops purge/replay and sync replay, including scope, reversibility, impact, and queued counts.
- Mark Market and Forge as preview/not connected in navigation and placeholders.
- Add projection graph paging/disclosure so graph and table share the same scoped projection set.

Fixes #321
Fixes #322
Fixes #331
Fixes #334

## Verification
- cargo check
- cargo test
- make fmt-check
- make lint
- cd panel && bun install --frozen-lockfile
- cd panel && bun run typecheck
- cd panel && bun run test
- cd panel && bun run build
- make e2e
- make perf-smoke