### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable public release changes are tracked here. Loom also publishes release
 archives, checksums, and provenance details on GitHub Releases.
 
+## [0.1.5] - 2026-06-27
+
+### Added
+
+- Configurable agent adapters with documented provider boundaries, so operators
+  can keep discovery, preview, local lockfiles, policy checks, projection, and
+  audit responsibilities separate.
+- Offline skill eval matrix support for repeatable skill quality checks.
+- Codex active view projection spec for moving Codex from a full registry mirror
+  to an explicit active runtime view.
+
+### Fixed
+
+- Skill eval now fails when cases fail, making quality gates actionable instead
+  of silently passing incomplete runs.
+- Workspace status and target flows now account for configurable adapter
+  behavior.
+
+## [0.1.4] - 2026-06-26
+
+### Added
+
+- Portable skill lint checks and inventory discovery commands for stricter skill
+  validation before projection.
+- Source provenance lockfiles and skill policy checks to make local skill
+  changes auditable before they reach agent runtimes.
+- Durable `loom plan use` / `loom apply` workflows for retry-safe skill setup
+  plans.
+
+### Changed
+
+- Refactored large skill command surfaces into focused modules without changing
+  the public lifecycle contract.
+- Trimmed release binary size and kept the release performance budget current.
+
+### Fixed
+
+- Source import now skips Git metadata instead of copying nested repository
+  internals into managed skill sources.
+- Durable plan apply no longer echoes idempotency keys and handles replay
+  failures more safely.
+
 ## [0.1.3] - 2026-06-04
 
 ### Added
@@ -77,6 +119,8 @@ archives, checksums, and provenance details on GitHub Releases.
 
 - Initial public release archives for Loom.
 
+[0.1.5]: https://github.com/majiayu000/loom/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/majiayu000/loom/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/majiayu000/loom/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/majiayu000/loom/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/majiayu000/loom/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "skillloom"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillloom"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 build = "build.rs"
 description = "Git-backed skill manager and registry for AI coding agents"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Loom can import from local directories, Git URLs, and GitHub locators, but it is
 ```bash
 # 1. Install a prebuilt release archive (recommended)
 # Pick one target: aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu
-VERSION="0.1.3" # replace with the latest release version
+VERSION="0.1.5" # replace with the latest release version
 TARGET="aarch64-apple-darwin"
 BASE_URL="https://github.com/majiayu000/loom/releases/download/v${VERSION}"
 curl -LO "${BASE_URL}/skillloom-${VERSION}-${TARGET}.tar.gz"


### PR DESCRIPTION
## Summary

- Bump skillloom to 0.1.5.
- Add CHANGELOG entries for 0.1.4 and 0.1.5.
- Update README Quick Start release version to 0.1.5.

## Validation

- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `make check`
- `cargo publish --dry-run --locked`