### PR TITLE
fix(skill): skip Git metadata during source import

### DIFF
--- a/docs/plan/skill-control-plane-audit-2026-06-24.md
+++ b/docs/plan/skill-control-plane-audit-2026-06-24.md
@@ -1,0 +1,66 @@
+# Skill Control Plane Audit: Correctness Roadmap
+
+Date: 2026-06-24
+Status: Active plan
+
+## Decision
+
+Loom's direction is sound: it should remain a Git-backed skill registry and
+projection control plane, not a generic skill marketplace. The durable product
+boundary is:
+
+1. upstream providers find or fetch skills;
+2. Loom records provenance and policy;
+3. Loom plans, applies, audits, projects, evaluates, and rolls back local
+   installations across agent targets.
+
+## Current Findings
+
+1. Remote `skill add` clones a Git URL, copies the clone into `skills/<name>`,
+   and stages that directory. The copy helper rejects symlinks but did not
+   explicitly exclude nested Git metadata. That can leak `.git` data into a
+   registry skill and risks embedded-repository behavior.
+2. V1 docs already require portable skills to use `SKILL.md` plus `name` and
+   `description` frontmatter, but runtime validation still accepts legacy
+   `skill.md` and parses descriptions by line scanning.
+3. Panel/API have a skill read model, but CLI lacks first-class
+   `skill list/show/search/resolve` commands.
+4. Loom has Git-backed lifecycle primitives, release tags, and projection
+   revisions, but does not yet have package-lock-style source provenance,
+   resolved commits, artifact digests, or project lock entries.
+5. Security docs are honest about current limits: Loom does not validate skill
+   contents or verify upstream signatures. Existing guardrails remain valuable
+   but are not a substitute for source locking, policy, review, sandboxing,
+   and rollback.
+6. `agent preflight` and command dry-runs are useful planning foundations, but
+   there is no durable plan-id/apply protocol with idempotency.
+7. Agent hosts are currently fixed built-ins. That is acceptable for V1, but an
+   adapter protocol is the right long-term extension point.
+8. Loom can prove projection health, not whether a skill is useful. Trigger,
+   process, outcome, and efficiency evals should be separate product work.
+
+## Issue Map
+
+| Issue | Priority | Scope |
+|---|---:|---|
+| #338 | P0 | Prevent remote skill add from importing nested Git metadata. |
+| #339 | P1 | Add strict Agent Skills lint and compatibility modes. |
+| #340 | P1 | Add CLI skill inventory and discovery commands. |
+| #341 | P1 | Add a human-friendly `loom use` flow. |
+| #342 | P1 | Introduce source provenance and `loom.lock`. |
+| #343 | P1 | Add skill trust, capability, and policy checks. |
+| #344 | P1 | Add durable agent plan/apply with idempotency. |
+| #345 | P2 | Define configurable agent adapter protocol. |
+| #346 | P2 | Add skill eval matrix. |
+| #347 | P2 | Define GitHub and `gh skill` provider boundary. |
+
+## P0 Acceptance
+
+The first implementation slice is intentionally narrow:
+
+1. Recursive skill-source copies skip nested `.git` metadata.
+2. Normal non-VCS dotfiles remain importable.
+3. Symlink rejection remains unchanged.
+4. Tests prove skipped Git metadata cannot be staged as a skill payload.
+5. The follow-up provider design can move toward `git archive` or immutable
+   content-addressed staging after this safety fix is merged.

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 
@@ -236,7 +237,11 @@ pub(crate) fn copy_dir_recursive_without_symlinks(src: &Path, dst: &Path) -> Res
     }
     fs::create_dir_all(dst).with_context(|| format!("failed to create {}", dst.display()))?;
 
-    for entry in WalkDir::new(src).follow_links(false).into_iter() {
+    for entry in WalkDir::new(src)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|entry| entry.path() == src || entry.file_name() != OsStr::new(".git"))
+    {
         let entry = entry.with_context(|| format!("failed to walk {}", src.display()))?;
         let rel = entry.path().strip_prefix(src)?;
         if rel.as_os_str().is_empty() {
@@ -300,6 +305,47 @@ fn create_symlink_like(source_link: &Path, link_target: &Path, dst: &Path) -> Re
 mod tests {
     use super::copy_dir_recursive_without_symlinks;
     use std::fs;
+
+    #[test]
+    fn copy_without_symlinks_skips_git_metadata_but_keeps_dotfiles() -> anyhow::Result<()> {
+        let base = std::env::temp_dir().join(format!(
+            "loom-copy-no-git-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let src = base.join("src");
+        let dst = base.join("dst");
+        fs::create_dir_all(src.join(".git/objects"))?;
+        fs::create_dir_all(src.join("nested"))?;
+        fs::write(src.join(".git/config"), "[core]\n")?;
+        fs::write(src.join(".git/objects/object"), "object\n")?;
+        fs::write(src.join("nested/.git"), "gitdir: ../real-git\n")?;
+        fs::write(src.join("nested/normal.txt"), "normal\n")?;
+        fs::write(src.join("SKILL.md"), "# skill\n")?;
+        fs::write(src.join(".env.example"), "LOOM=1\n")?;
+
+        copy_dir_recursive_without_symlinks(&src, &dst)?;
+
+        assert!(dst.join("SKILL.md").is_file(), "skill file must be copied");
+        assert!(
+            dst.join(".env.example").is_file(),
+            "normal dotfile must be copied"
+        );
+        assert!(
+            !dst.join(".git").exists(),
+            "git metadata directory must not be copied"
+        );
+        assert!(
+            dst.join("nested/normal.txt").is_file(),
+            "normal nested file must be copied"
+        );
+        assert!(
+            !dst.join("nested/.git").exists(),
+            "git metadata file must not be copied"
+        );
+
+        fs::remove_dir_all(base)?;
+        Ok(())
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -240,7 +240,11 @@ pub(crate) fn copy_dir_recursive_without_symlinks(src: &Path, dst: &Path) -> Res
     for entry in WalkDir::new(src)
         .follow_links(false)
         .into_iter()
-        .filter_entry(|entry| entry.path() == src || entry.file_name() != OsStr::new(".git"))
+        .filter_entry(|entry| {
+            entry.path() == src
+                || entry.file_name() != OsStr::new(".git")
+                || entry.file_type().is_symlink()
+        })
     {
         let entry = entry.with_context(|| format!("failed to walk {}", src.display()))?;
         let rel = entry.path().strip_prefix(src)?;
@@ -341,6 +345,36 @@ mod tests {
         assert!(
             !dst.join("nested/.git").exists(),
             "git metadata file must not be copied"
+        );
+
+        fs::remove_dir_all(base)?;
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_without_symlinks_rejects_git_metadata_symlink() -> anyhow::Result<()> {
+        let base = std::env::temp_dir().join(format!(
+            "loom-copy-git-symlink-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let src = base.join("src");
+        let dst = base.join("dst");
+        fs::create_dir_all(&src)?;
+        fs::write(src.join("SKILL.md"), "# skill\n")?;
+        std::os::unix::fs::symlink("/tmp/not-git", src.join(".git"))?;
+
+        let err = match copy_dir_recursive_without_symlinks(&src, &dst) {
+            Ok(()) => anyhow::bail!(".git symlink must be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("unsupported symlink"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !dst.join(".git").exists(),
+            "git symlink path must not be copied"
         );
 
         fs::remove_dir_all(base)?;

--- a/tests/reliability.rs
+++ b/tests/reliability.rs
@@ -1519,6 +1519,61 @@ fn skill_add_blocks_nested_symlink_source() {
     assert!(!root.path().join("skills/demo").exists());
 }
 
+#[test]
+fn skill_add_skips_nested_git_metadata_and_stages_regular_files() {
+    let root = TestDir::new("skill-add-no-nested-git");
+    let source = make_skill_source(root.path(), "source-git-skill");
+    fs::write(source.join(".env.example"), "LOOM=1\n").expect("write dotfile");
+    git_ok_in(&source, &["init"]);
+    git_set_identity(&source, "Source Skill", "source@example.com");
+    git_ok_in(&source, &["add", "SKILL.md", ".env.example"]);
+    git_ok_in(&source, &["commit", "-m", "source skill"]);
+
+    let env = run_loom_ok(
+        root.path(),
+        &["skill", "add", source.to_str().unwrap(), "--name", "demo"],
+    );
+
+    assert_eq!(env["ok"], Value::Bool(true));
+    assert!(
+        root.path().join("skills/demo/SKILL.md").is_file(),
+        "skill entrypoint should be copied"
+    );
+    assert!(
+        root.path().join("skills/demo/.env.example").is_file(),
+        "normal dotfiles should be copied"
+    );
+    assert!(
+        !root.path().join("skills/demo/.git").exists(),
+        "nested Git metadata must not be imported into registry skill"
+    );
+
+    let staged_tree = git_ok_in(root.path(), &["ls-files", "--stage", "--", "skills/demo"]);
+    assert!(
+        staged_tree.contains("100644") && staged_tree.contains("skills/demo/SKILL.md"),
+        "skill files should be tracked as normal blobs: {staged_tree}"
+    );
+    assert!(
+        !staged_tree.contains("160000"),
+        "skill import must not stage an embedded repository gitlink: {staged_tree}"
+    );
+
+    let fresh_clone = root.path().join("fresh-clone");
+    git_ok([
+        "clone",
+        root.path().to_str().unwrap(),
+        fresh_clone.to_str().unwrap(),
+    ]);
+    assert!(
+        fresh_clone.join("skills/demo/SKILL.md").is_file(),
+        "fresh clone should contain imported skill contents"
+    );
+    assert!(
+        !fresh_clone.join("skills/demo/.git").exists(),
+        "fresh clone must not contain nested Git metadata"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn skill_add_rolls_back_on_copy_failure_no_partial_tree() {


### PR DESCRIPTION
## Summary

- Skip entries named `.git` during skill source directory copies, while preserving existing symlink rejection.
- Add a helper-level regression test proving `.git` metadata is skipped but normal dotfiles are copied.
- Add a command-level regression test proving `loom skill add` imports a Git-backed source as normal files, does not stage mode `160000`, and survives a fresh clone.
- Add a concise audit roadmap/spec linking the broader product findings to issues #338-#347.

Fixes #338

## Verification

- `cargo test copy_without_symlinks -- --test-threads=1`
- `cargo test skill_add_skips_nested_git_metadata_and_stages_regular_files -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check`
- `cargo test -- --test-threads=1`
