### PR TITLE
feat(skill): add source provenance and loom.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +347,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -735,6 +783,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +821,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "thiserror",
  "tokio",
@@ -954,6 +1014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1048,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 include_dir = "0.7.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.150"
+sha2 = "0.10.9"
 tar = "0.4.44"
 thiserror = "2.0.12"
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "signal", "process", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ For managed projection flows:
 ```bash
 # Import a skill into the registry
 loom skill add "$HOME/.claude/skills/my-skill" --name my-skill
+# Or pin a Git/GitHub source ref and subdirectory.
+loom skill add github:owner/repo//skills/my-skill --name my-skill --ref v1.2.3
 
 # Register a managed Claude Code target
 mkdir -p "$HOME/.loom-targets/claude/skills"
@@ -174,11 +176,12 @@ The chain `add → capture → save → snapshot → release → rollback` is th
 
 | Verb | What it does | When to reach for it | Acts on |
 |------|--------------|----------------------|---------|
-| `loom skill add` | Import a skill source into the registry | First-time onboarding of a skill from a local path or Git URL | Source (initial import) |
+| `loom skill add` | Import a skill source into the registry and record source provenance in `loom.lock` | First-time onboarding of a skill from a local path, Git URL, local Git repo, or `github:owner/repo//subdir` | Source (initial import) |
 | `loom skill list` | List registry, source, and observed skill inventory | See what skills exist before mutating registry state | Source + registry metadata (read-only) |
 | `loom skill show` | Show one skill from the shared inventory model | Inspect entrypoint, description, source status, projections, compatible targets, warnings, and next actions | Source + registry metadata (read-only) |
 | `loom skill search` | Search skills with deterministic lexical scoring | Find likely skills by id, description, tags, warning state, agent, profile, status, or trust | Source + registry metadata (read-only) |
 | `loom skill resolve` | Resolve a task description to candidate skills without an LLM | Let agents choose a skill transparently from local metadata and scoring inputs | Source + registry metadata (read-only) |
+| `loom skill provenance inspect/verify/refresh` | Inspect, check, or refresh recorded source provenance and `loom.lock` | Confirm a skill still matches the source digest and pinned ref metadata | Source metadata + `loom.lock` |
 | `loom use` | Plan or apply target, binding, and projection setup in one flow | New users want to use a skill without copying target/binding IDs between commands | Source + target + registry metadata |
 | `loom skill project` | Realize a registry skill into an agent directory | Make the skill visible to the agent (Claude/Codex/…) | Target (live directory) |
 | `loom skill capture` | Pull live edits from a projection back into the source | The user edited the skill **inside the agent directory** and you want those edits tracked | Projection → source |
@@ -264,7 +267,10 @@ loom skill list
 loom skill show <skill>
 loom skill search <query> [--agent <agent>] [--profile <profile>] [--status <status>] [--trust <trust>]
 loom skill resolve <task-description> [--agent <agent>] [--workspace <path>]
-loom skill add <path|git-url> --name <skill>
+loom skill add <path|git-url|github:owner/repo//subdir> --name <skill> [--ref <branch|tag|commit>] [--subdir <path>]
+loom skill provenance inspect <skill>
+loom skill provenance verify <skill>
+loom skill provenance refresh <skill>
 loom skill project <skill> --binding <binding-id> [--target <target-id>] [--method <symlink|copy|materialize>] [--dry-run]
 loom skill capture [<skill>] [--binding <binding-id>] [--instance <instance-id>] [--message <msg>] [--dry-run]
 loom skill save <skill> [--message <msg>]

--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -376,7 +376,7 @@ Rules:
 ### 11.1 `skill add`
 
 ```bash
-loom --json --root <root> skill add <path|git-url> --name <skill-id>
+loom --json --root <root> skill add <path|git-url|github:owner/repo//subdir> --name <skill-id> [--ref <branch|tag|commit>] [--subdir <path>]
 ```
 
 Write command.
@@ -385,6 +385,31 @@ Rules:
 
 1. adds canonical source under `skills/<skill-id>`
 2. must fail when target skill already exists
+3. local directory imports use provider `local_path`
+4. Git URL and local Git repository imports use provider `git`; `--ref` may be a branch, tag, or commit
+5. `github:owner/repo//subdir` imports use provider `github` and clone `https://github.com/owner/repo.git`; this command must not require or duplicate `gh` authentication scope
+6. `--subdir` selects a source subdirectory when it is not encoded in the GitHub locator
+7. successful imports write `state/registry/sources.json` and deterministic root `loom.lock`
+8. provenance records include provider, locator, requested ref, resolved commit when Git-backed, source tree hash when Git-backed, source subdir, artifact digest, import time, and importer version
+
+### 11.1.1 `skill provenance`
+
+```bash
+loom --json --root <root> skill provenance inspect <skill-id>
+loom --json --root <root> skill provenance verify <skill-id>
+loom --json --root <root> skill provenance refresh <skill-id>
+```
+
+Mixed read/write command group.
+
+Rules:
+
+1. `inspect` is read-only and returns the recorded `sources.json` entry plus the matching `loom.lock` entry
+2. `verify` is read-only and compares the current canonical skill digest against both recorded provenance and `loom.lock`
+3. `refresh` is a write command; it recomputes the current canonical skill digest, updates `state/registry/sources.json` and `loom.lock`, and commits only provenance artifacts
+4. `refresh` must not mutate projection state, target directories, binding rules, or live agent skill directories
+5. `loom.lock` is generated from sorted source records so repeated writes are deterministic
+6. missing skill sources return `SKILL_NOT_FOUND`; missing provenance records return `STATE_NOT_INITIALIZED`
 
 ### 11.2 `skill import-observed`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 
+mod provenance;
 mod use_flow;
+pub use provenance::{AddArgs, SkillProvenanceCommand};
 pub use use_flow::{UseArgs, UseScope};
 
 #[derive(Debug, Clone, Parser, Serialize)]
@@ -217,6 +219,11 @@ pub enum SkillCommand {
         #[command(subcommand)]
         command: SkillTrashCommand,
     },
+    #[command(about = "Inspect, verify, and refresh skill source provenance")]
+    Provenance {
+        #[command(subcommand)]
+        command: SkillProvenanceCommand,
+    },
     #[command(about = "Verify a skill source has no uncommitted drift")]
     Verify(SkillOnlyArgs),
     #[command(about = "Lint one skill for portable Agent Skills compliance")]
@@ -392,16 +399,6 @@ pub struct HistoryRepairArgs {
 pub enum HistoryRepairStrategyArg {
     Local,
     Remote,
-}
-
-#[derive(Debug, Clone, Args, Serialize)]
-pub struct AddArgs {
-    /// Local skill directory or Git URL to import.
-    pub source: String,
-
-    /// Registry skill name, e.g. rust-review.
-    #[arg(long)]
-    pub name: String,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]

--- a/src/cli/provenance.rs
+++ b/src/cli/provenance.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use super::SkillOnlyArgs;
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct AddArgs {
+    /// Local skill directory, Git URL, local Git repo, or github:owner/repo//subdir source.
+    pub source: String,
+
+    /// Registry skill name, e.g. rust-review.
+    #[arg(long)]
+    pub name: String,
+
+    /// Source ref to import for Git/GitHub sources. May be a branch, tag, or commit.
+    #[arg(long = "ref")]
+    pub source_ref: Option<String>,
+
+    /// Subdirectory inside the source repository or local path.
+    #[arg(long)]
+    pub subdir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize)]
+pub enum SkillProvenanceCommand {
+    #[command(about = "Inspect recorded source provenance and lock metadata")]
+    Inspect(SkillOnlyArgs),
+    #[command(about = "Verify current source digest against provenance and loom.lock")]
+    Verify(SkillOnlyArgs),
+    #[command(about = "Refresh provenance and loom.lock from the current skill source")]
+    Refresh(SkillOnlyArgs),
+}

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -126,6 +126,11 @@ pub(crate) fn command_name(command: &Command) -> &'static str {
             SkillCommand::History(_) => "skill.history",
             SkillCommand::Lint(_) => "skill.lint",
             SkillCommand::Diagnose(_) => "skill.diagnose",
+            SkillCommand::Provenance { command } => match command {
+                crate::cli::SkillProvenanceCommand::Inspect(_) => "skill.provenance.inspect",
+                crate::cli::SkillProvenanceCommand::Verify(_) => "skill.provenance.verify",
+                crate::cli::SkillProvenanceCommand::Refresh(_) => "skill.provenance.refresh",
+            },
             SkillCommand::Trash {
                 command: SkillTrashCommand::Add(_),
             } => "skill.trash.add",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod history_cmds;
 #[cfg(test)]
 mod observed_tests;
 mod projections;
+mod provenance;
 mod skill_cmds;
 mod skill_diagnose;
 #[cfg(test)]
@@ -29,8 +30,8 @@ use uuid::Uuid;
 
 use crate::cli::{
     AgentCommand, Cli, Command, OpsCommand, OpsHistoryCommand, RemoteCommand, SkillCommand,
-    SkillOrphanCommand, SkillTrashCommand, SyncCommand, TargetCommand, WorkspaceBindingCommand,
-    WorkspaceCommand, WorkspaceInitArgs,
+    SkillOrphanCommand, SkillProvenanceCommand, SkillTrashCommand, SyncCommand, TargetCommand,
+    WorkspaceBindingCommand, WorkspaceCommand, WorkspaceInitArgs,
 };
 use crate::envelope::{Envelope, Meta};
 use crate::state::{AppContext, home_dir};
@@ -223,6 +224,9 @@ impl App {
                 SkillCommand::Show(args) => self.cmd_skill_show(args),
                 SkillCommand::Search(args) => self.cmd_skill_search(args),
                 SkillCommand::Resolve(args) => self.cmd_skill_resolve(args),
+                SkillCommand::Provenance { command } => {
+                    self.cmd_skill_provenance(command, &request_id)
+                }
                 SkillCommand::Verify(args) => self.cmd_verify(args),
                 SkillCommand::Lint(args) => self.cmd_skill_lint(args),
                 SkillCommand::Diagnose(args) => self.cmd_skill_diagnose(args),
@@ -401,6 +405,9 @@ fn command_requires_durable_audit(command: &Command) -> bool {
             | SkillCommand::Watch(_)
             | SkillCommand::Snapshot(_)
             | SkillCommand::Release(_)
+            | SkillCommand::Provenance {
+                command: SkillProvenanceCommand::Refresh(_),
+            }
             | SkillCommand::Trash {
                 command:
                     SkillTrashCommand::Add(_)
@@ -420,6 +427,9 @@ fn command_requires_durable_audit(command: &Command) -> bool {
             | SkillCommand::Lint(_)
             | SkillCommand::Verify(_)
             | SkillCommand::Diagnose(_)
+            | SkillCommand::Provenance {
+                command: SkillProvenanceCommand::Inspect(_) | SkillProvenanceCommand::Verify(_),
+            }
             | SkillCommand::Trash {
                 command: SkillTrashCommand::List,
             }

--- a/src/commands/provenance.rs
+++ b/src/commands/provenance.rs
@@ -1,0 +1,653 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+use crate::cli::{AddArgs, SkillOnlyArgs, SkillProvenanceCommand};
+use crate::envelope::Meta;
+use crate::fs_util::remove_path_if_exists;
+use crate::gitops;
+use crate::state::AppContext;
+use crate::state_model::RegistryStatePaths;
+use crate::types::ErrorCode;
+
+use super::helpers::{map_arg, map_git, map_io, validate_skill_name};
+use super::{App, CommandFailure};
+
+const SOURCES_REL: &str = "state/registry/sources.json";
+const LOCK_REL: &str = "loom.lock";
+
+#[derive(Debug, Clone)]
+pub(crate) struct AddSourceResolution {
+    pub copy_source: PathBuf,
+    pub descriptor: SourceDescriptor,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SkillSourcesFile {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub sources: Vec<SkillSourceRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SkillSourceRecord {
+    pub skill_id: String,
+    pub source: SourceDescriptor,
+    pub artifact: ArtifactDescriptor,
+    pub imported_at: DateTime<Utc>,
+    pub importer_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SourceDescriptor {
+    pub provider: String,
+    pub locator: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub subdir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tree_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ArtifactDescriptor {
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LoomLockFile {
+    version: u32,
+    skills: BTreeMap<String, LoomLockSkill>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LoomLockSkill {
+    source: String,
+    provider: String,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    requested_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tree_sha: Option<String>,
+    digest: String,
+    agents: Vec<String>,
+    scope: String,
+}
+
+impl App {
+    pub fn cmd_skill_provenance(
+        &self,
+        command: &SkillProvenanceCommand,
+        request_id: &str,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        match command {
+            SkillProvenanceCommand::Inspect(args) => self.cmd_provenance_inspect(args),
+            SkillProvenanceCommand::Verify(args) => self.cmd_provenance_verify(args),
+            SkillProvenanceCommand::Refresh(args) => self.cmd_provenance_refresh(args, request_id),
+        }
+    }
+
+    fn cmd_provenance_inspect(
+        &self,
+        args: &SkillOnlyArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        let record = load_record_for_skill(&self.ctx, &args.skill)?;
+        let lock = load_lock_entry_for_skill(&self.ctx, &args.skill)
+            .map_err(map_io)?
+            .unwrap_or(Value::Null);
+        Ok((
+            json!({
+                "skill": args.skill,
+                "provenance": record,
+                "lock": lock,
+            }),
+            Meta::default(),
+        ))
+    }
+
+    fn cmd_provenance_verify(
+        &self,
+        args: &SkillOnlyArgs,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        let record = load_record_for_skill(&self.ctx, &args.skill)?;
+        let current_digest =
+            skill_tree_digest(&self.ctx.skill_path(&args.skill)).map_err(map_io)?;
+        let lock = load_lock_entry_for_skill(&self.ctx, &args.skill).map_err(map_io)?;
+        let lock_digest = lock
+            .as_ref()
+            .and_then(|entry| entry.get("digest"))
+            .and_then(Value::as_str);
+        let matches_record = current_digest == record.artifact.digest;
+        let matches_lock = lock_digest == Some(current_digest.as_str());
+        Ok((
+            json!({
+                "skill": args.skill,
+                "matches": matches_record && matches_lock,
+                "recorded_digest": record.artifact.digest,
+                "current_digest": current_digest,
+                "lock_digest": lock_digest,
+                "lock_present": lock.is_some(),
+                "source": record.source,
+            }),
+            Meta::default(),
+        ))
+    }
+
+    fn cmd_provenance_refresh(
+        &self,
+        args: &SkillOnlyArgs,
+        request_id: &str,
+    ) -> std::result::Result<(Value, Meta), CommandFailure> {
+        validate_skill_name(&args.skill).map_err(map_arg)?;
+        let _workspace = self
+            .ctx
+            .lock_workspace()
+            .map_err(super::helpers::map_lock)?;
+        self.ensure_write_repo_ready()?;
+        let mut record = load_record_for_skill(&self.ctx, &args.skill)?;
+        let previous_digest = record.artifact.digest.clone();
+        record.artifact.digest =
+            skill_tree_digest(&self.ctx.skill_path(&args.skill)).map_err(map_io)?;
+        record.imported_at = Utc::now();
+        record.importer_version = importer_version();
+        save_record_and_lock(&self.ctx, record.clone())?;
+        stage_provenance_paths(&self.ctx)?;
+        let changed = previous_digest != record.artifact.digest;
+        let mut meta = Meta::default();
+        if gitops::has_staged_changes_for_path(&self.ctx, Path::new(SOURCES_REL))
+            .map_err(map_git)?
+            || gitops::has_staged_changes_for_path(&self.ctx, Path::new(LOCK_REL))
+                .map_err(map_git)?
+        {
+            let commit = gitops::commit(
+                &self.ctx,
+                &format!("provenance({}): refresh lock", args.skill),
+            )
+            .map_err(map_git)?;
+            super::projections::maybe_autosync_or_queue(
+                &self.ctx,
+                "provenance.refresh",
+                request_id,
+                json!({"skill": args.skill, "commit": commit}),
+                &mut meta,
+            )?;
+        }
+        Ok((
+            json!({
+                "skill": args.skill,
+                "changed": changed,
+                "previous_digest": previous_digest,
+                "current_digest": record.artifact.digest,
+                "provenance_path": sources_rel(),
+                "lock_path": LOCK_REL,
+            }),
+            meta,
+        ))
+    }
+}
+
+pub(crate) fn resolve_add_source(
+    ctx: &AppContext,
+    args: &AddArgs,
+    staging_root: &Path,
+) -> std::result::Result<AddSourceResolution, CommandFailure> {
+    let subdir = normalize_subdir(args.subdir.as_deref())?;
+    if let Some(github) = parse_github_source(&args.source, &subdir)? {
+        return clone_git_source(
+            ctx,
+            &github.clone_url,
+            args.source_ref.as_deref(),
+            github.subdir,
+            staging_root,
+            |commit, tree| SourceDescriptor {
+                provider: "github".to_string(),
+                locator: args.source.clone(),
+                repository: Some(github.repository),
+                path: None,
+                subdir: github.lock_subdir,
+                requested_ref: args.source_ref.clone(),
+                resolved_commit: Some(commit),
+                tree_sha: Some(tree),
+            },
+        );
+    }
+
+    let source_path = Path::new(&args.source);
+    let looks_like_git_ref_import = args.source_ref.is_some() && source_path.exists();
+    if source_path.exists() && !looks_like_git_ref_import {
+        let base = fs::canonicalize(source_path).map_err(map_io)?;
+        let copy_source = join_checked_subdir(&base, &subdir);
+        return Ok(AddSourceResolution {
+            copy_source,
+            descriptor: SourceDescriptor {
+                provider: "local_path".to_string(),
+                locator: args.source.clone(),
+                repository: None,
+                path: Some(base.display().to_string()),
+                subdir,
+                requested_ref: None,
+                resolved_commit: None,
+                tree_sha: None,
+            },
+        });
+    }
+
+    let source = args.source.as_str();
+    gitops::validate_git_url(source).map_err(|err| {
+        CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            format!("invalid git source '{}': {}", source, err),
+        )
+    })?;
+    clone_git_source(
+        ctx,
+        source,
+        args.source_ref.as_deref(),
+        subdir.clone(),
+        staging_root,
+        |commit, tree| SourceDescriptor {
+            provider: "git".to_string(),
+            locator: args.source.clone(),
+            repository: Some(args.source.clone()),
+            path: None,
+            subdir,
+            requested_ref: args.source_ref.clone(),
+            resolved_commit: Some(commit),
+            tree_sha: Some(tree),
+        },
+    )
+}
+
+pub(crate) fn provenance_record_for_skill(
+    skill: &str,
+    descriptor: SourceDescriptor,
+    skill_path: &Path,
+) -> std::result::Result<SkillSourceRecord, CommandFailure> {
+    Ok(SkillSourceRecord {
+        skill_id: skill.to_string(),
+        source: descriptor,
+        artifact: ArtifactDescriptor {
+            digest: skill_tree_digest(skill_path).map_err(map_io)?,
+        },
+        imported_at: Utc::now(),
+        importer_version: importer_version(),
+    })
+}
+
+pub(crate) fn save_record_and_lock(
+    ctx: &AppContext,
+    record: SkillSourceRecord,
+) -> std::result::Result<(), CommandFailure> {
+    let mut sources = load_sources(ctx).map_err(map_io)?;
+    sources
+        .sources
+        .retain(|item| item.skill_id != record.skill_id);
+    sources.sources.push(record);
+    sources.sources.sort_by(|a, b| a.skill_id.cmp(&b.skill_id));
+    write_sources(ctx, &sources).map_err(map_io)?;
+    write_lock(ctx, &sources).map_err(map_io)?;
+    Ok(())
+}
+
+pub(crate) fn stage_provenance_paths(ctx: &AppContext) -> std::result::Result<(), CommandFailure> {
+    gitops::stage_path(ctx, Path::new(SOURCES_REL)).map_err(map_git)?;
+    gitops::stage_path(ctx, Path::new(LOCK_REL)).map_err(map_git)?;
+    Ok(())
+}
+
+fn load_record_for_skill(
+    ctx: &AppContext,
+    skill: &str,
+) -> std::result::Result<SkillSourceRecord, CommandFailure> {
+    validate_skill_name(skill).map_err(map_arg)?;
+    if !ctx.skill_path(skill).exists() {
+        return Err(CommandFailure::new(
+            ErrorCode::SkillNotFound,
+            format!("skill '{}' not found", skill),
+        ));
+    }
+    let sources = load_sources(ctx).map_err(map_io)?;
+    sources
+        .sources
+        .into_iter()
+        .find(|record| record.skill_id == skill)
+        .ok_or_else(|| {
+            CommandFailure::new(
+                ErrorCode::StateNotInitialized,
+                format!("provenance for skill '{}' not found", skill),
+            )
+        })
+}
+
+fn load_sources(ctx: &AppContext) -> Result<SkillSourcesFile> {
+    let path = sources_file(ctx);
+    if !path.exists() {
+        return Ok(SkillSourcesFile {
+            schema_version: 1,
+            sources: Vec::new(),
+        });
+    }
+    let raw = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))
+}
+
+fn load_lock_entry_for_skill(ctx: &AppContext, skill: &str) -> Result<Option<Value>> {
+    let path = ctx.root.join(LOCK_REL);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let lock: LoomLockFile =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    lock.skills
+        .get(skill)
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn write_sources(ctx: &AppContext, sources: &SkillSourcesFile) -> Result<()> {
+    let path = sources_file(ctx);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let raw = serde_json::to_string_pretty(sources)? + "\n";
+    fs::write(&path, raw).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_lock(ctx: &AppContext, sources: &SkillSourcesFile) -> Result<()> {
+    let mut skills = BTreeMap::new();
+    for record in &sources.sources {
+        skills.insert(record.skill_id.clone(), lock_skill_for_record(ctx, record)?);
+    }
+    let lock = LoomLockFile { version: 1, skills };
+    let raw = serde_json::to_string_pretty(&lock)? + "\n";
+    fs::write(ctx.root.join(LOCK_REL), raw).with_context(|| format!("write {}", LOCK_REL))
+}
+
+fn lock_skill_for_record(ctx: &AppContext, record: &SkillSourceRecord) -> Result<LoomLockSkill> {
+    Ok(LoomLockSkill {
+        source: lock_source_locator(&record.source),
+        provider: record.source.provider.clone(),
+        requested_ref: record.source.requested_ref.clone(),
+        commit: record.source.resolved_commit.clone(),
+        tree_sha: record.source.tree_sha.clone(),
+        digest: record.artifact.digest.clone(),
+        agents: projected_agents(ctx, &record.skill_id)?,
+        scope: "project".to_string(),
+    })
+}
+
+fn projected_agents(ctx: &AppContext, skill: &str) -> Result<Vec<String>> {
+    let paths = RegistryStatePaths::from_app_context(ctx);
+    let Some(snapshot) = paths.maybe_load_snapshot()? else {
+        return Ok(Vec::new());
+    };
+    let mut target_ids = BTreeSet::new();
+    for projection in snapshot.projections.projections {
+        if projection.skill_id == skill {
+            target_ids.insert(projection.target_id);
+        }
+    }
+    for rule in snapshot.rules.rules {
+        if rule.skill_id == skill {
+            target_ids.insert(rule.target_id);
+        }
+    }
+    let mut agents = BTreeSet::new();
+    for target in snapshot.targets.targets {
+        if target_ids.contains(&target.target_id) {
+            agents.insert(target.agent);
+        }
+    }
+    Ok(agents.into_iter().collect())
+}
+
+fn lock_source_locator(source: &SourceDescriptor) -> String {
+    match source.provider.as_str() {
+        "github" => format!(
+            "github:{}//{}",
+            source.repository.as_deref().unwrap_or_default(),
+            source.subdir
+        ),
+        "git" => format!(
+            "{}//{}",
+            source.repository.as_deref().unwrap_or(&source.locator),
+            source.subdir
+        ),
+        "local_path" => format!(
+            "{}//{}",
+            source.path.as_deref().unwrap_or(&source.locator),
+            source.subdir
+        ),
+        _ => source.locator.clone(),
+    }
+}
+
+fn sources_file(ctx: &AppContext) -> PathBuf {
+    ctx.root.join(SOURCES_REL)
+}
+
+fn sources_rel() -> &'static str {
+    SOURCES_REL
+}
+
+fn importer_version() -> String {
+    format!("loom/{}", env!("CARGO_PKG_VERSION"))
+}
+
+fn skill_tree_digest(path: &Path) -> Result<String> {
+    let mut entries = Vec::new();
+    for entry in WalkDir::new(path).follow_links(false).sort_by_file_name() {
+        let entry = entry.with_context(|| format!("walk {}", path.display()))?;
+        if entry.file_type().is_dir() {
+            continue;
+        }
+        let rel = entry
+            .path()
+            .strip_prefix(path)
+            .with_context(|| format!("strip {}", path.display()))?;
+        entries.push((rel.to_path_buf(), entry.path().to_path_buf()));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (rel, full) in entries {
+        let rel = rel.to_string_lossy();
+        hasher.update(b"path\0");
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        let metadata =
+            fs::symlink_metadata(&full).with_context(|| format!("stat {}", full.display()))?;
+        if metadata.file_type().is_symlink() {
+            hasher.update(b"symlink\0");
+            hasher.update(fs::read_link(&full)?.to_string_lossy().as_bytes());
+        } else {
+            hasher.update(b"file\0");
+            let mut file =
+                fs::File::open(&full).with_context(|| format!("open {}", full.display()))?;
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf)
+                .with_context(|| format!("read {}", full.display()))?;
+            hasher.update((buf.len() as u64).to_be_bytes());
+            hasher.update(&buf);
+        }
+        hasher.update(b"\0");
+    }
+    Ok(format!("sha256:{}", to_hex(&hasher.finalize())))
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+struct GithubSource {
+    repository: String,
+    clone_url: String,
+    subdir: String,
+    lock_subdir: String,
+}
+
+fn parse_github_source(
+    raw: &str,
+    arg_subdir: &str,
+) -> std::result::Result<Option<GithubSource>, CommandFailure> {
+    let Some(rest) = raw.strip_prefix("github:") else {
+        return Ok(None);
+    };
+    let (repo, source_subdir) = rest.split_once("//").unwrap_or((rest, ""));
+    if repo.is_empty() || !repo.contains('/') {
+        return Err(CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            "github source must look like github:owner/repo//optional/subdir",
+        ));
+    }
+    if !source_subdir.is_empty() && !arg_subdir.is_empty() {
+        return Err(CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            "pass subdir either in github:owner/repo//subdir or --subdir, not both",
+        ));
+    }
+    let source_subdir = if source_subdir.is_empty() {
+        arg_subdir.to_string()
+    } else {
+        normalize_subdir(Some(Path::new(source_subdir)))?
+    };
+    Ok(Some(GithubSource {
+        repository: repo.to_string(),
+        clone_url: format!("https://github.com/{}.git", repo),
+        subdir: source_subdir.clone(),
+        lock_subdir: source_subdir,
+    }))
+}
+
+fn clone_git_source<F>(
+    _ctx: &AppContext,
+    source: &str,
+    requested_ref: Option<&str>,
+    subdir: String,
+    staging_root: &Path,
+    descriptor: F,
+) -> std::result::Result<AddSourceResolution, CommandFailure>
+where
+    F: FnOnce(String, String) -> SourceDescriptor,
+{
+    let clone_tmp = staging_root.join("clone");
+    remove_path_if_exists(&clone_tmp).map_err(map_io)?;
+    let clone = run_git_allow_failure_in(
+        staging_root,
+        &["clone", source, clone_tmp.to_string_lossy().as_ref()],
+    )
+    .map_err(map_git)?;
+    if !clone.status.success() {
+        return Err(CommandFailure::new(
+            ErrorCode::ArgInvalid,
+            format!(
+                "failed to clone source: {}",
+                String::from_utf8_lossy(&clone.stderr).trim()
+            ),
+        ));
+    }
+    if let Some(reference) = requested_ref {
+        let checkout = run_git_allow_failure_in(&clone_tmp, &["checkout", "--detach", reference])
+            .map_err(map_git)?;
+        if !checkout.status.success() {
+            return Err(CommandFailure::new(
+                ErrorCode::ArgInvalid,
+                format!(
+                    "failed to checkout ref '{}': {}",
+                    reference,
+                    String::from_utf8_lossy(&checkout.stderr).trim()
+                ),
+            ));
+        }
+    }
+    let commit = run_git_in(&clone_tmp, &["rev-parse", "HEAD"]).map_err(map_git)?;
+    let tree_ref = if subdir.is_empty() {
+        "HEAD^{tree}".to_string()
+    } else {
+        format!("HEAD:{}", subdir)
+    };
+    let tree = run_git_in(&clone_tmp, &["rev-parse", &tree_ref]).map_err(map_git)?;
+    let copy_source = join_checked_subdir(&clone_tmp, &subdir);
+    Ok(AddSourceResolution {
+        copy_source,
+        descriptor: descriptor(commit, tree),
+    })
+}
+
+fn normalize_subdir(value: Option<&Path>) -> std::result::Result<String, CommandFailure> {
+    let Some(path) = value else {
+        return Ok(String::new());
+    };
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(CommandFailure::new(
+                    ErrorCode::ArgInvalid,
+                    "--subdir must be a relative path without '..'",
+                ));
+            }
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+fn join_checked_subdir(base: &Path, subdir: &str) -> PathBuf {
+    if subdir.is_empty() {
+        base.to_path_buf()
+    } else {
+        base.join(subdir)
+    }
+}
+
+fn run_git_in(repo_dir: &Path, args: &[&str]) -> Result<String> {
+    let output = run_git_allow_failure_in(repo_dir, args)?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn run_git_allow_failure_in(repo_dir: &Path, args: &[&str]) -> Result<Output> {
+    Command::new("git")
+        .current_dir(repo_dir)
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .arg("-c")
+        .arg("protocol.file.allow=always")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run git {:?}", args))
+}

--- a/src/commands/skill_cmds.rs
+++ b/src/commands/skill_cmds.rs
@@ -39,6 +39,9 @@ use super::projections::{
     restore_registry_audit_state, snapshot_registry_audit_state, update_projection_after_capture,
     upsert_projection, upsert_rule,
 };
+use super::provenance::{
+    provenance_record_for_skill, resolve_add_source, save_record_and_lock, stage_provenance_paths,
+};
 use super::{App, CommandFailure};
 
 mod observed;
@@ -70,8 +73,6 @@ impl App {
             .state_dir
             .join(format!("tmp-add-{}", Uuid::new_v4()));
         let staging_skill = staging_root.join(&args.name);
-        let clone_tmp = staging_root.join("clone");
-
         let cleanup_staging = || {
             let _ = remove_path_if_exists(&staging_root);
         };
@@ -79,44 +80,10 @@ impl App {
         remove_path_if_exists(&staging_root).map_err(map_io)?;
         fs::create_dir_all(&staging_root).map_err(map_io)?;
 
-        if Path::new(&args.source).exists() {
-            if let Err(err) =
-                copy_dir_recursive_without_symlinks(Path::new(&args.source), &staging_skill)
-            {
-                cleanup_staging();
-                return Err(map_io(err));
-            }
-        } else {
-            let source = args.source.as_str();
-            gitops::validate_git_url(source).map_err(|err| {
-                CommandFailure::new(
-                    ErrorCode::ArgInvalid,
-                    format!("invalid git source '{}': {}", source, err),
-                )
-            })?;
-            let clone = gitops::run_git_allow_failure_restricted(
-                &self.ctx,
-                &[
-                    "clone",
-                    "--depth",
-                    "1",
-                    source,
-                    clone_tmp.to_string_lossy().as_ref(),
-                ],
-            )
-            .map_err(map_git)?;
-            if !clone.status.success() {
-                let stderr = String::from_utf8_lossy(&clone.stderr).to_string();
-                cleanup_staging();
-                return Err(CommandFailure::new(
-                    ErrorCode::ArgInvalid,
-                    format!("failed to clone source: {}", stderr.trim()),
-                ));
-            }
-            if let Err(err) = copy_dir_recursive_without_symlinks(&clone_tmp, &staging_skill) {
-                cleanup_staging();
-                return Err(map_io(err));
-            }
+        let source = resolve_add_source(&self.ctx, args, &staging_root)?;
+        if let Err(err) = copy_dir_recursive_without_symlinks(&source.copy_source, &staging_skill) {
+            cleanup_staging();
+            return Err(map_io(err));
         }
 
         if let Err(err) = fs::rename(&staging_skill, &dst) {
@@ -127,9 +94,18 @@ impl App {
 
         let mut meta = Meta::default();
         let skill_rel = format!("skills/{}", args.name);
+        let provenance = provenance_record_for_skill(&args.name, source.descriptor, &dst)?;
+        if let Err(err) = save_record_and_lock(&self.ctx, provenance) {
+            rollback_added_skill(&self.ctx, &skill_rel, &dst);
+            return Err(err);
+        }
         if let Err(err) = gitops::stage_path(&self.ctx, Path::new(&skill_rel)) {
             rollback_added_skill(&self.ctx, &skill_rel, &dst);
             return Err(map_git(err));
+        }
+        if let Err(err) = stage_provenance_paths(&self.ctx) {
+            rollback_added_skill(&self.ctx, &skill_rel, &dst);
+            return Err(err);
         }
         let staged = match gitops::has_staged_changes_for_path(&self.ctx, Path::new(&skill_rel)) {
             Ok(staged) => staged,

--- a/src/gitops/mod.rs
+++ b/src/gitops/mod.rs
@@ -27,39 +27,13 @@ const HISTORY_COMPACT_AFTER_SEGMENTS: usize = 8;
 const HISTORY_RETAIN_RECENT_SEGMENTS: usize = 4;
 const HISTORY_RETAIN_ARCHIVES: usize = 4;
 
-#[derive(Debug, Clone, Copy)]
-enum GitEnvMode {
-    Normal,
-    Restricted,
-}
-
 fn run_git_raw_in_with_env_and_input(
     repo_dir: &Path,
     envs: &[(&str, &str)],
     input: Option<&[u8]>,
     args: &[&str],
 ) -> Result<Output> {
-    run_git_raw_in_with_env_mode_and_input(repo_dir, envs, input, args, GitEnvMode::Normal)
-}
-
-fn run_git_raw_in_with_env_mode_and_input(
-    repo_dir: &Path,
-    envs: &[(&str, &str)],
-    input: Option<&[u8]>,
-    args: &[&str],
-    env_mode: GitEnvMode,
-) -> Result<Output> {
     let mut command = Command::new("git");
-    if matches!(env_mode, GitEnvMode::Restricted) {
-        command.env_clear();
-        if let Some(path) = std::env::var_os("PATH") {
-            command.env("PATH", path);
-        }
-        command
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_TERMINAL_PROMPT", "0");
-    }
     command
         .current_dir(repo_dir)
         .arg("-c")
@@ -72,9 +46,7 @@ fn run_git_raw_in_with_env_mode_and_input(
         .arg("protocol.https.allow=always")
         .arg("-c")
         .arg("protocol.ssh.allow=always");
-    if matches!(env_mode, GitEnvMode::Normal) {
-        command.arg("-c").arg("protocol.file.allow=always");
-    }
+    command.arg("-c").arg("protocol.file.allow=always");
     command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -129,10 +101,6 @@ fn run_git_in_with_input(repo_dir: &Path, args: &[&str], input: &[u8]) -> Result
 
 pub fn run_git_allow_failure(ctx: &AppContext, args: &[&str]) -> Result<Output> {
     run_git_allow_failure_in(&ctx.root, args)
-}
-
-pub fn run_git_allow_failure_restricted(ctx: &AppContext, args: &[&str]) -> Result<Output> {
-    run_git_raw_in_with_env_mode_and_input(&ctx.root, &[], None, args, GitEnvMode::Restricted)
 }
 
 fn run_git_allow_failure_in(repo_dir: &Path, args: &[&str]) -> Result<Output> {

--- a/src/panel/handlers/mutations.rs
+++ b/src/panel/handlers/mutations.rs
@@ -209,6 +209,8 @@ pub(in crate::panel) async fn registry_skill_add(
             command: crate::cli::SkillCommand::Add(AddArgs {
                 source: req.source,
                 name: req.name,
+                source_ref: None,
+                subdir: None,
             }),
         },
     )

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -122,11 +122,27 @@ fn cli_contract_docs_track_current_surface() {
         "loom skill trash list",
         "loom skill trash restore",
         "loom skill trash purge",
+        "loom skill provenance inspect",
+        "loom skill provenance verify",
+        "loom skill provenance refresh",
         "loom skill watch",
     ] {
         assert!(
             readme.contains(command),
             "README CLI reference missing command {command}"
+        );
+    }
+
+    for command in [
+        "skill add <path|git-url|github:owner/repo//subdir>",
+        "skill provenance inspect",
+        "skill provenance verify",
+        "skill provenance refresh",
+        "loom.lock",
+    ] {
+        assert!(
+            contract.contains(command),
+            "CLI contract missing provenance surface {command}"
         );
     }
 }

--- a/tests/skill_provenance.rs
+++ b/tests/skill_provenance.rs
@@ -1,0 +1,334 @@
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use common::actions::{binding_add, skill_project, target_add};
+use common::{TestDir, run_loom, write_file};
+use serde_json::{Value, json};
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("read json")).expect("parse json")
+}
+
+fn init_git_skill_repo(repo: &Path) -> (String, String) {
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .arg("-c")
+            .arg("commit.gpgsign=false")
+            .arg("-c")
+            .arg("tag.gpgSign=false")
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+
+    fs::create_dir_all(repo.join("skill")).expect("create skill dir");
+    write_file(&repo.join("skill/SKILL.md"), "# demo\n\nversion one\n");
+    git(&["init"]);
+    git(&["config", "--local", "user.name", "Skill Source"]);
+    git(&["config", "--local", "user.email", "source@example.com"]);
+    git(&["branch", "-M", "main"]);
+    git(&["add", "skill/SKILL.md"]);
+    git(&["commit", "-m", "skill v1"]);
+    let v1 = git(&["rev-parse", "HEAD"]);
+    git(&["tag", "v1"]);
+
+    write_file(&repo.join("skill/SKILL.md"), "# demo\n\nversion two\n");
+    git(&["add", "skill/SKILL.md"]);
+    git(&["commit", "-m", "skill v2"]);
+    let v2 = git(&["rev-parse", "HEAD"]);
+    (v1, v2)
+}
+
+#[test]
+fn skill_add_records_local_path_provenance_and_lock() {
+    let root = TestDir::new("skill-provenance-local");
+    let source = TestDir::new("skill-provenance-source");
+    write_file(
+        &source.path().join("SKILL.md"),
+        "# demo\n\nlocal path skill\n",
+    );
+
+    let source_arg = source.path().to_str().expect("source path");
+    let (output, env) = run_loom(root.path(), &["skill", "add", source_arg, "--name", "demo"]);
+    assert!(output.status.success(), "skill add should pass: {env}");
+
+    let sources = read_json(&root.path().join("state/registry/sources.json"));
+    assert_eq!(sources["schema_version"], json!(1));
+    let record = &sources["sources"][0];
+    assert_eq!(record["skill_id"], json!("demo"));
+    assert_eq!(record["source"]["provider"], json!("local_path"));
+    assert_eq!(
+        record["source"]["path"],
+        json!(
+            fs::canonicalize(source.path())
+                .expect("canonical source")
+                .display()
+                .to_string()
+        )
+    );
+    assert_eq!(record["source"]["subdir"], json!(""));
+    assert_eq!(
+        record["importer_version"],
+        json!(format!("loom/{}", env!("CARGO_PKG_VERSION")))
+    );
+    let digest = record["artifact"]["digest"]
+        .as_str()
+        .expect("record digest");
+    assert!(
+        digest.starts_with("sha256:"),
+        "digest should be sha256: {digest}"
+    );
+
+    let lock = read_json(&root.path().join("loom.lock"));
+    assert_eq!(lock["version"], json!(1));
+    assert_eq!(lock["skills"]["demo"]["provider"], json!("local_path"));
+    assert_eq!(lock["skills"]["demo"]["digest"], json!(digest));
+    assert_eq!(lock["skills"]["demo"]["agents"], json!([]));
+    assert_eq!(lock["skills"]["demo"]["scope"], json!("project"));
+
+    let (output, inspect) = run_loom(root.path(), &["skill", "provenance", "inspect", "demo"]);
+    assert!(output.status.success(), "inspect should pass: {inspect}");
+    assert_eq!(
+        inspect["data"]["provenance"]["artifact"]["digest"],
+        json!(digest)
+    );
+    assert_eq!(inspect["data"]["lock"]["digest"], json!(digest));
+
+    let (output, verify) = run_loom(root.path(), &["skill", "provenance", "verify", "demo"]);
+    assert!(output.status.success(), "verify should pass: {verify}");
+    assert_eq!(verify["data"]["matches"], json!(true));
+    assert_eq!(verify["data"]["current_digest"], json!(digest));
+    assert_eq!(verify["data"]["lock_digest"], json!(digest));
+}
+
+#[test]
+fn skill_provenance_verify_detects_local_source_drift() {
+    let root = TestDir::new("skill-provenance-drift");
+    let source = TestDir::new("skill-provenance-drift-source");
+    write_file(&source.path().join("SKILL.md"), "# demo\n\nversion one\n");
+
+    let source_arg = source.path().to_str().expect("source path");
+    assert!(
+        run_loom(root.path(), &["skill", "add", source_arg, "--name", "demo"])
+            .0
+            .status
+            .success()
+    );
+    let lock_before = read_json(&root.path().join("loom.lock"));
+    let recorded = lock_before["skills"]["demo"]["digest"]
+        .as_str()
+        .expect("recorded digest")
+        .to_string();
+
+    write_file(
+        &root.path().join("skills/demo/SKILL.md"),
+        "# demo\n\nversion two\n",
+    );
+
+    let (output, verify) = run_loom(root.path(), &["skill", "provenance", "verify", "demo"]);
+    assert!(output.status.success(), "verify should pass: {verify}");
+    assert_eq!(verify["data"]["matches"], json!(false));
+    assert_eq!(verify["data"]["recorded_digest"], json!(recorded));
+    assert_ne!(verify["data"]["current_digest"], json!(recorded));
+    assert_eq!(verify["data"]["lock_digest"], json!(recorded));
+}
+
+#[test]
+fn skill_provenance_verify_reads_actual_lock_file() {
+    let root = TestDir::new("skill-provenance-lock-drift");
+    let source = TestDir::new("skill-provenance-lock-drift-source");
+    write_file(&source.path().join("SKILL.md"), "# demo\n\nversion one\n");
+
+    let source_arg = source.path().to_str().expect("source path");
+    assert!(
+        run_loom(root.path(), &["skill", "add", source_arg, "--name", "demo"])
+            .0
+            .status
+            .success()
+    );
+    let mut lock = read_json(&root.path().join("loom.lock"));
+    lock["skills"]["demo"]["digest"] = json!("sha256:badlock");
+    write_file(
+        &root.path().join("loom.lock"),
+        &(serde_json::to_string_pretty(&lock).expect("serialize lock") + "\n"),
+    );
+
+    let (output, verify) = run_loom(root.path(), &["skill", "provenance", "verify", "demo"]);
+    assert!(output.status.success(), "verify should pass: {verify}");
+    assert_eq!(verify["data"]["matches"], json!(false));
+    assert_eq!(verify["data"]["lock_present"], json!(true));
+    assert_eq!(verify["data"]["lock_digest"], json!("sha256:badlock"));
+    assert_ne!(
+        verify["data"]["current_digest"], verify["data"]["lock_digest"],
+        "verify must compare against the actual loom.lock file"
+    );
+}
+
+#[test]
+fn skill_provenance_refresh_updates_lock_without_projection_mutation() {
+    let root = TestDir::new("skill-provenance-refresh");
+    let source = TestDir::new("skill-provenance-refresh-source");
+    let target = TestDir::new("skill-provenance-refresh-target");
+    write_file(&source.path().join("SKILL.md"), "# demo\n\nversion one\n");
+
+    let source_arg = source.path().to_str().expect("source path");
+    assert!(
+        run_loom(root.path(), &["skill", "add", source_arg, "--name", "demo"])
+            .0
+            .status
+            .success()
+    );
+    let (output, env) = target_add(root.path(), "codex", target.path(), "managed");
+    assert!(output.status.success(), "target add should pass: {env}");
+    let target_id = env["data"]["target"]["target_id"]
+        .as_str()
+        .expect("target id")
+        .to_string();
+    let (output, env) = binding_add(
+        root.path(),
+        "codex",
+        "default",
+        "path-prefix",
+        "/tmp/demo-workspace",
+        &target_id,
+    );
+    assert!(output.status.success(), "binding add should pass: {env}");
+    let binding_id = env["data"]["binding"]["binding_id"]
+        .as_str()
+        .expect("binding id")
+        .to_string();
+    let (output, env) = skill_project(root.path(), "demo", &binding_id, Some("copy"));
+    assert!(output.status.success(), "skill project should pass: {env}");
+
+    let projections_before =
+        fs::read_to_string(root.path().join("state/registry/projections.json"))
+            .expect("read projections before");
+    write_file(
+        &root.path().join("skills/demo/SKILL.md"),
+        "# demo\n\nversion two\n",
+    );
+
+    let (output, refresh) = run_loom(root.path(), &["skill", "provenance", "refresh", "demo"]);
+    assert!(output.status.success(), "refresh should pass: {refresh}");
+    assert_eq!(refresh["data"]["changed"], json!(true));
+    assert_eq!(
+        fs::read_to_string(root.path().join("state/registry/projections.json"))
+            .expect("read projections after"),
+        projections_before,
+        "provenance refresh must not rewrite projection state"
+    );
+
+    let (output, verify) = run_loom(root.path(), &["skill", "provenance", "verify", "demo"]);
+    assert!(output.status.success(), "verify should pass: {verify}");
+    assert_eq!(verify["data"]["matches"], json!(true));
+    assert_eq!(
+        verify["data"]["current_digest"],
+        refresh["data"]["current_digest"]
+    );
+}
+
+#[test]
+fn skill_add_records_local_git_ref_commit_and_tree_hash() {
+    let root = TestDir::new("skill-provenance-git");
+    let source = TestDir::new("skill-provenance-git-source");
+    let (v1, v2) = init_git_skill_repo(source.path());
+    let source_arg = source.path().to_str().expect("source path");
+
+    let (output, tag_env) = run_loom(
+        root.path(),
+        &[
+            "skill", "add", source_arg, "--name", "demo-tag", "--ref", "v1", "--subdir", "skill",
+        ],
+    );
+    assert!(output.status.success(), "tag import should pass: {tag_env}");
+
+    let (output, branch_env) = run_loom(
+        root.path(),
+        &[
+            "skill",
+            "add",
+            source_arg,
+            "--name",
+            "demo-branch",
+            "--ref",
+            "main",
+            "--subdir",
+            "skill",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "branch import should pass: {branch_env}"
+    );
+
+    let (output, commit_env) = run_loom(
+        root.path(),
+        &[
+            "skill",
+            "add",
+            source_arg,
+            "--name",
+            "demo-commit",
+            "--ref",
+            &v1,
+            "--subdir",
+            "skill",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "commit import should pass: {commit_env}"
+    );
+
+    let sources = read_json(&root.path().join("state/registry/sources.json"));
+    let records = sources["sources"].as_array().expect("sources array");
+    let find = |skill: &str| {
+        records
+            .iter()
+            .find(|record| record["skill_id"] == skill)
+            .unwrap_or_else(|| panic!("missing record for {skill}"))
+    };
+    let tag = find("demo-tag");
+    let branch = find("demo-branch");
+    let commit = find("demo-commit");
+
+    assert_eq!(tag["source"]["provider"], json!("git"));
+    assert_eq!(tag["source"]["repository"], json!(source_arg));
+    assert_eq!(tag["source"]["requested_ref"], json!("v1"));
+    assert_eq!(tag["source"]["resolved_commit"], json!(v1));
+    assert_eq!(tag["source"]["subdir"], json!("skill"));
+    assert!(tag["source"]["tree_sha"].as_str().is_some());
+
+    assert_eq!(branch["source"]["requested_ref"], json!("main"));
+    assert_eq!(branch["source"]["resolved_commit"], json!(v2));
+    assert_ne!(
+        branch["artifact"]["digest"], tag["artifact"]["digest"],
+        "branch import should reflect the newer skill contents"
+    );
+
+    assert_eq!(commit["source"]["requested_ref"], json!(v1));
+    assert_eq!(commit["source"]["resolved_commit"], json!(v1));
+    assert_eq!(
+        commit["artifact"]["digest"], tag["artifact"]["digest"],
+        "tag and pinned commit should import the same skill tree"
+    );
+
+    let lock = read_json(&root.path().join("loom.lock"));
+    assert_eq!(lock["skills"]["demo-tag"]["commit"], json!(v1));
+    assert_eq!(lock["skills"]["demo-tag"]["ref"], json!("v1"));
+    assert_eq!(lock["skills"]["demo-branch"]["commit"], json!(v2));
+    assert_eq!(lock["skills"]["demo-branch"]["ref"], json!("main"));
+}


### PR DESCRIPTION
## 摘要

- 为 `skill add` 增加 local path / Git URL / local Git repo / `github:owner/repo//subdir` provenance 记录，支持 `--ref` 和 `--subdir`。
- 新增 `state/registry/sources.json` 与确定性根目录 `loom.lock`，记录 requested ref、resolved commit、tree hash、digest、import time、importer version。
- 新增 `loom skill provenance inspect|verify|refresh`，其中 `verify` 会读取真实 `loom.lock`，`refresh` 只更新 provenance/lock，不改 projection state。
- 更新 CLI contract / README，并补 local path、tag、branch、pinned commit、lock drift、refresh projection safety 测试。

## 验证

- `cargo check`
- `cargo test --test skill_provenance -- --nocapture`
- `cargo test --test cli_surface cli_contract_docs_track_current_surface`
- `make lint`
- `cargo test`
- `make perf-smoke`
- `cargo fmt --check`
- `git diff --check`

Closes #342