### PR TITLE
docs(skill): define provider boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ AI coding agents (Claude Code, Codex, Cursor, Windsurf, …) all read skills fro
 
 **Loom treats skills like infrastructure**: a Git-backed registry (add → capture → save → snapshot → release → rollback → diff), projected onto one or many agent directories through explicit bindings (agent + profile + matcher + policy), with sync, replay, and audit trail. CLI-first for automation, Panel-assisted for visibility.
 
+Loom can import from local directories, Git URLs, and GitHub locators, but it is not a marketplace or a wrapper around `gh skill install`. Provider boundaries are documented in [Skill Provider Boundary](docs/SKILL_PROVIDER_BOUNDARY.md): upstream tools find, preview, or publish skills; Loom owns local lockfile, policy, projection, audit, rollback, and eval.
+
 ## Quick Start
 
 ```bash
@@ -387,7 +389,7 @@ and fails the commit if rustfmt would make changes. Disable with
 - Per-agent environment overrides beyond the default paths listed in [Supported Agents](docs/SUPPORTED_AGENTS.md).
 - Convert observed agent directories to managed projection targets from the Panel once users opt in.
 - Desktop packaging (Tauri) for users who prefer a GUI
-- Skill marketplace integration (upstream catalogs such as `agent-skills`)
+- Optional upstream provider integrations for discovery and preview, while keeping Loom as the local control plane
 
 ## Community
 

--- a/docs/LOOM_ARCHITECTURE_DECISIONS.md
+++ b/docs/LOOM_ARCHITECTURE_DECISIONS.md
@@ -1,6 +1,6 @@
 # Loom Registry Architecture Decisions
 
-Updated: 2026-04-27
+Updated: 2026-06-26
 Status: Accepted for phase 1
 
 This document closes the current design-debt split from issue #6. It freezes the phase-1 boundaries for operation history, registry vocabulary rules, projection removal, panel mutations, and environment-based discovery.
@@ -230,6 +230,29 @@ Rejected because: adding a required decision to every binding removal creates fr
 
 `GET /api/v1/projections?health=orphaned` returns orphaned projection records so the panel can surface an orphaned-count badge and a "Clean up" action on the Bindings page.
 
+## 7. Provider Boundary
+
+Decision: provider integrations discover and resolve upstream skill content, but
+do not own Loom registry state, `loom.lock`, policy, plan/apply, projection,
+audit, rollback, or eval semantics.
+
+Rules:
+
+1. GitHub and `gh skill` are upstream providers, not Loom's local control plane.
+2. `gh skill` may be used only after runtime version/help probing because the
+   GitHub CLI marks the surface as preview.
+3. Direct Git remains the fallback for GitHub repositories when `gh` is missing
+   or preview behavior changes.
+4. Provider output must be captured as deterministic provenance in
+   `state/registry/sources.json` and `loom.lock` before any local policy,
+   plan/apply, projection, rollback, or eval decision uses it.
+5. Loom must not call `gh skill install` or `gh skill update` for managed
+   projections because those commands write directly into host skill
+   directories outside Loom's binding and audit model.
+
+The full provider contract is in
+[SKILL_PROVIDER_BOUNDARY.md](SKILL_PROVIDER_BOUNDARY.md).
+
 ## Issue Mapping
 
 - #38 is closed by section 1.
@@ -237,3 +260,4 @@ Rejected because: adding a required decision to every binding removal creates fr
 - #40 is closed by sections 3 and 6.
 - #41 is closed by section 4.
 - #42 is closed by section 5.
+- #347 is closed by section 7.

--- a/docs/LOOM_CLI_CONTRACT.md
+++ b/docs/LOOM_CLI_CONTRACT.md
@@ -394,6 +394,7 @@ Rules:
 6. `--subdir` selects a source subdirectory when it is not encoded in the GitHub locator
 7. successful imports write `state/registry/sources.json` and deterministic root `loom.lock`
 8. provenance records include provider, locator, requested ref, resolved commit when Git-backed, source tree hash when Git-backed, source subdir, artifact digest, import time, and importer version
+9. provider resolution boundaries are defined in [SKILL_PROVIDER_BOUNDARY.md](SKILL_PROVIDER_BOUNDARY.md); `skill add` must not call `gh skill install` or write directly into agent host directories
 
 ### 11.1.1 `skill provenance`
 

--- a/docs/LOOM_STATE_MODEL.md
+++ b/docs/LOOM_STATE_MODEL.md
@@ -470,6 +470,9 @@ registry state rejects these designs:
 3. implicit two-way sync between live target and source registry
 4. panel-first workflows
 5. path-only identity without `binding_id` or `target_id`
+6. marketplace-provider identity as a substitute for Loom registry identity
+7. direct `gh skill install` or `gh skill update` writes as managed projection
+   state
 
 ## 18. Acceptance Criteria
 

--- a/docs/LOOM_V1_CORE_SPEC.md
+++ b/docs/LOOM_V1_CORE_SPEC.md
@@ -42,7 +42,10 @@ operator layer:
 4. No guessing a single Claude, Codex, or other agent directory as execution
    identity.
 5. No decorative Panel metrics or synthetic lifecycle events.
-6. No marketplace/catalog scope in V1 beyond import from local path or Git URL.
+6. No marketplace/catalog scope in V1 beyond importing provider-resolved
+   content into the local registry. GitHub and `gh skill` are upstream
+   providers; Loom remains the local control plane. See
+   [SKILL_PROVIDER_BOUNDARY.md](SKILL_PROVIDER_BOUNDARY.md).
 
 ## 4. Core Concepts
 

--- a/docs/SKILL_PROVIDER_BOUNDARY.md
+++ b/docs/SKILL_PROVIDER_BOUNDARY.md
@@ -1,0 +1,139 @@
+# Skill Provider Boundary
+
+Status: Accepted for V1 provider planning
+Issue: https://github.com/majiayu000/loom/issues/347
+Checked: 2026-06-26
+
+## Decision
+
+Loom is a local skill control plane, not a skill marketplace or downloader.
+Provider integrations may discover and resolve upstream skill content, but Loom
+owns the registry, `loom.lock`, policy, plan/apply, projection, audit, rollback,
+and eval contracts after content enters a registry.
+
+This keeps one authority for local state:
+
+1. providers answer "where can this source be fetched, and what upstream ref did
+   it resolve to?"
+2. Loom answers "is this source allowed, pinned, projected, audited, rolled
+   back, and evaluated for this team or workspace?"
+
+## Current Provider Roles
+
+| Surface | Owns | Must Not Own |
+|---------|------|--------------|
+| GitHub / `gh skill` | upstream discovery, preview, publish, upstream metadata, optional source resolution | Loom registry state, `loom.lock`, target bindings, live projections, rollback, eval, local/team policy |
+| direct Git URL | clone/fetch, requested ref resolution, commit/tree identity | policy decisions, projection writes, mutable target installs |
+| GitHub locator | normalized GitHub repository URL, subdirectory, requested ref | `gh` authentication assumptions, target placement |
+| local directory | source copy and artifact digest | remote provenance claims |
+| future enterprise registry | authenticated catalog metadata and artifact fetch | Loom registry mutation semantics unless the result is imported through Loom commands |
+
+## `gh skill` Preview Surface
+
+GitHub documents `gh skill` as preview and subject to change. The command group
+currently includes:
+
+| Command | Upstream role | Loom boundary |
+|---------|---------------|---------------|
+| `gh skill search` | discover public GitHub repositories containing skills | advisory candidate list only; normalize selected result to a Loom provider record |
+| `gh skill preview` | render remote `SKILL.md` and browse related files without install | optional human review source; no registry write by itself |
+| `gh skill install` | install a GitHub or local skill into host-specific agent directories | do not use as a Loom apply path; it bypasses registry, policy, bindings, and audit |
+| `gh skill list` | scan installed skills across known host directories | advisory observation input only; registered Loom state remains authoritative |
+| `gh skill update` | compare installed frontmatter tree SHA against upstream and update host directories | do not use for managed Loom projections; Loom updates must go through provenance refresh, plan/apply, and projection commands |
+| `gh skill publish` | validate and publish skills through GitHub releases | upstream publishing path; it is not `loom skill release` and must not write Loom registry state |
+
+Minimum detected version for any optional `gh skill` provider is `gh >= 2.90.0`.
+An implementation must also check `gh skill --help` at runtime because preview
+command shapes may change without notice. If the version or help probe fails,
+the provider must degrade to direct Git support instead of blocking local path,
+Git URL, or GitHub locator imports.
+
+Sources checked:
+
+1. GitHub CLI manual for `gh skill`: https://cli.github.com/manual/gh_skill
+2. GitHub changelog announcing `gh skill` and `v2.90.0`: https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/
+
+## Provider Abstraction
+
+Provider records should normalize every source into the same provenance fields
+before Loom writes registry state:
+
+```json
+{
+  "provider": "github",
+  "locator": "github:owner/repo//skills/example",
+  "requested_ref": "v1.2.0",
+  "resolved_commit": "abc123...",
+  "source_tree_hash": "def456...",
+  "subdir": "skills/example",
+  "artifact_digest": "sha256:...",
+  "resolver": "loom/git",
+  "resolver_version": "0.1.4",
+  "resolved_at": "2026-06-26T00:00:00Z"
+}
+```
+
+Provider-specific notes:
+
+1. `local_path` records a local path locator and artifact digest. It must not
+   claim a remote commit unless the source is also a Git repository and Loom
+   records that as `git`.
+2. `git` records requested ref, resolved commit, source tree hash, subdir, and
+   artifact digest. This is the fallback for GitHub repos when `gh` is missing
+   or preview behavior changes.
+3. `github` is a locator convenience over Git. It resolves
+   `github:owner/repo//subdir` to `https://github.com/owner/repo.git` and must
+   not require `gh` authentication for public imports.
+4. `gh_skill` may be added later as an optional resolver for discovery or
+   preview metadata. It must emit the same normalized fields and may not install
+   directly into agent directories.
+5. `enterprise_registry` is reserved for future authenticated catalogs. It must
+   produce immutable artifact identity before Loom imports the source.
+
+## Provenance And Lockfile Contract
+
+Provider output is not complete until Loom captures it in both
+`state/registry/sources.json` and the deterministic root `loom.lock`.
+
+Rules:
+
+1. successful imports must record provider, locator, requested ref, resolved
+   commit when Git-backed, source tree hash when Git-backed, source subdir,
+   artifact digest, import time, and importer version
+2. provider metadata injected by another tool may be preserved as advisory
+   source metadata, but `loom.lock` remains Loom's authority for local control
+   plane decisions
+3. `skill provenance verify` compares canonical source bytes against both
+   `sources.json` and `loom.lock`; provider claims alone do not prove integrity
+4. `skill provenance refresh` is the only V1 write path that updates source
+   provenance without changing projections or live target directories
+5. future provider-specific metadata must be additive and deterministic so
+   repeated imports or refreshes do not churn `loom.lock`
+
+## Runtime Guardrails
+
+1. Do not introduce a hard runtime dependency on `gh skill` for `skill add`,
+   `use`, `plan use`, `apply`, `skill project`, or `skill eval`.
+2. Do not call `gh skill install` from Loom apply flows because it writes
+   directly into host directories outside Loom's target/binding/projection
+   model.
+3. Do not call `gh skill update` for managed projections. Use provenance
+   refresh, review, plan/apply, and explicit projection updates instead.
+4. Read-only provider probes must return structured warnings when unavailable,
+   not silently downgrade source identity.
+5. Any future provider write must first pass the provenance/lockfile contract
+   and then reuse existing Loom registry write/audit semantics.
+
+## Acceptance Mapping
+
+This design closes issue #347 by making the following boundaries explicit:
+
+1. Loom is a local control plane instead of a marketplace.
+2. Current `gh skill` commands are listed with their upstream role and Loom
+   boundary.
+3. `gh >= 2.90.0` and `gh skill --help` probing are required before any
+   optional `gh skill` integration.
+4. direct Git remains the fallback implementation for environments without
+   compatible `gh skill`.
+5. provider output feeds the existing provenance and `loom.lock` design instead
+   of bypassing it.


### PR DESCRIPTION
## 摘要

- 新增 `docs/SKILL_PROVIDER_BOUNDARY.md`，明确 GitHub/`gh skill` 只是上游 provider，Loom 继续拥有本地 registry、`loom.lock`、policy、plan/apply、projection、audit、rollback、eval。
- 记录当前 `gh skill` preview 命令面：`search`、`preview`、`install`、`list`、`update`、`publish`，并要求可选集成先检测 `gh >= 2.90.0` 和 `gh skill --help`。
- 从 architecture decisions、V1 core spec、CLI contract、state model、README 链接 provider boundary，避免后续把 Loom 做成 marketplace/downloader 或直接依赖 `gh skill install`。

## 验证

- `git diff --check`
- `make check`
  - Rust: 384 passed
  - Panel: 151 passed
  - E2E: ALL PASS
  - perf smoke: `--version p95=4.8ms`, `--help p95=4.5ms`, panel gzip `47177 bytes`

## Sources

- GitHub CLI manual: https://cli.github.com/manual/gh_skill
- GitHub changelog for `gh skill` / `v2.90.0`: https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/

Closes #347